### PR TITLE
Bump minimum libc version requirement

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,7 +16,7 @@ thread-id = { version = "3.2.0", optional = true }
 backtrace = { version = "0.3.2", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2.15"
+libc = "0.2.27"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winnt", "ntstatus", "minwindef",


### PR DESCRIPTION
In versions of libc prior to 0.2.27, libc::SYS_futex did
not exist. This is required by parking_lot_core when building
with the nightly feature enabled, like so:
    cargo +nightly build --features nightly

This patch bumps the minimum acceptable libc version so that
compiles under this configuration. This prevents parking_lot_core
from breaking builds when included in other projects where the
libc version is older than 0.2.27.