### PR TITLE
cast suseconds_t to c_long, fix build on x86_64-apple-darwin

### DIFF
--- a/core/src/thread_parker/unix.rs
+++ b/core/src/thread_parker/unix.rs
@@ -174,7 +174,7 @@ unsafe fn timespec_now() -> libc::timespec {
     debug_assert_eq!(r, 0);
     libc::timespec {
         tv_sec: now.tv_sec,
-        tv_nsec: now.tv_usec * 1000,
+        tv_nsec: now.tv_usec as libc::c_long * 1000,
     }
 }
 #[cfg(not(any(target_os = "macos", target_os = "ios")))]


### PR DESCRIPTION
On `x86_64-apple-darwin` parking_lot_core currently fails to compile.
```
error[E0308]: mismatched types
   --> core/src/thread_parker/unix.rs:177:18
    |
177 |         tv_nsec: now.tv_usec * 1000,
    |                  ^^^^^^^^^^^^^^^^^^ expected i64, found i32
```
`libc::timespec.tv_nsec` is of type `libc::c_long` (i64 on x86_64). `libc::timeval.tv_usec` is of type `libc::suseconds_t` (i32 on x86_64). On i686 both types are i32 and the cast is a no-op.