### PR TITLE
Fix Compile Error on emscripten

### DIFF
--- a/src/raw_remutex.rs
+++ b/src/raw_remutex.rs
@@ -23,7 +23,7 @@ fn get_thread_id() -> usize {
     // reserved value to indicate an empty slot. We instead fall
     // back to using the address of a thread-local variable, which
     // is slightly slower but guaranteed to produce a non-zero value.
-    thread_local!(static KEY: u8 = unsafe { std::mem::uninitialized() });
+    thread_local!(static KEY: u8 = unsafe { ::std::mem::uninitialized() });
     KEY.with(|x| x as *const _ as usize)
 }
 


### PR DESCRIPTION
This is not the root module, so you can't access std like that as a relative path. I'd also be pretty happy if we can have a 0.4.2 for this, as I'd like to publish the next version of my crate to crates.io, but it relies on this working ^^'