### PR TITLE
Remove depreacted rand::weak_rng(), in favor of SmallRng

### DIFF
--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -5,7 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use rand::{self, Rng, XorShiftRng};
+use rand::{Rng, FromEntropy};
+use rand::rngs::SmallRng;
 use smallvec::SmallVec;
 use std::cell::{Cell, UnsafeCell};
 use std::mem;
@@ -88,14 +89,14 @@ struct FairTimeout {
     timeout: Instant,
 
     // Random number generator for calculating the next timeout
-    rng: XorShiftRng,
+    rng: SmallRng,
 }
 
 impl FairTimeout {
     fn new() -> FairTimeout {
         FairTimeout {
             timeout: Instant::now(),
-            rng: rand::weak_rng(),
+            rng: SmallRng::from_entropy(),
         }
     }
 


### PR DESCRIPTION
In https://github.com/rust-lang-nursery/rand/commit/1a4b3f753c41987e5077cadd5663758d56ffafd2
the weak_rng helper was deprecated, and SmallRng was
suggested to replace it instead.