### PR TITLE
Make raw lock/unlock methods more versatile on Mutex and RwLock

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ in the Rust standard library:
     problem where all threads try to acquire the lock at the same time.
 12. `RwLock` supports atomically downgrading a write lock into a read lock.
 13. `Mutex` and `RwLock` allow raw unlocking without a RAII guard object.
-14. `Mutex<()>` and `RwLock<()>` allow raw locking without an RAII guard
+14. `Mutex<()>` and `RwLock<()>` allow raw locking without a RAII guard
     object.
 
 ## The parking lot

--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ in the Rust standard library:
     rest to wait on the associated `Mutex`. This avoids a thundering herd
     problem where all threads try to acquire the lock at the same time.
 12. `RwLock` supports atomically downgrading a write lock into a read lock.
-13. `Mutex<()>` and `RwLock<()>` allow raw locking and unlocking without a
-    RAII guard object.
+13. `Mutex` and `RwLock` allow raw unlocking without a RAII guard object.
+14. `Mutex<()>` and `RwLock<()>` allow raw locking without an RAII guard
+    object.
 
 ## The parking lot
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,8 +54,9 @@
 //!     rest to wait on the associated `Mutex`. This avoids a thundering herd
 //!     problem where all threads try to acquire the lock at the same time.
 //! 12. `RwLock` supports atomically downgrading a write lock into a read lock.
-//! 13. `Mutex<()>` and `RwLock<()>` allow raw locking and unlocking without a
-//!     RAII guard object.
+//! 13. `Mutex` and `RwLock` allow raw unlocking without a RAII guard object.
+//! 14. `Mutex<()>` and `RwLock<()>` allow raw locking with a RAII guard
+//!     object.
 //!
 //! # The parking lot
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 //!     problem where all threads try to acquire the lock at the same time.
 //! 12. `RwLock` supports atomically downgrading a write lock into a read lock.
 //! 13. `Mutex` and `RwLock` allow raw unlocking without a RAII guard object.
-//! 14. `Mutex<()>` and `RwLock<()>` allow raw locking with a RAII guard
+//! 14. `Mutex<()>` and `RwLock<()>` allow raw locking without a RAII guard
 //!     object.
 //!
 //! # The parking lot

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -160,8 +160,19 @@ impl<T: ?Sized> Mutex<T> {
     pub fn get_mut(&mut self) -> &mut T {
         unsafe { &mut *self.data.get() }
     }
-}
 
+    /// Releases the mutex.
+    ///
+    /// # Safety
+    ///
+    /// This function must only be called if the mutex was locked using
+    /// `raw_lock` or `raw_try_lock`, or if a `MutexGuard` from this mutex was
+    /// leaked (e.g. with `mem::forget`). The mutex must be locked.
+    #[inline]
+    pub unsafe fn raw_unlock(&self) {
+        self.raw.unlock();
+    }
+}
 impl Mutex<()> {
     /// Acquires a mutex, blocking the current thread until it is able to do so.
     ///
@@ -180,17 +191,6 @@ impl Mutex<()> {
     #[inline]
     pub fn raw_try_lock(&self) -> bool {
         self.raw.try_lock()
-    }
-
-    /// Releases the mutex.
-    ///
-    /// # Safety
-    ///
-    /// This function must only be called if the mutex was locked using
-    /// `raw_lock` or `raw_try_lock`. The mutex must be locked.
-    #[inline]
-    pub unsafe fn raw_unlock(&self) {
-        self.raw.unlock();
     }
 }
 

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -221,6 +221,33 @@ impl<T: ?Sized> RwLock<T> {
     pub fn get_mut(&mut self) -> &mut T {
         unsafe { &mut *self.data.get() }
     }
+
+
+    /// Releases shared read access of the rwlock.
+    ///
+    /// # Safety
+    ///
+    /// This function must only be called if the rwlock was locked using
+    /// `raw_read` or `raw_try_read`, or if an `RwLockReadGuard` from this
+    /// rwlock was leaked (e.g. with `mem::forget`). The rwlock must be locked
+    /// with shared read access.
+    #[inline]
+    pub unsafe fn raw_unlock_read(&self) {
+        self.raw.unlock_shared();
+    }
+
+    /// Releases exclusive write access of the rwlock.
+    ///
+    /// # Safety
+    ///
+    /// This function must only be called if the rwlock was locked using
+    /// `raw_write` or `raw_try_write`, or if an `RwLockWriteGuard` from this
+    /// rwlock was leaked (e.g. with `mem::forget`). The rwlock must be locked
+    /// with exclusive write access.
+    #[inline]
+    pub unsafe fn raw_unlock_write(&self) {
+        self.raw.unlock_exclusive();
+    }
 }
 
 impl RwLock<()> {
@@ -231,7 +258,7 @@ impl RwLock<()> {
     /// returned. Instead you will need to call `raw_unlock` to release the
     /// rwlock.
     #[inline]
-    pub unsafe fn raw_read(&self) {
+    pub fn raw_read(&self) {
         self.raw.lock_shared();
     }
 
@@ -241,20 +268,8 @@ impl RwLock<()> {
     /// returned. Instead you will need to call `raw_unlock` to release the
     /// rwlock.
     #[inline]
-    pub unsafe fn raw_try_read(&self) -> bool {
+    pub fn raw_try_read(&self) -> bool {
         self.raw.try_lock_shared()
-    }
-
-    /// Releases shared read access of the rwlock.
-    ///
-    /// # Safety
-    ///
-    /// This function must only be called if the rwlock was locked using
-    /// `raw_read` or `raw_try_read`. The rwlock must be locked with shared
-    /// read access.
-    #[inline]
-    pub unsafe fn raw_unlock_read(&self) {
-        self.raw.unlock_shared();
     }
 
     /// Locks this rwlock with exclusive write access, blocking the current
@@ -264,7 +279,7 @@ impl RwLock<()> {
     /// returned. Instead you will need to call `raw_unlock` to release the
     /// rwlock.
     #[inline]
-    pub unsafe fn raw_write(&self) {
+    pub fn raw_write(&self) {
         self.raw.lock_exclusive();
     }
 
@@ -274,20 +289,8 @@ impl RwLock<()> {
     /// returned. Instead you will need to call `raw_unlock` to release the
     /// rwlock.
     #[inline]
-    pub unsafe fn raw_try_write(&self) -> bool {
+    pub fn raw_try_write(&self) -> bool {
         self.raw.try_lock_exclusive()
-    }
-
-    /// Releases exclusive write access of the rwlock.
-    ///
-    /// # Safety
-    ///
-    /// This function must only be called if the rwlock was locked using
-    /// `raw_write` or `raw_try_write`. The rwlock must be locked with exclusive
-    /// write access.
-    #[inline]
-    pub unsafe fn raw_unlock_write(&self) {
-        self.raw.unlock_exclusive();
     }
 }
 


### PR DESCRIPTION
Changes the raw lock and unlock methods to work on all `T: ?Sized`, not just `()`. The locking methods are somewhat useless I suppose but being able to unlock after using `mem::forget` on a Guard is useful.

Also removes `unsafe` on the `RwLock` raw locking methods. They are safe as far as I know (equivalent to `mem::forget(self.read())` and such), and there is no `unsafe` on the equivalent `Mutex` methods, so I don't think they are necessary.