### PR TITLE
Add "concurrency" category to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0/MIT"
 repository = "https://github.com/Amanieu/parking_lot"
 readme = "README.md"
 keywords = ["mutex", "condvar", "rwlock", "once", "thread"]
+categories = ["concurrency"]
 
 [dependencies]
 parking_lot_core = { path = "core", version = "0.2" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,6 +7,7 @@ documentation = "https://amanieu.github.io/parking_lot/parking_lot_core/index.ht
 license = "Apache-2.0/MIT"
 repository = "https://github.com/Amanieu/parking_lot"
 keywords = ["mutex", "condvar", "rwlock", "once", "thread"]
+categories = ["concurrency"]
 
 [dependencies]
 smallvec = "0.6"


### PR DESCRIPTION
I was browsing [Crates.rs](https://crates.rs/index), an
alternative UI for crates.io, and expected to find parking_lot in
the "Concurrency" category, but I didn't since it looks like
parking_lot doesn't have any category set.  Add a category to aid
with discoverability.