### PR TITLE
Remove dependency on the `synchapi` winapi feature

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,7 +20,7 @@ libc = "0.2.27"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winnt", "ntstatus", "minwindef",
-    "winerror", "winbase", "synchapi", "errhandlingapi", "handleapi"] }
+    "winerror", "winbase", "errhandlingapi", "handleapi"] }
 
 [features]
 nightly = []


### PR DESCRIPTION
Pulling in `parking_lot` to the Rust compiler unfortunately had adverse side
effects on the binary dependencies of rustc -- rust-lang/rust#49438. It turns
out this is due to a number of bugs happening all at once, and currently we're
looking for ways to fix the beta/master branches of rustc to fix this for now
(not necessarily in the best way).

This commit removes the activation of the `synchapi` feature of `winapi` which
prevents `libsynchronization.a` from being linked in (and prevents rustc from
accidentally picking up a dependency on a missing DLL). The `synchapi` feature
was only activated for access to the `Sleep` function, but that function
actually resides in `kernel32.dll`. As a result this commit inlines the
definition of `Sleep` into this crate to avoid needing to depend on an upstream
definition.