### PR TITLE
Add const_fn feature (more granular than nigthly)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,12 @@ rand = "0.5"
 [features]
 default = ["owning_ref"]
 owning_ref = ["lock_api/owning_ref"]
-nightly = ["parking_lot_core/nightly", "lock_api/nightly"]
+const_fn = ["lock_api/const_fn"]
+nightly = ["const_fn", "parking_lot_core/nightly", "lock_api/nightly"]
 deadlock_detection = ["parking_lot_core/deadlock_detection"]
+
+[package.metadata.docs.rs]
+features = ["const_fn"]
 
 [workspace]
 exclude = ["benchmark"]

--- a/README.md
+++ b/README.md
@@ -85,13 +85,14 @@ lock.
 There are a few restrictions when using this library on stable Rust:
 
 - `Mutex` and `Once` will use 1 word of space instead of 1 byte.
-- You will have to use `lazy_static!` to statically initialize `Mutex`,
-  `Condvar` and `RwLock` types instead of `const fn`.
+- Statically initializing `Mutex`, `Condvar` and `RwLock` types requires Rust
+  1.31 and has to be enabled by selecting the `const_fn` feature.
+  Otherwise you will have to use `lazy_static!`.
 - `RwLock` will not be able to take advantage of hardware lock elision for
   readers, which improves performance when there are multiple readers.
 
-To enable nightly-only functionality, you need to enable the `nightly` feature
-in Cargo (see below).
+To enable all nightly-only functionality, you need to enable the `nightly`
+feature in Cargo (see below).
 
 ## Usage
 

--- a/lock_api/Cargo.toml
+++ b/lock_api/Cargo.toml
@@ -13,4 +13,8 @@ scopeguard = { version = "0.3", default-features = false }
 owning_ref = { version = "0.3", optional = true }
 
 [features]
-nightly = []
+const_fn = []
+nightly = ["const_fn"]
+
+[package.metadata.docs.rs]
+features = ["const_fn"]

--- a/lock_api/src/lib.rs
+++ b/lock_api/src/lib.rs
@@ -77,15 +77,15 @@
 //!
 //! # Cargo features
 //!
-//! This crate supports two cargo features:
+//! This crate supports the following cargo features:
 //!
 //! - `owning_ref`: Allows your lock types to be used with the `owning_ref` crate.
-//! - `nightly`: Enables nightly-only features. At the moment the only such
+//! - `const_fn`: Enables `const fn` constructors for lock types. Requires Rust 1.31.
+//! - `nightly`: Enables all nightly-only features. At the moment the only such
 //!   feature is `const fn` constructors for lock types.
 
 #![no_std]
 #![warn(missing_docs)]
-#![cfg_attr(feature = "nightly", feature(const_fn))]
 
 #[macro_use]
 extern crate scopeguard;

