### PR TITLE
Add `?Sized` on `Send`- and `Sync`-impl for `Mutex` and `ReentrantMutex`

### DIFF
--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -98,8 +98,8 @@ pub struct Mutex<T: ?Sized> {
     data: UnsafeCell<T>,
 }
 
-unsafe impl<T: Send> Send for Mutex<T> {}
-unsafe impl<T: Send> Sync for Mutex<T> {}
+unsafe impl<T: ?Sized + Send> Send for Mutex<T> {}
+unsafe impl<T: ?Sized + Send> Sync for Mutex<T> {}
 
 /// An RAII implementation of a "scoped lock" of a mutex. When this structure is
 /// dropped (falls out of scope), the lock will be unlocked.

--- a/src/remutex.rs
+++ b/src/remutex.rs
@@ -33,8 +33,8 @@ pub struct ReentrantMutex<T: ?Sized> {
     data: UnsafeCell<T>,
 }
 
-unsafe impl<T: Send> Send for ReentrantMutex<T> {}
-unsafe impl<T: Send> Sync for ReentrantMutex<T> {}
+unsafe impl<T: ?Sized + Send> Send for ReentrantMutex<T> {}
+unsafe impl<T: ?Sized + Send> Sync for ReentrantMutex<T> {}
 
 /// An RAII implementation of a "scoped lock" of a reentrant mutex. When this structure
 /// is dropped (falls out of scope), the lock will be unlocked.


### PR DESCRIPTION
Would be awesome to add `?Sized` on `Mutex`'s `Send` and `Sync` in order to match it to https://doc.rust-lang.org/std/sync/struct.Mutex.html in that regard.