### PR TITLE
Safer word lock

### DIFF
--- a/core/src/word_lock.rs
+++ b/core/src/word_lock.rs
@@ -47,7 +47,7 @@ impl ThreadData {
 }
 
 // Returns a ThreadData structure for the current thread
-unsafe fn get_thread_data(local: &mut Option<ThreadData>) -> &ThreadData {
+fn get_thread_data(local: &mut Option<ThreadData>) -> &ThreadData {
     // Try to read from thread-local storage, but return None if the TLS has
     // already been destroyed.
     #[cfg(has_localkey_try_with)]
@@ -64,7 +64,7 @@ unsafe fn get_thread_data(local: &mut Option<ThreadData>) -> &ThreadData {
     if !cfg!(windows) && !cfg!(all(feature = "nightly", target_os = "linux")) {
         thread_local!(static THREAD_DATA: ThreadData = ThreadData::new());
         if let Some(tls) = try_get_tls(&THREAD_DATA) {
-            return &*tls;
+            return unsafe { &*tls };
         }
     }
 

--- a/core/src/word_lock.rs
+++ b/core/src/word_lock.rs
@@ -103,6 +103,7 @@ impl WordLock {
         self.lock_slow();
     }
 
+    /// Must not be called on an already unlocked `WordLock`!
     #[inline]
     pub unsafe fn unlock(&self) {
         let state = self.state.fetch_sub(LOCKED_BIT, Ordering::Release);

--- a/core/src/word_lock.rs
+++ b/core/src/word_lock.rs
@@ -170,7 +170,7 @@ impl WordLock {
 
             // Loop back and try locking again
             spinwait.reset();
-            self.state.load(Ordering::Relaxed);
+            state = self.state.load(Ordering::Relaxed);
         }
     }
 


### PR DESCRIPTION
I tried to reason a bit about the invariants of the unsafe code in WordLock. I think we can get away with them not being `unsafe` with some minor adjustments. Mostly this PR removes `unsafe` keywords from methods and adds `unsafe` blocks within them. But there is one more difference that I'm hoping should make this safe to call from the outside:
```rust
fn unlock(&self) {
    let state = self.state.fetch_and(!LOCKED_BIT, Ordering::Release);
    ...
}
```
Switching from `fetch_sub` to `fetch_and` is intended to make the method not corrupt `self.state` if called on an already unlocked `WordLock`. Previously multiple calls would continue to decrement the integer by one, locking and unlocking it as well as corrupting the part of it that is used as a pointer. By using the bit and operation this should just zero out the `LOCKED_BIT` without touching the rest. The test suite passes, I'm not sure if I have missed something else that makes this a bad change.

If you don't like the trait on `usize` providing the convenience methods we can skip them. They are unrelated to making the methods safe, other than it might be harder to screw code up if the bit manipulation is extracted.