--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -98,7 +98,7 @@ unsafe impl<R: RawMutex + Sync, T: ?Sized + Send> Sync for Mutex<R, T> {}
 
 impl<R: RawMutex, T> Mutex<R, T> {
     /// Creates a new mutex in an unlocked state ready for use.
-    #[cfg(feature = "nightly")]
+    #[cfg(feature = "const_fn")]
     #[inline]
     pub const fn new(val: T) -> Mutex<R, T> {
         Mutex {
@@ -108,7 +108,7 @@ impl<R: RawMutex, T> Mutex<R, T> {
     }
 
     /// Creates a new mutex in an unlocked state ready for use.
-    #[cfg(not(feature = "nightly"))]
+    #[cfg(not(feature = "const_fn"))]
     #[inline]
     pub fn new(val: T) -> Mutex<R, T> {
         Mutex {

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -149,7 +149,7 @@ unsafe impl<R: RawMutex + Sync, G: GetThreadId + Sync, T: ?Sized + Send> Sync
 
 impl<R: RawMutex, G: GetThreadId, T> ReentrantMutex<R, G, T> {
     /// Creates a new reentrant mutex in an unlocked state ready for use.
-    #[cfg(feature = "nightly")]
+    #[cfg(feature = "const_fn")]
     #[inline]
     pub const fn new(val: T) -> ReentrantMutex<R, G, T> {
         ReentrantMutex {
@@ -164,7 +164,7 @@ impl<R: RawMutex, G: GetThreadId, T> ReentrantMutex<R, G, T> {
     }
 
     /// Creates a new reentrant mutex in an unlocked state ready for use.
-    #[cfg(not(feature = "nightly"))]
+    #[cfg(not(feature = "const_fn"))]
     #[inline]
     pub fn new(val: T) -> ReentrantMutex<R, G, T> {
         ReentrantMutex {

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -235,7 +235,7 @@ unsafe impl<R: RawRwLock + Sync, T: ?Sized + Send + Sync> Sync for RwLock<R, T> 
 
 impl<R: RawRwLock, T> RwLock<R, T> {
     /// Creates a new instance of an `RwLock<T>` which is unlocked.
-    #[cfg(feature = "nightly")]
+    #[cfg(feature = "const_fn")]
     #[inline]
     pub const fn new(val: T) -> RwLock<R, T> {
         RwLock {
@@ -245,7 +245,7 @@ impl<R: RawRwLock, T> RwLock<R, T> {
     }
 
     /// Creates a new instance of an `RwLock<T>` which is unlocked.
-    #[cfg(not(feature = "nightly"))]
+    #[cfg(not(feature = "const_fn"))]
     #[inline]
     pub fn new(val: T) -> RwLock<R, T> {
         RwLock {

--- a/src/condvar.rs
+++ b/src/condvar.rs
@@ -51,7 +51,7 @@ impl WaitTimeoutResult {
 ///   woken up.
 /// - Only requires 1 word of space, whereas the standard library boxes the
 ///   `Condvar` due to platform limitations.
-/// - Can be statically constructed (requires the `const_fn` nightly feature).
+/// - Can be statically constructed (requires the `const_fn` feature).
 /// - Does not require any drop glue when dropped.
 /// - Inline fast path for the uncontended case.
 ///
@@ -87,7 +87,7 @@ pub struct Condvar {
 impl Condvar {
     /// Creates a new condition variable which is ready to be waited on and
     /// notified.
-    #[cfg(feature = "nightly")]
+    #[cfg(feature = "const_fn")]
     #[inline]
     pub const fn new() -> Condvar {
         Condvar {
@@ -97,7 +97,7 @@ impl Condvar {
 
     /// Creates a new condition variable which is ready to be waited on and
     /// notified.
-    #[cfg(not(feature = "nightly"))]
+    #[cfg(not(feature = "const_fn"))]
     #[inline]
     pub fn new() -> Condvar {
         Condvar {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 //! standard library. It also provides a `ReentrantMutex` type.
 
 #![warn(missing_docs)]
-#![cfg_attr(feature = "nightly", feature(const_fn))]
 #![cfg_attr(feature = "nightly", feature(integer_atomics))]
 #![cfg_attr(feature = "nightly", feature(asm))]
 

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -42,7 +42,7 @@ use raw_mutex::RawMutex;
 /// - No poisoning, the lock is released normally on panic.
 /// - Only requires 1 byte of space, whereas the standard library boxes the
 ///   `Mutex` due to platform limitations.
-/// - Can be statically constructed (requires the `const_fn` nightly feature).
+/// - Can be statically constructed (requires the `const_fn` feature).
 /// - Does not require any drop glue when dropped.
 /// - Inline fast path for the uncontended case.
 /// - Efficient handling of micro-contention using adaptive spinning.

--- a/src/once.rs
+++ b/src/once.rs
@@ -96,14 +96,14 @@ pub const ONCE_INIT: Once = Once(ATOMIC_U8_INIT);
 
 impl Once {
     /// Creates a new `Once` value.
-    #[cfg(feature = "nightly")]
+    #[cfg(feature = "const_fn")]
     #[inline]
     pub const fn new() -> Once {
         Once(ATOMIC_U8_INIT)
     }
 
     /// Creates a new `Once` value.
-    #[cfg(not(feature = "nightly"))]
+    #[cfg(not(feature = "const_fn"))]
     #[inline]
     pub fn new() -> Once {
         Once(ATOMIC_U8_INIT)

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -55,7 +55,7 @@ use raw_rwlock::RawRwLock;
 /// - No poisoning, the lock is released normally on panic.
 /// - Only requires 1 word of space, whereas the standard library boxes the
 ///   `RwLock` due to platform limitations.
-/// - Can be statically constructed (requires the `const_fn` nightly feature).
+/// - Can be statically constructed (requires the `const_fn` feature).
 /// - Does not require any drop glue when dropped.
 /// - Inline fast path for the uncontended case.
 /// - Efficient handling of micro-contention using adaptive spinning.


### PR DESCRIPTION
[`min_const_fn`](https://github.com/rust-lang/rust/issues/53555) has been stabilized. It should still be opt-in, because it bumps the minimum Rust version to 1.31 (currently in beta).

This adds a new `const_fn` Cargo feature that allows using this without all current and future features implied by `nightly`. `nightly` still also implies `const_fn`.