### PR TITLE
Fix future compatibilty warnings and bump version

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parking_lot_core"
-version = "0.2.8"
+version = "0.2.9"
 authors = ["Amanieu d'Antras <amanieu@gmail.com>"]
 description = "An advanced API for creating custom synchronization primitives."
 documentation = "https://amanieu.github.io/parking_lot/parking_lot_core/index.html"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,15 +11,16 @@
 //! # The parking lot
 //!
 //! To keep synchronization primitives small, all thread queuing and suspending
-//! functionality is offloaded to the *parking lot*. The idea behind this is
-//! based on the Webkit [`WTF::ParkingLot`]
-//! (https://webkit.org/blog/6161/locking-in-webkit/) class, which essentially
-//! consists of a hash table mapping of lock addresses to queues of parked
-//! (sleeping) threads. The Webkit parking lot was itself inspired by Linux
-//! [futexes](http://man7.org/linux/man-pages/man2/futex.2.html), but it is more
-//! powerful since it allows invoking callbacks while holding a queue lock.
+//! functionality is offloaded to the *parking lot*. The idea behind this is based
+//! on the Webkit [`WTF::ParkingLot`](https://webkit.org/blog/6161/locking-in-webkit/)
+//! class, which essentially consists of a hash table mapping of lock addresses
+//! to queues of parked (sleeping) threads. The Webkit parking lot was itself
+//! inspired by Linux [futexes](http://man7.org/linux/man-pages/man2/futex.2.html),
+//! but it is more powerful since it allows invoking callbacks while holding a
+//! queue lock.
 //!
 //! There are two main operations that can be performed on the parking lot:
+//!
 //!  - *Parking* refers to suspending the thread while simultaneously enqueuing it
 //! on a queue keyed by some address.
 //! - *Unparking* refers to dequeuing a thread from a queue keyed by some address

--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -890,7 +890,7 @@ unsafe fn unpark_requeue_internal(
     let mut link = &bucket_from.queue_head;
     let mut current = bucket_from.queue_head.get();
     let mut previous = ptr::null();
-    let mut requeue_threads = ptr::null();
+    let mut requeue_threads: *const ThreadData = ptr::null();
     let mut requeue_threads_tail: *const ThreadData = ptr::null();
     let mut wakeup_thread = None;
     while !current.is_null() {


### PR DESCRIPTION
- Fix pulldown migration warnings in parking_lot_core
  
  Lists now require an empty line before them, and a link can no longer be
  split on multiple lines.
  See rust-lang/rust#44229.
  This is required to unblock rust-lang/rust#46278.

- Add an explicit type to silence a future compatibility warning
  
  `requeue_threads` now requires an explicit type because of the `is_null`
  method call later in the code.
  See rust-lang/rust#46906.

- Bump version to 0.2.9