### PR TITLE
Update for latest nightly, bump version number.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parking_lot"
-version = "0.4.7"
+version = "0.4.8"
 authors = ["Amanieu d'Antras <amanieu@gmail.com>"]
 description = "More compact and efficient implementations of the standard synchronization primitives."
 documentation = "https://amanieu.github.io/parking_lot/parking_lot/index.html"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,12 @@
 
 #![warn(missing_docs)]
 #![cfg_attr(feature = "nightly", feature(const_fn))]
+#![cfg_attr(feature = "nightly", feature(const_atomic_u8_new))]
+#![cfg_attr(feature = "nightly", feature(const_atomic_usize_new))]
+#![cfg_attr(feature = "nightly", feature(const_cell_new))]
+#![cfg_attr(feature = "nightly", feature(const_ptr_null_mut))]
+#![cfg_attr(feature = "nightly", feature(const_atomic_ptr_new))]
+#![cfg_attr(feature = "nightly", feature(const_unsafe_cell_new))]
 #![cfg_attr(feature = "nightly", feature(integer_atomics))]
 #![cfg_attr(feature = "nightly", feature(asm))]
 


### PR DESCRIPTION
Fixes for changes from https://github.com/rust-lang/rust/pull/43017. Updated version number as well in hopes of a quick release so that https://github.com/SergioBenitez/Rocket/issues/433 is resolved.