### PR TITLE
 Make functions from parking_lot_core #[inline]

### DIFF
--- a/core/src/thread_parker/generic.rs
+++ b/core/src/thread_parker/generic.rs
@@ -20,6 +20,7 @@ pub struct ThreadParker {
 impl ThreadParker {
     pub const IS_CHEAP_TO_CONSTRUCT: bool = true;
 
+    #[inline]
     pub fn new() -> ThreadParker {
         ThreadParker {
             parked: AtomicBool::new(false),
@@ -27,18 +28,21 @@ impl ThreadParker {
     }
 
     // Prepares the parker. This should be called before adding it to the queue.
+    #[inline]
     pub fn prepare_park(&self) {
         self.parked.store(true, Ordering::Relaxed);
     }
 
     // Checks if the park timed out. This should be called while holding the
     // queue lock after park_until has returned false.
+    #[inline]
     pub fn timed_out(&self) -> bool {
         self.parked.load(Ordering::Relaxed) != false
     }
 
     // Parks the thread until it is unparked. This should be called after it has
     // been added to the queue, after unlocking the queue.
+    #[inline]
     pub fn park(&self) {
         while self.parked.load(Ordering::Acquire) != false {
             spin_loop_hint();
@@ -48,6 +52,7 @@ impl ThreadParker {
     // Parks the thread until it is unparked or the timeout is reached. This
     // should be called after it has been added to the queue, after unlocking
     // the queue. Returns true if we were unparked and false if we timed out.
+    #[inline]
     pub fn park_until(&self, timeout: Instant) -> bool {
         while self.parked.load(Ordering::Acquire) != false {
             if Instant::now() >= timeout {
@@ -61,6 +66,7 @@ impl ThreadParker {
     // Locks the parker to prevent the target thread from exiting. This is
     // necessary to ensure that thread-local ThreadData objects remain valid.
     // This should be called while holding the queue lock.
+    #[inline]
     pub fn unpark_lock(&self) -> UnparkHandle {
         // We don't need to lock anything, just clear the state
         self.parked.store(false, Ordering::Release);
@@ -76,6 +82,7 @@ pub struct UnparkHandle(());
 impl UnparkHandle {
     // Wakes up the parked thread. This should be called after the queue lock is
     // released to avoid blocking the queue for too long.
+    #[inline]
     pub fn unpark(self) {}
 }
 

--- a/core/src/thread_parker/windows/waitaddress.rs
+++ b/core/src/thread_parker/windows/waitaddress.rs
@@ -56,14 +56,17 @@ impl WaitAddress {
         }
     }
 
+    #[inline]
     pub fn prepare_park(&'static self, key: &AtomicUsize) {
         key.store(1, Ordering::Relaxed);
     }
 
+    #[inline]
     pub fn timed_out(&'static self, key: &AtomicUsize) -> bool {
         key.load(Ordering::Relaxed) != 0
     }
 
+    #[inline]
     pub fn park(&'static self, key: &AtomicUsize) {
         while key.load(Ordering::Acquire) != 0 {
             let r = self.wait_on_address(key, INFINITE);
@@ -71,6 +74,7 @@ impl WaitAddress {
         }
     }
 
+    #[inline]
     pub fn park_until(&'static self, key: &AtomicUsize, timeout: Instant) -> bool {
         while key.load(Ordering::Acquire) != 0 {
             let now = Instant::now();
@@ -97,6 +101,7 @@ impl WaitAddress {
         true
     }
 
+    #[inline]
     pub fn unpark_lock(&'static self, key: &AtomicUsize) -> UnparkHandle {
         // We don't need to lock anything, just clear the state
         key.store(0, Ordering::Release);
@@ -130,6 +135,7 @@ pub struct UnparkHandle {
 impl UnparkHandle {
     // Wakes up the parked thread. This should be called after the queue lock is
     // released to avoid blocking the queue for too long.
+    #[inline]
     pub fn unpark(self) {
         (self.waitaddress.WakeByAddressSingle)(self.key as PVOID);
     }

--- a/core/src/word_lock.rs
+++ b/core/src/word_lock.rs
@@ -36,6 +36,7 @@ struct ThreadData {
 }
 
 impl ThreadData {
+    #[inline]
     fn new() -> ThreadData {
         assert!(mem::align_of::<ThreadData>() > !QUEUE_MASK);
         ThreadData {
@@ -48,6 +49,7 @@ impl ThreadData {
 }
 
 // Invokes the given closure with a reference to the current thread `ThreadData`.
+#[inline]
 fn with_thread_data<F, T>(f: F) -> T
 where
     F: FnOnce(&ThreadData) -> T,


### PR DESCRIPTION
These are only ever called from #[inline(never)] functions, so there shouldn't be too much code duplication from monomorphization.