### PR TITLE
Fix Compile Error with x32 ABI

### DIFF
--- a/core/src/thread_parker/unix.rs
+++ b/core/src/thread_parker/unix.rs
@@ -210,8 +210,13 @@ unsafe fn timeout_to_timespec(timeout: Duration) -> Option<libc::timespec> {
         return None;
     }
 
+    #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
+    type NSec = i64;
+    #[cfg(not(all(target_arch = "x86_64", target_pointer_width = "32")))]
+    type NSec = libc::c_long;
+
     let now = timespec_now();
-    let mut nsec = now.tv_nsec + timeout.subsec_nanos() as libc::c_long;
+    let mut nsec = now.tv_nsec + timeout.subsec_nanos() as NSec;
     let mut sec = now.tv_sec.checked_add(timeout.as_secs() as libc::time_t);
     if nsec >= 1_000_000_000 {
         nsec -= 1_000_000_000;


### PR DESCRIPTION
With the x32 ABI, the tv_nsec is specified to be a i64 explicitly. So casting to c_long causes a type conflict on the x86_64-unknown-linux-gnux32 target.