### PR TITLE
Condvar: Return bool / usize from notify_one / notify_all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.7.0 (2018-11-20)
+==================
+
+- Return if or how many threads were notified from `Condvar::notify_*`
+
 0.6.3 (2018-07-18)
 ==================
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parking_lot"
-version = "0.6.4"
+version = "0.7.0"
 authors = ["Amanieu d'Antras <amanieu@gmail.com>"]
 description = "More compact and efficient implementations of the standard synchronization primitives."
 license = "Apache-2.0/MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["mutex", "condvar", "rwlock", "once", "thread"]
 categories = ["concurrency"]
 
 [dependencies]
-parking_lot_core = { path = "core", version = "0.3" }
+parking_lot_core = { path = "core", version = "0.4" }
 lock_api = { path = "lock_api", version = "0.1" }
 
 [dev-dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parking_lot_core"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Amanieu d'Antras <amanieu@gmail.com>"]
 description = "An advanced API for creating custom synchronization primitives."
 license = "Apache-2.0/MIT"

--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -455,6 +455,9 @@ pub struct UnparkResult {
     /// should be used to switch to a fair unlocking mechanism for a particular
     /// unlock.
     pub be_fair: bool,
+
+    /// Private field so new fields can be added without breakage.
+    _sealed: (),
 }
 
 /// Operation that `unpark_requeue` should perform.


### PR DESCRIPTION
This simply returns the values already stored in `UnparkResult`.

Please tell me if you'd prefer not to merge the version bump.

## Changes

* Add return value to both methods to indicate if or how many threads were woken up (BREAKING)
* Bump version to 0.7.0 and add changelog entry
* Add `UnparkResult::requeued_threads`

## Issues

Fixes #104 