### PR TITLE
Using spin_loop_hint since it's now stabilized

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 sudo: false
 
 rust:
-- 1.18.0
+- 1.24.0
 - stable
 - beta
 - nightly

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,10 +6,10 @@ environment:
   - TARGET: nightly-i686-pc-windows-msvc
   - TARGET: nightly-x86_64-pc-windows-gnu
   - TARGET: nightly-i686-pc-windows-gnu
-  - TARGET: 1.18.0-x86_64-pc-windows-msvc
-  - TARGET: 1.18.0-i686-pc-windows-msvc
-  - TARGET: 1.18.0-x86_64-pc-windows-gnu
-  - TARGET: 1.18.0-i686-pc-windows-gnu
+  - TARGET: 1.24.0-x86_64-pc-windows-msvc
+  - TARGET: 1.24.0-i686-pc-windows-msvc
+  - TARGET: 1.24.0-x86_64-pc-windows-gnu
+  - TARGET: 1.24.0-i686-pc-windows-gnu
 
 install:
   - SET PATH=C:\Python27;C:\Python27\Scripts;%PATH%;%APPDATA%\Python\Scripts


### PR DESCRIPTION
SpinWait used to use custom assembly to access the `pause` instruction; this
only works on nightly. Now that [std::sync::atomic::spin_loop_hint](https://doc.rust-lang.org/std/sync/atomic/fn.spin_loop_hint.html) has been
stabilized, this custom assembly is not necessary (code on stable Rust gets
faster, woohoo!).

@Amanieu 
