### PR TITLE
Fix doc on Mutex

### DIFF
--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -134,7 +134,7 @@ impl<T: ?Sized> Mutex<T> {
 
     /// Attempts to acquire this lock.
     ///
-    /// If the lock could not be acquired at this time, then `Err` is returned.
+    /// If the lock could not be acquired at this time, then `None` is returned.
     /// Otherwise, an RAII guard is returned. The lock will be unlocked when the
     /// guard is dropped.
     ///


### PR DESCRIPTION
`try_lock` returns an `Option`, not a `Result`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amanieu/parking_lot/7)
<!-- Reviewable:end -->
