### PR TITLE
use std::fmt::DebugStruct to format debug output

### DIFF
--- a/src/condvar.rs
+++ b/src/condvar.rs
@@ -7,7 +7,7 @@
 
 use std::sync::atomic::{AtomicPtr, Ordering};
 use std::time::{Duration, Instant};
-use std::ptr;
+use std::{ptr, fmt};
 use parking_lot_core::{self, ParkResult, RequeueOp, UnparkResult, DEFAULT_PARK_TOKEN};
 use mutex::{guard_lock, MutexGuard};
 use raw_mutex::{RawMutex, TOKEN_HANDOFF, TOKEN_NORMAL};
@@ -354,6 +354,12 @@ impl Default for Condvar {
     }
 }
 
+impl fmt::Debug for Condvar {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.pad("Condvar { .. }")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::mpsc::channel;
@@ -509,5 +515,11 @@ mod tests {
         drop(g);
 
         let _ = c.wait_for(&mut m3.lock(), Duration::from_millis(1));
+    }
+
+    #[test]
+    fn test_debug_condvar() {
+        let c = Condvar::new();
+        assert_eq!(format!("{:?}", c), "Condvar { .. }");
     }
 }

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -278,7 +278,9 @@ impl<T: ?Sized + Default> Default for Mutex<T> {
 impl<T: ?Sized + fmt::Debug> fmt::Debug for Mutex<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.try_lock() {
-            Some(guard) => write!(f, "Mutex {{ data: {:?} }}", &*guard),
+            Some(guard) => f.debug_struct("Mutex")
+                .field("data", &&*guard)
+                .finish(),
             None => write!(f, "Mutex {{ <locked> }}"),
         }
     }
@@ -531,5 +533,22 @@ mod tests {
 
         let mutex = Mutex::new(());
         sync(mutex.lock());
+    }
+
+    #[test]
+    fn test_mutex_debug() {
+        let mutex = Mutex::new(vec![0u8, 10]);
+
+        assert_eq!(format!("{:?}", mutex), "Mutex { data: [0, 10] }");
+        assert_eq!(format!("{:#?}", mutex),
+"Mutex {
+    data: [
+        0,
+        10
+    ]
+}"
+        );
+        let _lock = mutex.lock();
+        assert_eq!(format!("{:?}", mutex), "Mutex { <locked> }");
     }
 }

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -281,7 +281,7 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for Mutex<T> {
             Some(guard) => f.debug_struct("Mutex")
                 .field("data", &&*guard)
                 .finish(),
-            None => write!(f, "Mutex {{ <locked> }}"),
+            None => f.pad("Mutex { <locked> }"),
         }
     }
 }

--- a/src/once.rs
+++ b/src/once.rs
@@ -345,7 +345,9 @@ impl Default for Once {
 
 impl fmt::Debug for Once {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Once {{ state: {:?} }}", &self.state())
+        f.debug_struct("Once")
+            .field("state", &self.state())
+            .finish()
     }
 }
 
@@ -469,5 +471,17 @@ mod tests {
 
         assert!(t1.join().is_ok());
         assert!(t2.join().is_ok());
+    }
+
+    #[test]
+    fn test_once_debug() {
+        static O: Once = ONCE_INIT;
+
+        assert_eq!(format!("{:?}", O), "Once { state: New }");
+        assert_eq!(format!("{:#?}", O),
+"Once {
+    state: New
+}"
+        );
     }
 }

--- a/src/remutex.rs
+++ b/src/remutex.rs
@@ -217,7 +217,7 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for ReentrantMutex<T> {
             Some(guard) => f.debug_struct("ReentrantMutex")
                 .field("data", &&*guard)
                 .finish(),
-            None => write!(f, "ReentrantMutex {{ <locked> }}"),
+            None => f.pad("ReentrantMutex { <locked> }"),
         }
     }
 }

--- a/src/remutex.rs
+++ b/src/remutex.rs
@@ -214,7 +214,9 @@ impl<T: ?Sized + Default> Default for ReentrantMutex<T> {
 impl<T: ?Sized + fmt::Debug> fmt::Debug for ReentrantMutex<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.try_lock() {
-            Some(guard) => write!(f, "ReentrantMutex {{ data: {:?} }}", &*guard),
+            Some(guard) => f.debug_struct("ReentrantMutex")
+                .field("data", &&*guard)
+                .finish(),
             None => write!(f, "ReentrantMutex {{ <locked> }}"),
         }
     }
@@ -334,5 +336,20 @@ mod tests {
         }).join()
             .unwrap();
         let _lock3 = m.try_lock();
+    }
+
+    #[test]
+    fn test_reentrant_mutex_debug() {
+        let mutex = ReentrantMutex::new(vec![0u8, 10]);
+
+        assert_eq!(format!("{:?}", mutex), "ReentrantMutex { data: [0, 10] }");
+        assert_eq!(format!("{:#?}", mutex),
+"ReentrantMutex {
+    data: [
+        0,
+        10
+    ]
+}"
+        );
     }
 }

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -732,7 +732,7 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for RwLock<T> {
             Some(guard) => f.debug_struct("RwLock")
                 .field("data", &&*guard)
                 .finish(),
-            None => write!(f, "RwLock {{ <locked> }}"),
+            None => f.pad("RwLock { <locked> }"),
         }
     }
 }


### PR DESCRIPTION
debug formatting now respects standard formatting flags:
`sign_plus`, `sign_minus`, `alternate`, or `sign_aware_zero_pad`