### PR TITLE
Use Duff's device and unroll spinwait loops

### DIFF
--- a/core/src/spinwait.rs
+++ b/core/src/spinwait.rs
@@ -42,7 +42,7 @@ fn thread_yield() {
 // using a hint to indicate to the CPU that we are spinning.
 #[cfg(all(feature = "nightly", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline]
-fn pause(iterations: u32) {
+fn pause() {
     unsafe {
         asm!("pause" ::: "memory" : "volatile");
     }
@@ -50,7 +50,7 @@ fn pause(iterations: u32) {
 
 #[cfg(all(feature = "nightly", target_arch = "aarch64"))]
 #[inline]
-fn pause(iterations: u32) {
+fn pause() {
     unsafe {
         asm!("yield" ::: "memory" : "volatile");
     }


### PR DESCRIPTION
This was benchmarked to give a small performance improvement from about 5.6kHz to 5.5kHz.

Old: parking_lot::Mutex   |      5.627 kHz |      5.684 kHz |      0.115 kHz
New: parking_lot::Mutex   |      5.525 kHz |      5.521 kHz |      0.225 kHz

It should also give a power usage improvement.