### PR TITLE
Add a for_lock method on RwLockReadGuard and RwLockWriteGuard.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parking_lot"
-version = "0.3.7"
+version = "0.3.8"
 authors = ["Amanieu d'Antras <amanieu@gmail.com>"]
 description = "More compact and efficient implementations of the standard synchronization primitives."
 documentation = "https://amanieu.github.io/parking_lot/parking_lot/index.html"

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -457,6 +457,12 @@ impl<'a, T: ?Sized + 'a> RwLockReadGuard<'a, T> {
     pub fn unlock_fair(self) {
         self.rwlock.raw.unlock_shared(true);
     }
+
+    /// Return a reference to the lock being guarded.
+    #[inline]
+    pub fn for_lock(&self) -> &'a RwLock<T> {
+        self.rwlock
+    }
 }
 
 impl<'a, T: ?Sized + 'a> Deref for RwLockReadGuard<'a, T> {
@@ -509,6 +515,12 @@ impl<'a, T: ?Sized + 'a> RwLockWriteGuard<'a, T> {
     #[inline]
     pub fn unlock_fair(self) {
         self.rwlock.raw.unlock_exclusive(true);
+    }
+
+    /// Return a reference to the lock being guarded.
+    #[inline]
+    pub fn for_lock(&self) -> &'a RwLock<T> {
+        self.rwlock
     }
 }
 


### PR DESCRIPTION
In Servo, I’m trying a scheme where mupltiple objects, each in `Arc<_>`, are protected by a single shared `RwLock`. This lock can be acquired once to access many objects.

https://bugzilla.mozilla.org/show_bug.cgi?id=1335941#c10

On each access, we assert that the guard being used indeed is for the same lock that protects the object being accessed. This is done by comparing `*const RwLock<()>` pointers. I currently keep this pointer in my guard wrapper types, but this is wasted space since this crate’s guards already hold a reference to the lock.

This commit adds public API to guards to expose this reference.