### PR TITLE
[WIP] New RwLock implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ lock_api = { path = "lock_api", version = "0.1" }
 
 [dev-dependencies]
 rand = "0.6"
+lazy_static = "1.0"
 
 [features]
 default = ["owning_ref"]

--- a/lock_api/Cargo.toml
+++ b/lock_api/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["mutex", "rwlock", "lock", "no_std"]
 categories = ["concurrency", "no-std"]
 
 [dependencies]
-scopeguard = { version = "0.3", default-features = false }
+scopeguard = { version = "1.0", default-features = false }
 owning_ref = { version = "0.4", optional = true }
 
 [features]

--- a/src/deadlock.rs
+++ b/src/deadlock.rs
@@ -44,10 +44,11 @@ mod tests {
     use std::thread::{self, sleep};
     use std::time::Duration;
     use {Mutex, ReentrantMutex, RwLock};
-    use lock_api::RawMutex;
 
     // We need to serialize these tests since deadlock detection uses global state
-    static DEADLOCK_DETECTION_LOCK: ::RawMutex = RawMutex::INIT;
+    lazy_static! {
+        static ref DEADLOCK_DETECTION_LOCK: Mutex<()> = Mutex::new(());
+    }
 
     fn check_deadlock() -> bool {
         use parking_lot_core::deadlock::check_deadlock;
@@ -56,7 +57,7 @@ mod tests {
 
     #[test]
     fn test_mutex_deadlock() {
-        DEADLOCK_DETECTION_LOCK.lock();
+        let _guard = DEADLOCK_DETECTION_LOCK.lock();
 
         let m1: Arc<Mutex<()>> = Default::default();
         let m2: Arc<Mutex<()>> = Default::default();
@@ -97,13 +98,11 @@ mod tests {
         assert!(check_deadlock());
 
         assert!(!check_deadlock());
-
-        DEADLOCK_DETECTION_LOCK.unlock();
     }
 
     #[test]
     fn test_mutex_deadlock_reentrant() {
-        DEADLOCK_DETECTION_LOCK.lock();
+        let _guard = DEADLOCK_DETECTION_LOCK.lock();
 
         let m1: Arc<Mutex<()>> = Default::default();
 
@@ -118,13 +117,11 @@ mod tests {
         assert!(check_deadlock());
 
         assert!(!check_deadlock());
-
-        DEADLOCK_DETECTION_LOCK.unlock();
     }
 
     #[test]
     fn test_remutex_deadlock() {
-        DEADLOCK_DETECTION_LOCK.lock();
+        let _guard = DEADLOCK_DETECTION_LOCK.lock();
 
         let m1: Arc<ReentrantMutex<()>> = Default::default();
         let m2: Arc<ReentrantMutex<()>> = Default::default();
@@ -168,13 +165,11 @@ mod tests {
         assert!(check_deadlock());
 
         assert!(!check_deadlock());
-
-        DEADLOCK_DETECTION_LOCK.unlock();
     }
 
     #[test]
     fn test_rwlock_deadlock() {
-        DEADLOCK_DETECTION_LOCK.lock();
+        let _guard = DEADLOCK_DETECTION_LOCK.lock();
 
         let m1: Arc<RwLock<()>> = Default::default();
         let m2: Arc<RwLock<()>> = Default::default();
@@ -215,13 +210,12 @@ mod tests {
         assert!(check_deadlock());
 
         assert!(!check_deadlock());
-
-        DEADLOCK_DETECTION_LOCK.unlock();
     }
 
+    #[cfg(rwlock_deadlock_detection_not_supported)]
     #[test]
     fn test_rwlock_deadlock_reentrant() {
-        DEADLOCK_DETECTION_LOCK.lock();
+        let _guard = DEADLOCK_DETECTION_LOCK.lock();
 
         let m1: Arc<RwLock<()>> = Default::default();
 
@@ -236,7 +230,5 @@ mod tests {
         assert!(check_deadlock());
 
         assert!(!check_deadlock());
-
-        DEADLOCK_DETECTION_LOCK.unlock();
     }
 }

--- a/src/elision.rs
+++ b/src/elision.rs
@@ -12,17 +12,14 @@ pub trait AtomicElisionExt {
     type IntType;
 
     // Perform a compare_exchange and start a transaction
-    fn elision_acquire(
+    fn elision_compare_exchange_acquire(
         &self,
         current: Self::IntType,
         new: Self::IntType,
     ) -> Result<Self::IntType, Self::IntType>;
-    // Perform a compare_exchange and end a transaction
-    fn elision_release(
-        &self,
-        current: Self::IntType,
-        new: Self::IntType,
-    ) -> Result<Self::IntType, Self::IntType>;
+
+    // Perform a fetch_sub and end a transaction
+    fn elision_fetch_sub_release(&self, val: Self::IntType) -> Self::IntType;
 }
 
 // Indicates whether the target architecture supports lock elision
@@ -41,22 +38,23 @@ impl AtomicElisionExt for AtomicUsize {
     type IntType = usize;
 
     #[inline]
-    fn elision_acquire(&self, _: usize, _: usize) -> Result<usize, usize> {
+    fn elision_compare_exchange_acquire(&self, _: usize, _: usize) -> Result<usize, usize> {
         unreachable!();
     }
 
     #[inline]
-    fn elision_release(&self, _: usize, _: usize) -> Result<usize, usize> {
+    fn elision_fetch_sub_release(&self, _: usize) -> usize {
         unreachable!();
     }
 }
 
-#[cfg(all(feature = "nightly", target_arch = "x86"))]
+#[cfg(all(feature = "nightly", any(target_arch = "x86", target_arch = "x86_64")))]
 impl AtomicElisionExt for AtomicUsize {
     type IntType = usize;
 
+    #[cfg(target_pointer_width = "32")]
     #[inline]
-    fn elision_acquire(&self, current: usize, new: usize) -> Result<usize, usize> {
+    fn elision_compare_exchange_acquire(&self, current: usize, new: usize) -> Result<usize, usize> {
         unsafe {
             let prev: usize;
             asm!("xacquire; lock; cmpxchgl $2, $1"
@@ -71,78 +69,9 @@ impl AtomicElisionExt for AtomicUsize {
             }
         }
     }
-
+    #[cfg(target_pointer_width = "64")]
     #[inline]
-    fn elision_release(&self, current: usize, new: usize) -> Result<usize, usize> {
-        unsafe {
-            let prev: usize;
-            asm!("xrelease; lock; cmpxchgl $2, $1"
-                 : "={eax}" (prev), "+*m" (self)
-                 : "r" (new), "{eax}" (current)
-                 : "memory"
-                 : "volatile");
-            if prev == current {
-                Ok(prev)
-            } else {
-                Err(prev)
-            }
-        }
-    }
-}
-
-#[cfg(all(
-    feature = "nightly",
-    target_arch = "x86_64",
-    target_pointer_width = "32"
-))]
-impl AtomicElisionExt for AtomicUsize {
-    type IntType = usize;
-
-    #[inline]
-    fn elision_acquire(&self, current: usize, new: usize) -> Result<usize, usize> {
-        unsafe {
-            let prev: usize;
-            asm!("xacquire; lock; cmpxchgl $2, $1"
-                 : "={rax}" (prev), "+*m" (self)
-                 : "r" (new), "{rax}" (current)
-                 : "memory"
-                 : "volatile");
-            if prev == current {
-                Ok(prev)
-            } else {
-                Err(prev)
-            }
-        }
-    }
-
-    #[inline]
-    fn elision_release(&self, current: usize, new: usize) -> Result<usize, usize> {
-        unsafe {
-            let prev: usize;
-            asm!("xrelease; lock; cmpxchgl $2, $1"
-                 : "={rax}" (prev), "+*m" (self)
-                 : "r" (new), "{rax}" (current)
-                 : "memory"
-                 : "volatile");
-            if prev == current {
-                Ok(prev)
-            } else {
-                Err(prev)
-            }
-        }
-    }
-}
-
-#[cfg(all(
-    feature = "nightly",
-    target_arch = "x86_64",
-    target_pointer_width = "64"
-))]
-impl AtomicElisionExt for AtomicUsize {
-    type IntType = usize;
-
-    #[inline]
-    fn elision_acquire(&self, current: usize, new: usize) -> Result<usize, usize> {
+    fn elision_compare_exchange_acquire(&self, current: usize, new: usize) -> Result<usize, usize> {
         unsafe {
             let prev: usize;
             asm!("xacquire; lock; cmpxchgq $2, $1"
@@ -158,20 +87,30 @@ impl AtomicElisionExt for AtomicUsize {
         }
     }
 
+    #[cfg(target_pointer_width = "32")]
     #[inline]
-    fn elision_release(&self, current: usize, new: usize) -> Result<usize, usize> {
+    fn elision_fetch_sub_release(&self, val: usize) -> usize {
         unsafe {
             let prev: usize;
-            asm!("xrelease; lock; cmpxchgq $2, $1"
-                 : "={rax}" (prev), "+*m" (self)
-                 : "r" (new), "{rax}" (current)
+            asm!("xrelease; lock; xaddl $2, $1"
+                 : "=r" (prev), "+*m" (self)
+                 : "0" (val.wrapping_neg())
                  : "memory"
                  : "volatile");
-            if prev == current {
-                Ok(prev)
-            } else {
-                Err(prev)
-            }
+            prev
+        }
+    }
+    #[cfg(target_pointer_width = "64")]
+    #[inline]
+    fn elision_fetch_sub_release(&self, val: usize) -> usize {
+        unsafe {
+            let prev: usize;
+            asm!("xrelease; lock; xaddq $2, $1"
+                 : "=r" (prev), "+*m" (self)
+                 : "0" (val.wrapping_neg())
+                 : "memory"
+                 : "volatile");
+            prev
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,11 @@
 extern crate lock_api;
 extern crate parking_lot_core;
 
+#[cfg(test)]
+#[cfg(feature = "deadlock_detection")]
+#[macro_use]
+extern crate lazy_static;
+
 mod condvar;
 mod elision;
 mod mutex;

--- a/src/raw_rwlock.rs
+++ b/src/raw_rwlock.rs
@@ -5,38 +5,53 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use deadlock;
 use elision::{have_elision, AtomicElisionExt};
 use lock_api::{
     GuardNoSend, RawRwLock as RawRwLockTrait, RawRwLockDowngrade, RawRwLockFair,
     RawRwLockRecursive, RawRwLockRecursiveTimed, RawRwLockTimed, RawRwLockUpgrade,
     RawRwLockUpgradeDowngrade, RawRwLockUpgradeFair, RawRwLockUpgradeTimed,
 };
-use parking_lot_core::{self, FilterOp, ParkResult, ParkToken, SpinWait, UnparkResult};
+use parking_lot_core::{
+    self, deadlock, FilterOp, ParkResult, ParkToken, SpinWait, UnparkResult, UnparkToken,
+};
 use raw_mutex::{TOKEN_HANDOFF, TOKEN_NORMAL};
 use std::cell::Cell;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 use util;
 
-const PARKED_BIT: usize = 0b001;
-const UPGRADING_BIT: usize = 0b010;
-// A shared guard acquires a single guard resource
-const SHARED_GUARD: usize = 0b100;
-const GUARD_COUNT_MASK: usize = !(SHARED_GUARD - 1);
-// An exclusive lock acquires all of guard resource (i.e. it is exclusive)
-const EXCLUSIVE_GUARD: usize = GUARD_COUNT_MASK;
-// An upgradable lock acquires just over half of the guard resource
-// This should be (GUARD_COUNT_MASK + SHARED_GUARD) >> 1, however this might
-// overflow, so we shift before adding (which is okay since the least
-// significant bit is zero for both GUARD_COUNT_MASK and SHARED_GUARD)
-const UPGRADABLE_GUARD: usize = (GUARD_COUNT_MASK >> 1) + (SHARED_GUARD >> 1);
+// This reader-writer lock implementation is based on Boost's upgrade_mutex:
+// https://github.com/boostorg/thread/blob/fc08c1fe2840baeeee143440fba31ef9e9a813c8/include/boost/thread/v2/shared_mutex.hpp#L432
+//
+// This implementation uses 2 wait queues, one at key [addr] and one at key
+// [addr + 1]. The primary queue is used for all new waiting threads, and the
+// secondary queue is used by the thread which has acquired WRITER_BIT but is
+// waiting for the remaining readers to exit the lock.
+//
+// This implementation is fair between readers and writers since it uses the
+// order in which threads first started queuing to alternate between read phases
+// and write phases. In particular is it not vulnerable to write starvation
+// since readers will block if there is a pending writer.
 
-// Token indicating what type of lock queued threads are trying to acquire
-const TOKEN_SHARED: ParkToken = ParkToken(SHARED_GUARD);
-const TOKEN_EXCLUSIVE: ParkToken = ParkToken(EXCLUSIVE_GUARD);
-const TOKEN_UPGRADABLE: ParkToken = ParkToken(UPGRADABLE_GUARD);
-const TOKEN_UPGRADING: ParkToken = ParkToken((EXCLUSIVE_GUARD - UPGRADABLE_GUARD) | UPGRADING_BIT);
+// There is at least one thread in the main queue.
+const PARKED_BIT: usize = 0b0001;
+// There is a parked thread holding WRITER_BIT. WRITER_BIT must be set.
+const WRITER_PARKED_BIT: usize = 0b0010;
+// A reader is holding an upgradable lock. The reader count must be non-zero and
+// WRITER_BIT must not be set.
+const UPGRADABLE_BIT: usize = 0b0100;
+// If the reader count is zero: a writer is currently holding an exclusive lock.
+// Otherwise: a writer is waiting for the remaining readers to exit the lock.
+const WRITER_BIT: usize = 0b1000;
+// Mask of bits used to count readers.
+const READERS_MASK: usize = !0b1111;
+// Base unit for counting readers.
+const ONE_READER: usize = 0b10000;
+
+// Token indicating what type of lock a queued thread is trying to acquire
+const TOKEN_SHARED: ParkToken = ParkToken(ONE_READER);
+const TOKEN_EXCLUSIVE: ParkToken = ParkToken(WRITER_BIT);
+const TOKEN_UPGRADABLE: ParkToken = ParkToken(ONE_READER | UPGRADABLE_BIT);
 
 /// Raw reader-writer lock type backed by the parking lot.
 pub struct RawRwLock {
@@ -54,23 +69,23 @@ unsafe impl RawRwLockTrait for RawRwLock {
     fn lock_exclusive(&self) {
         if self
             .state
-            .compare_exchange_weak(0, EXCLUSIVE_GUARD, Ordering::Acquire, Ordering::Relaxed)
+            .compare_exchange_weak(0, WRITER_BIT, Ordering::Acquire, Ordering::Relaxed)
             .is_err()
         {
             let result = self.lock_exclusive_slow(None);
             debug_assert!(result);
         }
-        unsafe { deadlock::acquire_resource(self as *const _ as usize) };
+        self.deadlock_acquire();
     }
 
     #[inline]
     fn try_lock_exclusive(&self) -> bool {
         if self
             .state
-            .compare_exchange(0, EXCLUSIVE_GUARD, Ordering::Acquire, Ordering::Relaxed)
+            .compare_exchange(0, WRITER_BIT, Ordering::Acquire, Ordering::Relaxed)
             .is_ok()
         {
-            unsafe { deadlock::acquire_resource(self as *const _ as usize) };
+            self.deadlock_acquire();
             true
         } else {
             false
@@ -79,10 +94,10 @@ unsafe impl RawRwLockTrait for RawRwLock {
 
     #[inline]
     fn unlock_exclusive(&self) {
-        unsafe { deadlock::release_resource(self as *const _ as usize) };
+        self.deadlock_release();
         if self
             .state
-            .compare_exchange_weak(EXCLUSIVE_GUARD, 0, Ordering::Release, Ordering::Relaxed)
+            .compare_exchange(WRITER_BIT, 0, Ordering::Release, Ordering::Relaxed)
             .is_ok()
         {
             return;
@@ -96,7 +111,7 @@ unsafe impl RawRwLockTrait for RawRwLock {
             let result = self.lock_shared_slow(false, None);
             debug_assert!(result);
         }
-        unsafe { deadlock::acquire_resource(self as *const _ as usize) };
+        self.deadlock_acquire();
     }
 
     #[inline]
@@ -107,85 +122,38 @@ unsafe impl RawRwLockTrait for RawRwLock {
             self.try_lock_shared_slow(false)
         };
         if result {
-            unsafe { deadlock::acquire_resource(self as *const _ as usize) };
+            self.deadlock_acquire();
         }
         result
     }
 
     #[inline]
     fn unlock_shared(&self) {
-        unsafe { deadlock::release_resource(self as *const _ as usize) };
-        let state = self.state.load(Ordering::Relaxed);
-        if state & PARKED_BIT == 0
-            || (state & UPGRADING_BIT == 0 && state & GUARD_COUNT_MASK != SHARED_GUARD)
-        {
-            if have_elision() {
-                if self
-                    .state
-                    .elision_release(state, state - SHARED_GUARD)
-                    .is_ok()
-                {
-                    return;
-                }
-            } else {
-                if self
-                    .state
-                    .compare_exchange_weak(
-                        state,
-                        state - SHARED_GUARD,
-                        Ordering::Release,
-                        Ordering::Relaxed,
-                    )
-                    .is_ok()
-                {
-                    return;
-                }
-            }
+        self.deadlock_release();
+        let state = if have_elision() {
+            self.state.elision_fetch_sub_release(ONE_READER)
+        } else {
+            self.state.fetch_sub(ONE_READER, Ordering::Release)
+        };
+        if state & (READERS_MASK | WRITER_PARKED_BIT) == (ONE_READER | WRITER_PARKED_BIT) {
+            self.unlock_shared_slow();
         }
-        self.unlock_shared_slow(false);
     }
 }
 
 unsafe impl RawRwLockFair for RawRwLock {
     #[inline]
     fn unlock_shared_fair(&self) {
-        unsafe { deadlock::release_resource(self as *const _ as usize) };
-        let state = self.state.load(Ordering::Relaxed);
-        if state & PARKED_BIT == 0
-            || (state & UPGRADING_BIT == 0 && state & GUARD_COUNT_MASK != SHARED_GUARD)
-        {
-            if have_elision() {
-                if self
-                    .state
-                    .elision_release(state, state - SHARED_GUARD)
-                    .is_ok()
-                {
-                    return;
-                }
-            } else {
-                if self
-                    .state
-                    .compare_exchange_weak(
-                        state,
-                        state - SHARED_GUARD,
-                        Ordering::Release,
-                        Ordering::Relaxed,
-                    )
-                    .is_ok()
-                {
-                    return;
-                }
-            }
-        }
-        self.unlock_shared_slow(true);
+        // Shared unlocking is always fair in this implementation.
+        self.unlock_shared();
     }
 
     #[inline]
     fn unlock_exclusive_fair(&self) {
-        unsafe { deadlock::release_resource(self as *const _ as usize) };
+        self.deadlock_release();
         if self
             .state
-            .compare_exchange_weak(EXCLUSIVE_GUARD, 0, Ordering::Release, Ordering::Relaxed)
+            .compare_exchange(WRITER_BIT, 0, Ordering::Release, Ordering::Relaxed)
             .is_ok()
         {
             return;
@@ -195,7 +163,9 @@ unsafe impl RawRwLockFair for RawRwLock {
 
     #[inline]
     fn bump_shared(&self) {
-        if self.state.load(Ordering::Relaxed) & PARKED_BIT != 0 {
+        if self.state.load(Ordering::Relaxed) & (READERS_MASK | WRITER_BIT)
+            == ONE_READER | WRITER_BIT
+        {
             self.bump_shared_slow();
         }
     }
@@ -213,7 +183,7 @@ unsafe impl RawRwLockDowngrade for RawRwLock {
     fn downgrade(&self) {
         let state = self
             .state
-            .fetch_sub(EXCLUSIVE_GUARD - SHARED_GUARD, Ordering::Release);
+            .fetch_add(ONE_READER - WRITER_BIT, Ordering::Release);
 
         // Wake up parked shared and upgradable threads if there are any
         if state & PARKED_BIT != 0 {
@@ -234,7 +204,7 @@ unsafe impl RawRwLockTimed for RawRwLock {
             self.lock_shared_slow(false, util::to_deadline(timeout))
         };
         if result {
-            unsafe { deadlock::acquire_resource(self as *const _ as usize) };
+            self.deadlock_acquire();
         }
         result
     }
@@ -247,7 +217,7 @@ unsafe impl RawRwLockTimed for RawRwLock {
             self.lock_shared_slow(false, Some(timeout))
         };
         if result {
-            unsafe { deadlock::acquire_resource(self as *const _ as usize) };
+            self.deadlock_acquire();
         }
         result
     }
@@ -256,7 +226,7 @@ unsafe impl RawRwLockTimed for RawRwLock {
     fn try_lock_exclusive_for(&self, timeout: Duration) -> bool {
         let result = if self
             .state
-            .compare_exchange_weak(0, EXCLUSIVE_GUARD, Ordering::Acquire, Ordering::Relaxed)
+            .compare_exchange_weak(0, WRITER_BIT, Ordering::Acquire, Ordering::Relaxed)
             .is_ok()
         {
             true
@@ -264,7 +234,7 @@ unsafe impl RawRwLockTimed for RawRwLock {
             self.lock_exclusive_slow(util::to_deadline(timeout))
         };
         if result {
-            unsafe { deadlock::acquire_resource(self as *const _ as usize) };
+            self.deadlock_acquire();
         }
         result
     }
@@ -273,7 +243,7 @@ unsafe impl RawRwLockTimed for RawRwLock {
     fn try_lock_exclusive_until(&self, timeout: Instant) -> bool {
         let result = if self
             .state
-            .compare_exchange_weak(0, EXCLUSIVE_GUARD, Ordering::Acquire, Ordering::Relaxed)
+            .compare_exchange_weak(0, WRITER_BIT, Ordering::Acquire, Ordering::Relaxed)
             .is_ok()
         {
             true
@@ -281,7 +251,7 @@ unsafe impl RawRwLockTimed for RawRwLock {
             self.lock_exclusive_slow(Some(timeout))
         };
         if result {
-            unsafe { deadlock::acquire_resource(self as *const _ as usize) };
+            self.deadlock_acquire();
         }
         result
     }
@@ -294,7 +264,7 @@ unsafe impl RawRwLockRecursive for RawRwLock {
             let result = self.lock_shared_slow(true, None);
             debug_assert!(result);
         }
-        unsafe { deadlock::acquire_resource(self as *const _ as usize) };
+        self.deadlock_acquire();
     }
 
     #[inline]
@@ -305,7 +275,7 @@ unsafe impl RawRwLockRecursive for RawRwLock {
             self.try_lock_shared_slow(true)
         };
         if result {
-            unsafe { deadlock::acquire_resource(self as *const _ as usize) };
+            self.deadlock_acquire();
         }
         result
     }
@@ -320,7 +290,7 @@ unsafe impl RawRwLockRecursiveTimed for RawRwLock {
             self.lock_shared_slow(true, util::to_deadline(timeout))
         };
         if result {
-            unsafe { deadlock::acquire_resource(self as *const _ as usize) };
+            self.deadlock_acquire();
         }
         result
     }
@@ -333,7 +303,7 @@ unsafe impl RawRwLockRecursiveTimed for RawRwLock {
             self.lock_shared_slow(true, Some(timeout))
         };
         if result {
-            unsafe { deadlock::acquire_resource(self as *const _ as usize) };
+            self.deadlock_acquire();
         }
         result
     }
@@ -346,7 +316,7 @@ unsafe impl RawRwLockUpgrade for RawRwLock {
             let result = self.lock_upgradable_slow(None);
             debug_assert!(result);
         }
-        unsafe { deadlock::acquire_resource(self as *const _ as usize) };
+        self.deadlock_acquire();
     }
 
     #[inline]
@@ -357,47 +327,51 @@ unsafe impl RawRwLockUpgrade for RawRwLock {
             self.try_lock_upgradable_slow()
         };
         if result {
-            unsafe { deadlock::acquire_resource(self as *const _ as usize) };
+            self.deadlock_acquire();
         }
         result
     }
 
     #[inline]
     fn unlock_upgradable(&self) {
-        unsafe { deadlock::release_resource(self as *const _ as usize) };
-        if self
-            .state
-            .compare_exchange_weak(UPGRADABLE_GUARD, 0, Ordering::Release, Ordering::Relaxed)
-            .is_ok()
-        {
-            return;
+        self.deadlock_release();
+        let state = self.state.load(Ordering::Relaxed);
+        if state & PARKED_BIT == 0 {
+            if self
+                .state
+                .compare_exchange_weak(
+                    state,
+                    state - (ONE_READER | UPGRADABLE_BIT),
+                    Ordering::Release,
+                    Ordering::Relaxed,
+                )
+                .is_ok()
+            {
+                return;
+            }
         }
         self.unlock_upgradable_slow(false);
     }
 
     #[inline]
     fn upgrade(&self) {
-        if self
-            .state
-            .compare_exchange_weak(
-                UPGRADABLE_GUARD,
-                EXCLUSIVE_GUARD,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            )
-            .is_err()
-        {
+        let state = self.state.fetch_sub(
+            (ONE_READER | UPGRADABLE_BIT) - WRITER_BIT,
+            Ordering::Relaxed,
+        );
+        if state & READERS_MASK != ONE_READER {
             let result = self.upgrade_slow(None);
             debug_assert!(result);
         }
     }
 
+    #[inline]
     fn try_upgrade(&self) -> bool {
         if self
             .state
             .compare_exchange_weak(
-                UPGRADABLE_GUARD,
-                EXCLUSIVE_GUARD,
+                ONE_READER | UPGRADABLE_BIT,
+                WRITER_BIT,
                 Ordering::Relaxed,
                 Ordering::Relaxed,
             )
@@ -413,20 +387,28 @@ unsafe impl RawRwLockUpgrade for RawRwLock {
 unsafe impl RawRwLockUpgradeFair for RawRwLock {
     #[inline]
     fn unlock_upgradable_fair(&self) {
-        unsafe { deadlock::release_resource(self as *const _ as usize) };
-        if self
-            .state
-            .compare_exchange_weak(UPGRADABLE_GUARD, 0, Ordering::Release, Ordering::Relaxed)
-            .is_ok()
-        {
-            return;
+        self.deadlock_release();
+        let state = self.state.load(Ordering::Relaxed);
+        if state & PARKED_BIT == 0 {
+            if self
+                .state
+                .compare_exchange_weak(
+                    state,
+                    state - (ONE_READER | UPGRADABLE_BIT),
+                    Ordering::Release,
+                    Ordering::Relaxed,
+                )
+                .is_ok()
+            {
+                return;
+            }
         }
-        self.unlock_upgradable_slow(true);
+        self.unlock_upgradable_slow(false);
     }
 
     #[inline]
     fn bump_upgradable(&self) {
-        if self.state.load(Ordering::Relaxed) & PARKED_BIT != 0 {
+        if self.state.load(Ordering::Relaxed) == ONE_READER | UPGRADABLE_BIT | PARKED_BIT {
             self.bump_upgradable_slow();
         }
     }
@@ -435,21 +417,20 @@ unsafe impl RawRwLockUpgradeFair for RawRwLock {
 unsafe impl RawRwLockUpgradeDowngrade for RawRwLock {
     #[inline]
     fn downgrade_upgradable(&self) {
-        let state = self
-            .state
-            .fetch_sub(UPGRADABLE_GUARD - SHARED_GUARD, Ordering::Relaxed);
+        let state = self.state.fetch_sub(UPGRADABLE_BIT, Ordering::Relaxed);
 
-        // Wake up parked shared and upgradable threads if there are any
+        // Wake up parked upgradable threads if there are any
         if state & PARKED_BIT != 0 {
-            self.downgrade_upgradable_slow(state);
+            self.downgrade_slow();
         }
     }
 
     #[inline]
     fn downgrade_to_upgradable(&self) {
-        let state = self
-            .state
-            .fetch_sub(EXCLUSIVE_GUARD - UPGRADABLE_GUARD, Ordering::Release);
+        let state = self.state.fetch_add(
+            (ONE_READER | UPGRADABLE_BIT) - WRITER_BIT,
+            Ordering::Release,
+        );
 
         // Wake up parked shared threads if there are any
         if state & PARKED_BIT != 0 {
@@ -467,7 +448,7 @@ unsafe impl RawRwLockUpgradeTimed for RawRwLock {
             self.lock_upgradable_slow(Some(timeout))
         };
         if result {
-            unsafe { deadlock::acquire_resource(self as *const _ as usize) };
+            self.deadlock_acquire();
         }
         result
     }
@@ -480,23 +461,18 @@ unsafe impl RawRwLockUpgradeTimed for RawRwLock {
             self.lock_upgradable_slow(util::to_deadline(timeout))
         };
         if result {
-            unsafe { deadlock::acquire_resource(self as *const _ as usize) };
+            self.deadlock_acquire();
         }
         result
     }
 
     #[inline]
     fn try_upgrade_until(&self, timeout: Instant) -> bool {
-        if self
-            .state
-            .compare_exchange_weak(
-                UPGRADABLE_GUARD,
-                EXCLUSIVE_GUARD,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            )
-            .is_ok()
-        {
+        let state = self.state.fetch_sub(
+            (ONE_READER | UPGRADABLE_BIT) - WRITER_BIT,
+            Ordering::Relaxed,
+        );
+        if state & READERS_MASK == ONE_READER {
             true
         } else {
             self.upgrade_slow(Some(timeout))
@@ -505,16 +481,11 @@ unsafe impl RawRwLockUpgradeTimed for RawRwLock {
 
     #[inline]
     fn try_upgrade_for(&self, timeout: Duration) -> bool {
-        if self
-            .state
-            .compare_exchange_weak(
-                UPGRADABLE_GUARD,
-                EXCLUSIVE_GUARD,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            )
-            .is_ok()
-        {
+        let state = self.state.fetch_sub(
+            (ONE_READER | UPGRADABLE_BIT) - WRITER_BIT,
+            Ordering::Relaxed,
+        );
+        if state & READERS_MASK == ONE_READER {
             true
         } else {
             self.upgrade_slow(util::to_deadline(timeout))
@@ -527,364 +498,30 @@ impl RawRwLock {
     fn try_lock_shared_fast(&self, recursive: bool) -> bool {
         let state = self.state.load(Ordering::Relaxed);
 
-        // We can't allow grabbing a shared lock while there are parked threads
-        // since that could lead to writer starvation.
-        if !recursive && state & PARKED_BIT != 0 {
-            return false;
+        // We can't allow grabbing a shared lock if there is a writer, even if
+        // the writer is still waiting for the remaining readers to exit.
+        if state & WRITER_BIT != 0 {
+            // To allow recursive locks, we make an exception and allow readers
+            // to skip ahead of a pending writer to avoid deadlocking, at the
+            // cost of breaking the fairness guarantees.
+            if !recursive || state & READERS_MASK == 0 {
+                return false;
+            }
         }
 
         // Use hardware lock elision to avoid cache conflicts when multiple
         // readers try to acquire the lock. We only do this if the lock is
         // completely empty since elision handles conflicts poorly.
         if have_elision() && state == 0 {
-            self.state.elision_acquire(0, SHARED_GUARD).is_ok()
-        } else if let Some(new_state) = state.checked_add(SHARED_GUARD) {
+            self.state
+                .elision_compare_exchange_acquire(0, ONE_READER)
+                .is_ok()
+        } else if let Some(new_state) = state.checked_add(ONE_READER) {
             self.state
                 .compare_exchange_weak(state, new_state, Ordering::Acquire, Ordering::Relaxed)
                 .is_ok()
         } else {
             false
-        }
-    }
-
-    #[inline(always)]
-    fn try_lock_upgradable_fast(&self) -> bool {
-        let state = self.state.load(Ordering::Relaxed);
-
-        // We can't allow grabbing an upgradable lock while there are parked threads
-        // since that could lead to writer starvation.
-        if state & PARKED_BIT != 0 {
-            return false;
-        }
-
-        if let Some(new_state) = state.checked_add(UPGRADABLE_GUARD) {
-            self.state
-                .compare_exchange_weak(state, new_state, Ordering::Acquire, Ordering::Relaxed)
-                .is_ok()
-        } else {
-            false
-        }
-    }
-
-    #[cold]
-    #[inline(never)]
-    fn lock_exclusive_slow(&self, timeout: Option<Instant>) -> bool {
-        let mut spinwait = SpinWait::new();
-        let mut state = self.state.load(Ordering::Relaxed);
-        loop {
-            // Grab the lock if it isn't locked, even if there are other
-            // threads parked.
-            if let Some(new_state) = state.checked_add(EXCLUSIVE_GUARD) {
-                match self.state.compare_exchange_weak(
-                    state,
-                    new_state,
-                    Ordering::Acquire,
-                    Ordering::Relaxed,
-                ) {
-                    Ok(_) => return true,
-                    Err(x) => state = x,
-                }
-                continue;
-            }
-
-            // If there are no parked threads and only one reader or writer, try
-            // spinning a few times.
-            if (state == EXCLUSIVE_GUARD || state == SHARED_GUARD || state == UPGRADABLE_GUARD)
-                && spinwait.spin()
-            {
-                state = self.state.load(Ordering::Relaxed);
-                continue;
-            }
-
-            // Park our thread until we are woken up by an unlock
-            unsafe {
-                let addr = self as *const _ as usize;
-                let validate = || {
-                    let mut state = self.state.load(Ordering::Relaxed);
-                    loop {
-                        // If the rwlock is free, abort the park and try to grab
-                        // it immediately.
-                        if state & GUARD_COUNT_MASK == 0 {
-                            return false;
-                        }
-
-                        // Nothing to do if the parked bit is already set
-                        if state & PARKED_BIT != 0 {
-                            return true;
-                        }
-
-                        // Set the parked bit
-                        match self.state.compare_exchange_weak(
-                            state,
-                            state | PARKED_BIT,
-                            Ordering::Relaxed,
-                            Ordering::Relaxed,
-                        ) {
-                            Ok(_) => return true,
-                            Err(x) => state = x,
-                        }
-                    }
-                };
-                let before_sleep = || {};
-                let timed_out = |_, was_last_thread| {
-                    // Clear the parked bit if we were the last parked thread
-                    if was_last_thread {
-                        self.state.fetch_and(!PARKED_BIT, Ordering::Relaxed);
-                    }
-                };
-                match parking_lot_core::park(
-                    addr,
-                    validate,
-                    before_sleep,
-                    timed_out,
-                    TOKEN_EXCLUSIVE,
-                    timeout,
-                ) {
-                    // The thread that unparked us passed the lock on to us
-                    // directly without unlocking it.
-                    ParkResult::Unparked(TOKEN_HANDOFF) => return true,
-
-                    // We were unparked normally, try acquiring the lock again
-                    ParkResult::Unparked(_) => (),
-
-                    // The validation function failed, try locking again
-                    ParkResult::Invalid => (),
-
-                    // Timeout expired
-                    ParkResult::TimedOut => return false,
-                }
-            }
-
-            // Loop back and try locking again
-            spinwait.reset();
-            state = self.state.load(Ordering::Relaxed);
-        }
-    }
-
-    #[cold]
-    #[inline(never)]
-    fn unlock_exclusive_slow(&self, force_fair: bool) {
-        // Unlock directly if there are no parked threads
-        if self
-            .state
-            .compare_exchange(EXCLUSIVE_GUARD, 0, Ordering::Release, Ordering::Relaxed)
-            .is_ok()
-        {
-            return;
-        };
-
-        // There are threads to unpark. We unpark threads up to the guard capacity.
-        let guard_count = Cell::new(0usize);
-        unsafe {
-            let addr = self as *const _ as usize;
-            let filter = |ParkToken(token)| -> FilterOp {
-                match guard_count.get().checked_add(token) {
-                    Some(new_guard_count) => {
-                        guard_count.set(new_guard_count);
-                        FilterOp::Unpark
-                    }
-                    None => FilterOp::Stop,
-                }
-            };
-            let callback = |result: UnparkResult| {
-                // If we are using a fair unlock then we should keep the
-                // rwlock locked and hand it off to the unparked threads.
-                if result.unparked_threads != 0 && (force_fair || result.be_fair) {
-                    // We need to set the guard count accordingly.
-                    let mut new_state = guard_count.get();
-
-                    if result.have_more_threads {
-                        new_state |= PARKED_BIT;
-                    }
-
-                    self.state.store(new_state, Ordering::Release);
-                    TOKEN_HANDOFF
-                } else {
-                    // Clear the parked bit if there are no more parked threads.
-                    if result.have_more_threads {
-                        self.state.store(PARKED_BIT, Ordering::Release);
-                    } else {
-                        self.state.store(0, Ordering::Release);
-                    }
-                    TOKEN_NORMAL
-                }
-            };
-            parking_lot_core::unpark_filter(addr, filter, callback);
-        }
-    }
-
-    #[cold]
-    #[inline(never)]
-    fn downgrade_slow(&self) {
-        unsafe {
-            let addr = self as *const _ as usize;
-            let mut guard_count = SHARED_GUARD;
-            let filter = |ParkToken(token)| -> FilterOp {
-                match guard_count.checked_add(token) {
-                    Some(new_guard_count) => {
-                        guard_count = new_guard_count;
-                        FilterOp::Unpark
-                    }
-                    None => FilterOp::Stop,
-                }
-            };
-            let callback = |result: UnparkResult| {
-                // Clear the parked bit if there no more parked threads
-                if !result.have_more_threads {
-                    self.state.fetch_and(!PARKED_BIT, Ordering::Relaxed);
-                }
-                TOKEN_NORMAL
-            };
-            parking_lot_core::unpark_filter(addr, filter, callback);
-        }
-    }
-
-    #[cold]
-    #[inline(never)]
-    fn downgrade_to_upgradable_slow(&self) {
-        unsafe {
-            let addr = self as *const _ as usize;
-            let mut guard_count = UPGRADABLE_GUARD;
-            let filter = |ParkToken(token)| -> FilterOp {
-                match guard_count.checked_add(token) {
-                    Some(new_guard_count) => {
-                        guard_count = new_guard_count;
-                        FilterOp::Unpark
-                    }
-                    None => FilterOp::Stop,
-                }
-            };
-            let callback = |result: UnparkResult| {
-                // Clear the parked bit if there no more parked threads
-                if !result.have_more_threads {
-                    self.state.fetch_and(!PARKED_BIT, Ordering::Relaxed);
-                }
-                TOKEN_NORMAL
-            };
-            parking_lot_core::unpark_filter(addr, filter, callback);
-        }
-    }
-
-    #[cold]
-    #[inline(never)]
-    fn lock_shared_slow(&self, recursive: bool, timeout: Option<Instant>) -> bool {
-        let mut spinwait = SpinWait::new();
-        let mut spinwait_shared = SpinWait::new();
-        let mut state = self.state.load(Ordering::Relaxed);
-        let mut unparked = false;
-        loop {
-            // Use hardware lock elision to avoid cache conflicts when multiple
-            // readers try to acquire the lock. We only do this if the lock is
-            // completely empty since elision handles conflicts poorly.
-            if have_elision() && state == 0 {
-                match self.state.elision_acquire(0, SHARED_GUARD) {
-                    Ok(_) => return true,
-                    Err(x) => state = x,
-                }
-            }
-
-            // Grab the lock if there are no exclusive threads locked or
-            // waiting. However if we were unparked then we are allowed to grab
-            // the lock even if there are pending exclusive threads.
-            if unparked || recursive || state & PARKED_BIT == 0 {
-                if let Some(new_state) = state.checked_add(SHARED_GUARD) {
-                    if self
-                        .state
-                        .compare_exchange_weak(
-                            state,
-                            new_state,
-                            Ordering::Acquire,
-                            Ordering::Relaxed,
-                        )
-                        .is_ok()
-                    {
-                        return true;
-                    }
-
-                    // If there is high contention on the reader count then we want
-                    // to leave some time between attempts to acquire the lock to
-                    // let other threads make progress.
-                    spinwait_shared.spin_no_yield();
-                    state = self.state.load(Ordering::Relaxed);
-                    continue;
-                } else {
-                    // We were unparked spuriously, reset unparked flag.
-                    unparked = false;
-                }
-            }
-
-            // If there are no parked threads, try spinning a few times
-            if state & PARKED_BIT == 0 && spinwait.spin() {
-                state = self.state.load(Ordering::Relaxed);
-                continue;
-            }
-
-            // Park our thread until we are woken up by an unlock
-            unsafe {
-                let addr = self as *const _ as usize;
-                let validate = || {
-                    let mut state = self.state.load(Ordering::Relaxed);
-                    loop {
-                        // Nothing to do if the parked bit is already set
-                        if state & PARKED_BIT != 0 {
-                            return true;
-                        }
-
-                        // If the parked bit is not set then it means we are at
-                        // the front of the queue. If there is space for another
-                        // lock then we should abort the park and try acquiring
-                        // the lock again.
-                        if state & GUARD_COUNT_MASK != GUARD_COUNT_MASK {
-                            return false;
-                        }
-
-                        // Set the parked bit
-                        match self.state.compare_exchange_weak(
-                            state,
-                            state | PARKED_BIT,
-                            Ordering::Relaxed,
-                            Ordering::Relaxed,
-                        ) {
-                            Ok(_) => return true,
-                            Err(x) => state = x,
-                        }
-                    }
-                };
-                let before_sleep = || {};
-                let timed_out = |_, was_last_thread| {
-                    // Clear the parked bit if we were the last parked thread
-                    if was_last_thread {
-                        self.state.fetch_and(!PARKED_BIT, Ordering::Relaxed);
-                    }
-                };
-                match parking_lot_core::park(
-                    addr,
-                    validate,
-                    before_sleep,
-                    timed_out,
-                    TOKEN_SHARED,
-                    timeout,
-                ) {
-                    // The thread that unparked us passed the lock on to us
-                    // directly without unlocking it.
-                    ParkResult::Unparked(TOKEN_HANDOFF) => return true,
-
-                    // We were unparked normally, try acquiring the lock again
-                    ParkResult::Unparked(_) => (),
-
-                    // The validation function failed, try locking again
-                    ParkResult::Invalid => (),
-
-                    // Timeout expired
-                    ParkResult::TimedOut => return false,
-                }
-            }
-
-            // Loop back and try locking again
-            spinwait.reset();
-            spinwait_shared.reset();
-            state = self.state.load(Ordering::Relaxed);
-            unparked = true;
         }
     }
 
@@ -893,155 +530,170 @@ impl RawRwLock {
     fn try_lock_shared_slow(&self, recursive: bool) -> bool {
         let mut state = self.state.load(Ordering::Relaxed);
         loop {
-            if !recursive && state & PARKED_BIT != 0 {
-                return false;
+            // This mirrors the condition in try_lock_shared_fast
+            if state & WRITER_BIT != 0 {
+                if !recursive || state & READERS_MASK == 0 {
+                    return false;
+                }
             }
             if have_elision() && state == 0 {
-                match self.state.elision_acquire(0, SHARED_GUARD) {
+                match self.state.elision_compare_exchange_acquire(0, ONE_READER) {
                     Ok(_) => return true,
                     Err(x) => state = x,
                 }
             } else {
-                match state.checked_add(SHARED_GUARD) {
-                    Some(new_state) => match self.state.compare_exchange_weak(
-                        state,
-                        new_state,
+                match self.state.compare_exchange_weak(
+                    state,
+                    state
+                        .checked_add(ONE_READER)
+                        .expect("RwLock reader count overflow"),
+                    Ordering::Acquire,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => return true,
+                    Err(x) => state = x,
+                }
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn try_lock_upgradable_fast(&self) -> bool {
+        let state = self.state.load(Ordering::Relaxed);
+
+        // We can't grab an upgradable lock if there is already a writer or
+        // upgradable reader.
+        if state & (WRITER_BIT | UPGRADABLE_BIT) != 0 {
+            return false;
+        }
+
+        if let Some(new_state) = state.checked_add(ONE_READER | UPGRADABLE_BIT) {
+            self.state
+                .compare_exchange_weak(state, new_state, Ordering::Acquire, Ordering::Relaxed)
+                .is_ok()
+        } else {
+            false
+        }
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn try_lock_upgradable_slow(&self) -> bool {
+        let mut state = self.state.load(Ordering::Relaxed);
+        loop {
+            // This mirrors the condition in try_lock_upgradable_fast
+            if state & (WRITER_BIT | UPGRADABLE_BIT) != 0 {
+                return false;
+            }
+
+            match self.state.compare_exchange_weak(
+                state,
+                state
+                    .checked_add(ONE_READER | UPGRADABLE_BIT)
+                    .expect("RwLock reader count overflow"),
+                Ordering::Acquire,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return true,
+                Err(x) => state = x,
+            }
+        }
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn lock_exclusive_slow(&self, timeout: Option<Instant>) -> bool {
+        // Step 1: grab exclusive ownership of WRITER_BIT
+        let timed_out = !self.lock_common(
+            timeout,
+            TOKEN_EXCLUSIVE,
+            |state| {
+                loop {
+                    if *state & (WRITER_BIT | UPGRADABLE_BIT) != 0 {
+                        return false;
+                    }
+
+                    // Grab WRITER_BIT if it isn't set, even if there are parked threads.
+                    match self.state.compare_exchange_weak(
+                        *state,
+                        *state | WRITER_BIT,
                         Ordering::Acquire,
                         Ordering::Relaxed,
                     ) {
                         Ok(_) => return true,
-                        Err(x) => state = x,
-                    },
-                    None => return false,
+                        Err(x) => *state = x,
+                    }
                 }
-            }
+            },
+            |state| state & (WRITER_BIT | UPGRADABLE_BIT) != 0,
+        );
+        if timed_out {
+            return false;
         }
+
+        // Step 2: wait for all remaining readers to exit the lock.
+        self.wait_for_readers(timeout, 0)
     }
 
     #[cold]
     #[inline(never)]
-    fn unlock_shared_slow(&self, force_fair: bool) {
-        let mut state = self.state.load(Ordering::Relaxed);
-        loop {
-            // Just release the lock if there are no parked thread or if we are
-            // not the last shared thread.
-            if state & PARKED_BIT == 0
-                || (state & UPGRADING_BIT == 0 && state & GUARD_COUNT_MASK != SHARED_GUARD)
-                || (state & UPGRADING_BIT != 0
-                    && state & GUARD_COUNT_MASK != UPGRADABLE_GUARD + SHARED_GUARD)
-            {
-                match self.state.compare_exchange_weak(
-                    state,
-                    state - SHARED_GUARD,
-                    Ordering::Release,
-                    Ordering::Relaxed,
-                ) {
-                    Ok(_) => return,
-                    Err(x) => state = x,
+    fn unlock_exclusive_slow(&self, force_fair: bool) {
+        // There are threads to unpark. Try to unpark as many as we can.
+        let callback = |mut new_state, result: UnparkResult| {
+            // If we are using a fair unlock then we should keep the
+            // rwlock locked and hand it off to the unparked threads.
+            if result.unparked_threads != 0 && (force_fair || result.be_fair) {
+                if result.have_more_threads {
+                    new_state |= PARKED_BIT;
                 }
-                continue;
-            }
-
-            break;
-        }
-
-        // There are threads to unpark. If there is a thread waiting to be
-        // upgraded, we find that thread and let it upgrade, otherwise we
-        // unpark threads up to the guard capacity. Note that there is a
-        // potential race condition here: another thread might grab a shared
-        // lock between now and when we actually release our lock.
-        let additional_guards = Cell::new(0usize);
-        let has_upgraded = Cell::new(false);
-        unsafe {
-            let addr = self as *const _ as usize;
-            let filter = |ParkToken(token)| -> FilterOp {
-                // We need to check UPGRADING_BIT while holding the bucket lock,
-                // otherwise we might miss a thread trying to upgrade.
-                if self.state.load(Ordering::Relaxed) & UPGRADING_BIT == 0 {
-                    match additional_guards.get().checked_add(token) {
-                        Some(x) => {
-                            additional_guards.set(x);
-                            FilterOp::Unpark
-                        }
-                        None => FilterOp::Stop,
-                    }
-                } else if has_upgraded.get() {
-                    FilterOp::Stop
+                self.state.store(new_state, Ordering::Release);
+                TOKEN_HANDOFF
+            } else {
+                // Clear the parked bit if there are no more parked threads.
+                if result.have_more_threads {
+                    self.state.store(PARKED_BIT, Ordering::Release);
                 } else {
-                    if token & UPGRADING_BIT != 0 {
-                        additional_guards.set(token & !UPGRADING_BIT);
-                        has_upgraded.set(true);
-                        FilterOp::Unpark
-                    } else {
-                        FilterOp::Skip
-                    }
+                    self.state.store(0, Ordering::Release);
                 }
-            };
-            let callback = |result: UnparkResult| {
-                let mut state = self.state.load(Ordering::Relaxed);
-                loop {
-                    // Release our shared lock
-                    let mut new_state = state - SHARED_GUARD;
-
-                    // Clear the parked bit if there are no more threads in
-                    // the queue.
-                    if !result.have_more_threads {
-                        new_state &= !PARKED_BIT;
-                    }
-
-                    // Clear the upgrading bit if we are upgrading a thread.
-                    if has_upgraded.get() {
-                        new_state &= !UPGRADING_BIT;
-                    }
-
-                    // Consider using fair unlocking. If we are, then we should set
-                    // the state to the new value and tell the threads that we are
-                    // handing the lock directly.
-                    let token = if result.unparked_threads != 0 && (force_fair || result.be_fair) {
-                        match new_state.checked_add(additional_guards.get()) {
-                            Some(x) => {
-                                new_state = x;
-                                TOKEN_HANDOFF
-                            }
-                            None => TOKEN_NORMAL,
-                        }
-                    } else {
-                        TOKEN_NORMAL
-                    };
-
-                    match self.state.compare_exchange_weak(
-                        state,
-                        new_state,
-                        Ordering::Release,
-                        Ordering::Relaxed,
-                    ) {
-                        Ok(_) => return token,
-                        Err(x) => state = x,
-                    }
-                }
-            };
-            parking_lot_core::unpark_filter(addr, filter, callback);
-        }
+                TOKEN_NORMAL
+            }
+        };
+        self.wake_parked_threads(0, callback);
     }
 
     #[cold]
     #[inline(never)]
-    fn lock_upgradable_slow(&self, timeout: Option<Instant>) -> bool {
-        let mut spinwait = SpinWait::new();
-        let mut spinwait_shared = SpinWait::new();
-        let mut state = self.state.load(Ordering::Relaxed);
-        let mut unparked = false;
-        loop {
-            // Grab the lock if there are no exclusive or upgradable threads
-            // locked or waiting. However if we were unparked then we are
-            // allowed to grab the lock even if there are pending exclusive threads.
-            if unparked || state & PARKED_BIT == 0 {
-                if let Some(new_state) = state.checked_add(UPGRADABLE_GUARD) {
+    fn lock_shared_slow(&self, recursive: bool, timeout: Option<Instant>) -> bool {
+        self.lock_common(
+            timeout,
+            TOKEN_SHARED,
+            |state| {
+                let mut spinwait_shared = SpinWait::new();
+                loop {
+                    // Use hardware lock elision to avoid cache conflicts when multiple
+                    // readers try to acquire the lock. We only do this if the lock is
+                    // completely empty since elision handles conflicts poorly.
+                    if have_elision() && *state == 0 {
+                        match self.state.elision_compare_exchange_acquire(0, ONE_READER) {
+                            Ok(_) => return true,
+                            Err(x) => *state = x,
+                        }
+                    }
+
+                    // This is the same condition as try_lock_shared_fast
+                    if *state & WRITER_BIT != 0 {
+                        if !recursive || *state & READERS_MASK == 0 {
+                            return false;
+                        }
+                    }
+
                     if self
                         .state
                         .compare_exchange_weak(
-                            state,
-                            new_state,
+                            *state,
+                            state
+                                .checked_add(ONE_READER)
+                                .expect("RwLock reader count overflow"),
                             Ordering::Acquire,
                             Ordering::Relaxed,
                         )
@@ -1054,50 +706,379 @@ impl RawRwLock {
                     // to leave some time between attempts to acquire the lock to
                     // let other threads make progress.
                     spinwait_shared.spin_no_yield();
-                    state = self.state.load(Ordering::Relaxed);
-                    continue;
-                } else {
-                    // We were unparked spuriously, reset unparked flag.
-                    unparked = false;
+                    *state = self.state.load(Ordering::Relaxed);
+                }
+            },
+            |state| state & WRITER_BIT != 0,
+        )
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn unlock_shared_slow(&self) {
+        // At this point WRITER_PARKED_BIT is set and READER_MASK is empty. We
+        // just need to wake up a potentially sleeping pending writer.
+        unsafe {
+            // Using the 2nd key at addr + 1
+            let addr = self as *const _ as usize + 1;
+            let callback = |result: UnparkResult| {
+                // Clear the WRITER_PARKED_BIT here since there can only be one
+                // parked writer thread.
+                debug_assert!(!result.have_more_threads);
+                self.state.fetch_and(!WRITER_PARKED_BIT, Ordering::Relaxed);
+                TOKEN_NORMAL
+            };
+            parking_lot_core::unpark_one(addr, callback);
+        }
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn lock_upgradable_slow(&self, timeout: Option<Instant>) -> bool {
+        self.lock_common(
+            timeout,
+            TOKEN_UPGRADABLE,
+            |state| {
+                let mut spinwait_shared = SpinWait::new();
+                loop {
+                    if *state & (WRITER_BIT | UPGRADABLE_BIT) != 0 {
+                        return false;
+                    }
+
+                    if self
+                        .state
+                        .compare_exchange_weak(
+                            *state,
+                            state
+                                .checked_add(ONE_READER | UPGRADABLE_BIT)
+                                .expect("RwLock reader count overflow"),
+                            Ordering::Acquire,
+                            Ordering::Relaxed,
+                        )
+                        .is_ok()
+                    {
+                        return true;
+                    }
+
+                    // If there is high contention on the reader count then we want
+                    // to leave some time between attempts to acquire the lock to
+                    // let other threads make progress.
+                    spinwait_shared.spin_no_yield();
+                    *state = self.state.load(Ordering::Relaxed);
+                }
+            },
+            |state| state & (WRITER_BIT | UPGRADABLE_BIT) != 0,
+        )
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn unlock_upgradable_slow(&self, force_fair: bool) {
+        // Just release the lock if there are no parked threads.
+        let mut state = self.state.load(Ordering::Relaxed);
+        while state & PARKED_BIT == 0 {
+            match self.state.compare_exchange_weak(
+                state,
+                state - (ONE_READER | UPGRADABLE_BIT),
+                Ordering::Release,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return,
+                Err(x) => state = x,
+            }
+        }
+
+        // There are threads to unpark. Try to unpark as many as we can.
+        let callback = |new_state, result: UnparkResult| {
+            // If we are using a fair unlock then we should keep the
+            // rwlock locked and hand it off to the unparked threads.
+            let mut state = self.state.load(Ordering::Relaxed);
+            if force_fair || result.be_fair {
+                // Fall back to normal unpark on overflow. Panicking is
+                // not allowed in parking_lot callbacks.
+                while let Some(mut new_state) =
+                    (state - (ONE_READER | UPGRADABLE_BIT)).checked_add(new_state)
+                {
+                    if result.have_more_threads {
+                        new_state |= PARKED_BIT;
+                    } else {
+                        new_state &= !PARKED_BIT;
+                    }
+                    match self.state.compare_exchange_weak(
+                        state,
+                        new_state,
+                        Ordering::Relaxed,
+                        Ordering::Relaxed,
+                    ) {
+                        Ok(_) => return TOKEN_HANDOFF,
+                        Err(x) => state = x,
+                    }
                 }
             }
 
-            // If there are no parked threads, try spinning a few times
-            if state & PARKED_BIT == 0 && spinwait.spin() {
+            // Otherwise just release the upgradable lock and update PARKED_BIT.
+            loop {
+                let mut new_state = state - (ONE_READER | UPGRADABLE_BIT);
+                if result.have_more_threads {
+                    new_state |= PARKED_BIT;
+                } else {
+                    new_state &= !PARKED_BIT;
+                }
+                match self.state.compare_exchange_weak(
+                    state,
+                    new_state,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => return TOKEN_NORMAL,
+                    Err(x) => state = x,
+                }
+            }
+        };
+        self.wake_parked_threads(0, callback);
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn try_upgrade_slow(&self) -> bool {
+        let mut state = self.state.load(Ordering::Relaxed);
+        loop {
+            if state & READERS_MASK != ONE_READER {
+                return false;
+            }
+            match self.state.compare_exchange_weak(
+                state,
+                state - (ONE_READER | UPGRADABLE_BIT) + WRITER_BIT,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return true,
+                Err(x) => state = x,
+            }
+        }
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn upgrade_slow(&self, timeout: Option<Instant>) -> bool {
+        self.wait_for_readers(timeout, ONE_READER | UPGRADABLE_BIT)
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn downgrade_slow(&self) {
+        // We only reach this point if PARKED_BIT is set.
+        let callback = |_, result: UnparkResult| {
+            // Clear the parked bit if there no more parked threads
+            if !result.have_more_threads {
+                self.state.fetch_and(!PARKED_BIT, Ordering::Relaxed);
+            }
+            TOKEN_NORMAL
+        };
+        self.wake_parked_threads(ONE_READER, callback);
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn downgrade_to_upgradable_slow(&self) {
+        // We only reach this point if PARKED_BIT is set.
+        let callback = |_, result: UnparkResult| {
+            // Clear the parked bit if there no more parked threads
+            if !result.have_more_threads {
+                self.state.fetch_and(!PARKED_BIT, Ordering::Relaxed);
+            }
+            TOKEN_NORMAL
+        };
+        self.wake_parked_threads(ONE_READER | UPGRADABLE_BIT, callback);
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn bump_shared_slow(&self) {
+        self.unlock_shared();
+        self.lock_shared();
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn bump_exclusive_slow(&self) {
+        self.deadlock_release();
+        self.unlock_exclusive_slow(true);
+        self.lock_exclusive();
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn bump_upgradable_slow(&self) {
+        self.deadlock_release();
+        self.unlock_upgradable_slow(true);
+        self.lock_upgradable();
+    }
+
+    // Common code for waking up parked threads after releasing WRITER_BIT or
+    // UPGRADABLE_BIT.
+    #[inline]
+    fn wake_parked_threads<C>(&self, new_state: usize, callback: C)
+    where
+        C: FnOnce(usize, UnparkResult) -> UnparkToken,
+    {
+        // We must wake up at least one upgrader or writer if there is one,
+        // otherwise they may end up parked indefinitely since unlock_shared
+        // does not call wake_parked_threads.
+        let new_state = Cell::new(new_state);
+        unsafe {
+            let addr = self as *const _ as usize;
+            let filter = |ParkToken(token)| {
+                let s = new_state.get();
+
+                // If we are waking up a writer, don't wake anything else.
+                if s & WRITER_BIT != 0 {
+                    return FilterOp::Stop;
+                }
+
+                // Otherwise wake *all* readers and one upgrader/writer.
+                if token & (UPGRADABLE_BIT | WRITER_BIT) != 0 && s & UPGRADABLE_BIT != 0 {
+                    // Skip writers and upgradable readers if we already have
+                    // a writer/upgradable reader.
+                    FilterOp::Skip
+                } else {
+                    new_state.set(s + token);
+                    FilterOp::Unpark
+                }
+            };
+            parking_lot_core::unpark_filter(addr, filter, |result| {
+                callback(new_state.get(), result)
+            });
+        }
+    }
+
+    // Common code for waiting for readers to exit the lock after acquiring
+    // WRITER_BIT.
+    #[inline]
+    fn wait_for_readers(&self, timeout: Option<Instant>, prev_value: usize) -> bool {
+        // At this point WRITER_BIT is already set, we just need to wait for the
+        // remaining readers to exit the lock.
+        let mut spinwait = SpinWait::new();
+        let mut state = self.state.load(Ordering::Relaxed);
+        while state & READERS_MASK != 0 {
+            // Spin a few times to wait for readers to exit
+            if spinwait.spin() {
                 state = self.state.load(Ordering::Relaxed);
                 continue;
+            }
+
+            // Set the parked bit
+            if state & WRITER_PARKED_BIT == 0 {
+                if let Err(x) = self.state.compare_exchange_weak(
+                    state,
+                    state | WRITER_PARKED_BIT,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                ) {
+                    state = x;
+                    continue;
+                }
+            }
+
+            // Park our thread until we are woken up by an unlock
+            unsafe {
+                // Using the 2nd key at addr + 1
+                let addr = self as *const _ as usize + 1;
+                let validate = || {
+                    let state = self.state.load(Ordering::Relaxed);
+                    state & READERS_MASK != 0 && state & WRITER_PARKED_BIT != 0
+                };
+                let before_sleep = || {};
+                let timed_out = |_, _| {};
+                match parking_lot_core::park(
+                    addr,
+                    validate,
+                    before_sleep,
+                    timed_out,
+                    TOKEN_EXCLUSIVE,
+                    timeout,
+                ) {
+                    // We still need to re-check the state if we are unparked
+                    // since a previous writer timing-out could have allowed
+                    // another reader to sneak in before we parked.
+                    ParkResult::Unparked(_) | ParkResult::Invalid => {
+                        state = self.state.load(Ordering::Relaxed);
+                        continue;
+                    }
+
+                    // Timeout expired
+                    ParkResult::TimedOut => {
+                        // We need to release WRITER_BIT and revert back to
+                        // our previous value. We also wake up any threads that
+                        // might be waiting on WRITER_BIT.
+                        let state = self.state.fetch_add(
+                            prev_value.wrapping_sub(WRITER_BIT | WRITER_PARKED_BIT),
+                            Ordering::Relaxed,
+                        );
+                        if state & PARKED_BIT != 0 {
+                            let callback = |_, result: UnparkResult| {
+                                // Clear the parked bit if there no more parked threads
+                                if !result.have_more_threads {
+                                    self.state.fetch_and(!PARKED_BIT, Ordering::Relaxed);
+                                }
+                                TOKEN_NORMAL
+                            };
+                            self.wake_parked_threads(ONE_READER | UPGRADABLE_BIT, callback);
+                        }
+                        return false;
+                    }
+                }
+            }
+        }
+        true
+    }
+
+    // Common code for acquiring a lock
+    #[inline]
+    fn lock_common<F, V>(
+        &self,
+        timeout: Option<Instant>,
+        token: ParkToken,
+        mut try_lock: F,
+        validate: V,
+    ) -> bool
+    where
+        F: FnMut(&mut usize) -> bool,
+        V: Fn(usize) -> bool,
+    {
+        let mut spinwait = SpinWait::new();
+        let mut state = self.state.load(Ordering::Relaxed);
+        loop {
+            // Attempt to grab the lock
+            if try_lock(&mut state) {
+                return true;
+            }
+
+            // If there are no parked threads, try spinning a few times.
+            if state & (PARKED_BIT | WRITER_PARKED_BIT) == 0 && spinwait.spin() {
+                state = self.state.load(Ordering::Relaxed);
+                continue;
+            }
+
+            // Set the parked bit
+            if state & PARKED_BIT == 0 {
+                if let Err(x) = self.state.compare_exchange_weak(
+                    state,
+                    state | PARKED_BIT,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                ) {
+                    state = x;
+                    continue;
+                }
             }
 
             // Park our thread until we are woken up by an unlock
             unsafe {
                 let addr = self as *const _ as usize;
                 let validate = || {
-                    let mut state = self.state.load(Ordering::Relaxed);
-                    loop {
-                        // Nothing to do if the parked bit is already set
-                        if state & PARKED_BIT != 0 {
-                            return true;
-                        }
-
-                        // If the parked bit is not set then it means we are at
-                        // the front of the queue. If there is space for an
-                        // upgradable lock then we should abort the park and try
-                        // acquiring the lock again.
-                        if state & UPGRADABLE_GUARD != UPGRADABLE_GUARD {
-                            return false;
-                        }
-
-                        // Set the parked bit
-                        match self.state.compare_exchange_weak(
-                            state,
-                            state | PARKED_BIT,
-                            Ordering::Relaxed,
-                            Ordering::Relaxed,
-                        ) {
-                            Ok(_) => return true,
-                            Err(x) => state = x,
-                        }
-                    }
+                    let state = self.state.load(Ordering::Relaxed);
+                    state & PARKED_BIT != 0 && validate(state)
                 };
                 let before_sleep = || {};
                 let timed_out = |_, was_last_thread| {
@@ -1111,249 +1092,7 @@ impl RawRwLock {
                     validate,
                     before_sleep,
                     timed_out,
-                    TOKEN_UPGRADABLE,
-                    timeout,
-                ) {
-                    // The thread that unparked us passed the lock on to us
-                    // directly without unlocking it.
-                    ParkResult::Unparked(TOKEN_HANDOFF) => return true,
-
-                    // We were unparked normally, try acquiring the lock again
-                    ParkResult::Unparked(_) => (),
-
-                    // The validation function failed, try locking again
-                    ParkResult::Invalid => (),
-
-                    // Timeout expired
-                    ParkResult::TimedOut => return false,
-                }
-            }
-
-            // Loop back and try locking again
-            spinwait.reset();
-            spinwait_shared.reset();
-            state = self.state.load(Ordering::Relaxed);
-            unparked = true;
-        }
-    }
-
-    #[cold]
-    #[inline(never)]
-    fn try_lock_upgradable_slow(&self) -> bool {
-        let mut state = self.state.load(Ordering::Relaxed);
-        loop {
-            if state & PARKED_BIT != 0 {
-                return false;
-            }
-
-            match state.checked_add(UPGRADABLE_GUARD) {
-                Some(new_state) => match self.state.compare_exchange_weak(
-                    state,
-                    new_state,
-                    Ordering::Acquire,
-                    Ordering::Relaxed,
-                ) {
-                    Ok(_) => return true,
-                    Err(x) => state = x,
-                },
-                None => return false,
-            }
-        }
-    }
-
-    #[cold]
-    #[inline(never)]
-    fn unlock_upgradable_slow(&self, force_fair: bool) {
-        let mut state = self.state.load(Ordering::Relaxed);
-        loop {
-            // Just release the lock if there are no parked threads.
-            if state & PARKED_BIT == 0 {
-                match self.state.compare_exchange_weak(
-                    state,
-                    state - UPGRADABLE_GUARD,
-                    Ordering::Release,
-                    Ordering::Relaxed,
-                ) {
-                    Ok(_) => return,
-                    Err(x) => state = x,
-                }
-                continue;
-            }
-
-            break;
-        }
-
-        // There are threads to unpark. We unpark threads up to the guard capacity.
-        let additional_guards = Cell::new(0usize);
-        unsafe {
-            let addr = self as *const _ as usize;
-            let filter = |ParkToken(token)| -> FilterOp {
-                match additional_guards.get().checked_add(token) {
-                    Some(x) => {
-                        additional_guards.set(x);
-                        FilterOp::Unpark
-                    }
-                    None => FilterOp::Stop,
-                }
-            };
-            let callback = |result: UnparkResult| {
-                let mut state = self.state.load(Ordering::Relaxed);
-                loop {
-                    // Release our upgradable lock
-                    let mut new_state = state - UPGRADABLE_GUARD;
-
-                    // Clear the parked bit if there are no more threads in
-                    // the queue
-                    if !result.have_more_threads {
-                        new_state &= !PARKED_BIT;
-                    }
-
-                    // Consider using fair unlocking. If we are, then we should set
-                    // the state to the new value and tell the threads that we are
-                    // handing the lock directly.
-                    let token = if result.unparked_threads != 0 && (force_fair || result.be_fair) {
-                        match new_state.checked_add(additional_guards.get()) {
-                            Some(x) => {
-                                new_state = x;
-                                TOKEN_HANDOFF
-                            }
-                            None => TOKEN_NORMAL,
-                        }
-                    } else {
-                        TOKEN_NORMAL
-                    };
-
-                    match self.state.compare_exchange_weak(
-                        state,
-                        new_state,
-                        Ordering::Release,
-                        Ordering::Relaxed,
-                    ) {
-                        Ok(_) => return token,
-                        Err(x) => state = x,
-                    }
-                }
-            };
-            parking_lot_core::unpark_filter(addr, filter, callback);
-        }
-    }
-
-    #[cold]
-    #[inline(never)]
-    fn downgrade_upgradable_slow(&self, state: usize) {
-        unsafe {
-            let addr = self as *const _ as usize;
-            let mut guard_count = (state & GUARD_COUNT_MASK) - UPGRADABLE_GUARD;
-            let filter = |ParkToken(token)| -> FilterOp {
-                match guard_count.checked_add(token) {
-                    Some(x) => {
-                        guard_count = x;
-                        FilterOp::Unpark
-                    }
-                    None => FilterOp::Stop,
-                }
-            };
-            let callback = |result: UnparkResult| {
-                // Clear the parked bit if there no more parked threads
-                if !result.have_more_threads {
-                    self.state.fetch_and(!PARKED_BIT, Ordering::Relaxed);
-                }
-                TOKEN_NORMAL
-            };
-            parking_lot_core::unpark_filter(addr, filter, callback);
-        }
-    }
-
-    #[cold]
-    #[inline(never)]
-    fn try_upgrade_slow(&self) -> bool {
-        let mut state = self.state.load(Ordering::Relaxed);
-        loop {
-            match state.checked_add(EXCLUSIVE_GUARD - SHARED_GUARD) {
-                Some(new_state) => match self.state.compare_exchange_weak(
-                    state,
-                    new_state,
-                    Ordering::Relaxed,
-                    Ordering::Relaxed,
-                ) {
-                    Ok(_) => return true,
-                    Err(x) => state = x,
-                },
-                None => return false,
-            }
-        }
-    }
-
-    #[cold]
-    #[inline(never)]
-    fn upgrade_slow(&self, timeout: Option<Instant>) -> bool {
-        let mut spinwait = SpinWait::new();
-        let mut state = self.state.load(Ordering::Relaxed);
-        loop {
-            // Grab the lock if it isn't locked, even if there are other
-            // threads parked.
-            if let Some(new_state) = state.checked_add(EXCLUSIVE_GUARD - UPGRADABLE_GUARD) {
-                match self.state.compare_exchange_weak(
-                    state,
-                    new_state,
-                    Ordering::Acquire,
-                    Ordering::Relaxed,
-                ) {
-                    Ok(_) => return true,
-                    Err(x) => state = x,
-                }
-                continue;
-            }
-
-            // If there are no parked threads and only one other reader, try
-            // spinning a few times.
-            if state == UPGRADABLE_GUARD | SHARED_GUARD && spinwait.spin() {
-                state = self.state.load(Ordering::Relaxed);
-                continue;
-            }
-
-            // Park our thread until we are woken up by an unlock
-            unsafe {
-                let addr = self as *const _ as usize;
-                let validate = || {
-                    let mut state = self.state.load(Ordering::Relaxed);
-                    loop {
-                        // If the rwlock is free, abort the park and try to grab
-                        // it immediately.
-                        if state & GUARD_COUNT_MASK == UPGRADABLE_GUARD {
-                            return false;
-                        }
-
-                        // Set the upgrading and parked bits
-                        match self.state.compare_exchange_weak(
-                            state,
-                            state | (UPGRADING_BIT | PARKED_BIT),
-                            Ordering::Relaxed,
-                            Ordering::Relaxed,
-                        ) {
-                            Ok(_) => return true,
-                            Err(x) => state = x,
-                        }
-                    }
-                };
-                let before_sleep = || {};
-                let timed_out = |_, was_last_thread| {
-                    // Clear the upgrading bit
-                    let mut flags = UPGRADING_BIT;
-
-                    // Clear the parked bit if we were the last parked thread
-                    if was_last_thread {
-                        flags |= PARKED_BIT;
-                    }
-
-                    self.state.fetch_and(!flags, Ordering::Relaxed);
-                };
-                match parking_lot_core::park(
-                    addr,
-                    validate,
-                    before_sleep,
-                    timed_out,
-                    TOKEN_UPGRADING,
+                    token,
                     timeout,
                 ) {
                     // The thread that unparked us passed the lock on to us
@@ -1377,27 +1116,15 @@ impl RawRwLock {
         }
     }
 
-    #[cold]
-    #[inline(never)]
-    fn bump_shared_slow(&self) {
-        unsafe { deadlock::release_resource(self as *const _ as usize) };
-        self.unlock_shared_slow(true);
-        self.lock_shared();
+    #[inline]
+    fn deadlock_acquire(&self) {
+        unsafe { deadlock::acquire_resource(self as *const _ as usize) };
+        unsafe { deadlock::acquire_resource(self as *const _ as usize + 1) };
     }
 
-    #[cold]
-    #[inline(never)]
-    fn bump_exclusive_slow(&self) {
+    #[inline]
+    fn deadlock_release(&self) {
         unsafe { deadlock::release_resource(self as *const _ as usize) };
-        self.unlock_exclusive_slow(true);
-        self.lock_exclusive();
-    }
-
-    #[cold]
-    #[inline(never)]
-    fn bump_upgradable_slow(&self) {
-        unsafe { deadlock::release_resource(self as *const _ as usize) };
-        self.unlock_upgradable_slow(true);
-        self.lock_upgradable();
+        unsafe { deadlock::release_resource(self as *const _ as usize + 1) };
     }
 }


### PR DESCRIPTION
The new implementation is inspired by boost's [`upgrade_mutex`](https://github.com/boostorg/thread/blob/fc08c1fe2840baeeee143440fba31ef9e9a813c8/include/boost/thread/v2/shared_mutex.hpp#L432) rwlock implementation.

The main benefit is that it fixes #101: upgradable reads no longer block normal reads. The code has also been refactored and is now much simpler than before.

cc @matklad @nikomatsakis