### PR TITLE
Escape [] in docs to avoid warnings on nightly

### DIFF
--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -1059,7 +1059,7 @@ unsafe fn unpark_filter_internal(
     result
 }
 
-/// [Experimental] Deadlock detection
+/// \[Experimental\] Deadlock detection
 ///
 /// Enabled via the `deadlock_detection` feature flag.
 pub mod deadlock {

--- a/src/deadlock.rs
+++ b/src/deadlock.rs
@@ -1,4 +1,4 @@
-//! [Experimental] Deadlock detection
+//! \[Experimental\] Deadlock detection
 //!
 //! This feature is optional and can be enabled via the `deadlock_detection` feature flag.
 //!


### PR DESCRIPTION
Before this commit, these `[Experimental]` parts of the documentation
were seen as intra-links. Those links could not been resolved, resulting
in a warning on nightly.

It would be awesome, if this can be merged and maybe released as a point release, as `cargo doc` on nightly is quite noisy with many dependencies :)