### PR TITLE
Replace _padding with proper repr(align(x)) on newer Rust

### DIFF
--- a/core/build.rs
+++ b/core/build.rs
@@ -2,6 +2,9 @@ extern crate rustc_version;
 use rustc_version::{version, Version};
 
 fn main() {
+    if version().unwrap() >= Version::parse("1.25.0").unwrap() {
+        println!("cargo:rustc-cfg=has_repr_align");
+    }
     if version().unwrap() >= Version::parse("1.26.0").unwrap() {
         println!("cargo:rustc-cfg=has_localkey_try_with");
     }


### PR DESCRIPTION
This reduces the `Bucket` struct size from 112 bytes to 64 bytes when compiled on Rust >= 1.25 that supports `#[repr(align(x))]`