### PR TITLE
Upgrade to rust2018

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: rust
 sudo: false
 
 rust:
-- 1.24.0
-- 1.26.2
+- 1.31.0
 - stable
 - beta
 - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parking_lot"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Amanieu d'Antras <amanieu@gmail.com>"]
 description = "More compact and efficient implementations of the standard synchronization primitives."
 license = "Apache-2.0/MIT"
@@ -11,8 +11,8 @@ categories = ["concurrency"]
 edition = "2018"
 
 [dependencies]
-parking_lot_core = { path = "core", version = "0.4" }
-lock_api = { path = "lock_api", version = "0.1" }
+parking_lot_core = { path = "core", version = "0.5" }
+lock_api = { path = "lock_api", version = "0.2" }
 
 [dev-dependencies]
 rand = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/Amanieu/parking_lot"
 readme = "README.md"
 keywords = ["mutex", "condvar", "rwlock", "once", "thread"]
 categories = ["concurrency"]
+edition = "2018"
 
 [dependencies]
 parking_lot_core = { path = "core", version = "0.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rand = "0.6"
 lazy_static = "1.0"
 
 [features]
-default = ["owning_ref"]
+default = []
 owning_ref = ["lock_api/owning_ref"]
 nightly = ["parking_lot_core/nightly", "lock_api/nightly"]
 deadlock_detection = ["parking_lot_core/deadlock_detection"]

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-parking_lot = "0.6"
+parking_lot = "0.8"
 ```
 
 and this to your crate root:
@@ -112,7 +112,7 @@ To enable nightly-only features, add this to your `Cargo.toml` instead:
 
 ```toml
 [dependencies]
-parking_lot = {version = "0.6", features = ["nightly"]}
+parking_lot = {version = "0.8", features = ["nightly"]}
 ```
 
 The experimental deadlock detector can be enabled with the

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ changes to the core API do not cause breaking changes for users of `parking_lot`
 
 ## Minimum Rust version
 
-The current minimum required Rust version is 1.24. Any change to this is
+The current minimum required Rust version is 1.31. Any change to this is
 considered a breaking change and will require a major version bump.
 
 ## License

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,10 +6,10 @@ environment:
   - TARGET: nightly-i686-pc-windows-msvc
   - TARGET: nightly-x86_64-pc-windows-gnu
   - TARGET: nightly-i686-pc-windows-gnu
-  - TARGET: 1.24.0-x86_64-pc-windows-msvc
-  - TARGET: 1.24.0-i686-pc-windows-msvc
-  - TARGET: 1.24.0-x86_64-pc-windows-gnu
-  - TARGET: 1.24.0-i686-pc-windows-gnu
+  - TARGET: 1.31.0-x86_64-pc-windows-msvc
+  - TARGET: 1.31.0-i686-pc-windows-msvc
+  - TARGET: 1.31.0-x86_64-pc-windows-gnu
+  - TARGET: 1.31.0-i686-pc-windows-gnu
 
 install:
   - SET PATH=C:\Python27;C:\Python27\Scripts;%PATH%;%APPDATA%\Python\Scripts

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,6 +25,3 @@ winapi = { version = "0.3", features = ["winnt", "ntstatus", "minwindef",
 [features]
 nightly = []
 deadlock_detection = ["petgraph", "thread-id", "backtrace"]
-
-[build-dependencies]
-rustc_version = "0.2"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0/MIT"
 repository = "https://github.com/Amanieu/parking_lot"
 keywords = ["mutex", "condvar", "rwlock", "once", "thread"]
 categories = ["concurrency"]
+edition = "2018"
 
 [dependencies]
 smallvec = "0.6"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parking_lot_core"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Amanieu d'Antras <amanieu@gmail.com>"]
 description = "An advanced API for creating custom synchronization primitives."
 license = "Apache-2.0/MIT"

--- a/core/build.rs
+++ b/core/build.rs
@@ -1,8 +1,0 @@
-extern crate rustc_version;
-use rustc_version::{version, Version};
-
-fn main() {
-    if version().unwrap() >= Version::parse("1.26.0").unwrap() {
-        println!("cargo:rustc-cfg=has_localkey_try_with");
-    }
-}

--- a/core/build.rs
+++ b/core/build.rs
@@ -2,9 +2,6 @@ extern crate rustc_version;
 use rustc_version::{version, Version};
 
 fn main() {
-    if version().unwrap() >= Version::parse("1.25.0").unwrap() {
-        println!("cargo:rustc-cfg=has_repr_align");
-    }
     if version().unwrap() >= Version::parse("1.26.0").unwrap() {
         println!("cargo:rustc-cfg=has_localkey_try_with");
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -43,22 +43,6 @@
     feature(integer_atomics)
 )]
 
-extern crate rand;
-extern crate smallvec;
-
-#[cfg(feature = "deadlock_detection")]
-extern crate backtrace;
-#[cfg(feature = "deadlock_detection")]
-extern crate petgraph;
-#[cfg(feature = "deadlock_detection")]
-extern crate thread_id;
-
-#[cfg(unix)]
-extern crate libc;
-
-#[cfg(windows)]
-extern crate winapi;
-
 #[cfg(all(feature = "nightly", target_os = "linux"))]
 #[path = "thread_parker/linux.rs"]
 mod thread_parker;
@@ -77,8 +61,10 @@ mod spinwait;
 mod util;
 mod word_lock;
 
-pub use parking_lot::deadlock;
-pub use parking_lot::{park, unpark_all, unpark_filter, unpark_one, unpark_requeue};
-pub use parking_lot::{FilterOp, ParkResult, ParkToken, RequeueOp, UnparkResult, UnparkToken};
-pub use parking_lot::{DEFAULT_PARK_TOKEN, DEFAULT_UNPARK_TOKEN};
-pub use spinwait::SpinWait;
+pub use self::parking_lot::deadlock;
+pub use self::parking_lot::{park, unpark_all, unpark_filter, unpark_one, unpark_requeue};
+pub use self::parking_lot::{
+    FilterOp, ParkResult, ParkToken, RequeueOp, UnparkResult, UnparkToken,
+};
+pub use self::parking_lot::{DEFAULT_PARK_TOKEN, DEFAULT_UNPARK_TOKEN};
+pub use self::spinwait::SpinWait;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -39,10 +39,6 @@
 
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
-#![cfg_attr(
-    all(feature = "nightly", target_os = "linux"),
-    feature(integer_atomics)
-)]
 
 #[cfg(all(feature = "nightly", target_os = "linux"))]
 #[path = "thread_parker/linux.rs"]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -38,6 +38,7 @@
 //! reference count and the two mutex bits in the same atomic word.
 
 #![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
 #![cfg_attr(
     all(feature = "nightly", target_os = "linux"),
     feature(integer_atomics)

--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -5,6 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::thread_parker::ThreadParker;
+use crate::util::UncheckedOptionExt;
+use crate::word_lock::WordLock;
 use rand::rngs::SmallRng;
 use rand::{FromEntropy, Rng};
 use smallvec::SmallVec;
@@ -12,9 +15,6 @@ use std::cell::{Cell, UnsafeCell};
 use std::ptr;
 use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
-use thread_parker::ThreadParker;
-use util::UncheckedOptionExt;
-use word_lock::WordLock;
 
 static NUM_THREADS: AtomicUsize = AtomicUsize::new(0);
 static HASHTABLE: AtomicPtr<HashTable> = AtomicPtr::new(ptr::null_mut());
@@ -1085,6 +1085,7 @@ pub mod deadlock {
 #[cfg(feature = "deadlock_detection")]
 mod deadlock_impl {
     use super::{get_hashtable, lock_bucket, with_thread_data, ThreadData, NUM_THREADS};
+    use crate::word_lock::WordLock;
     use backtrace::Backtrace;
     use petgraph;
     use petgraph::graphmap::DiGraphMap;
@@ -1093,7 +1094,6 @@ mod deadlock_impl {
     use std::sync::atomic::Ordering;
     use std::sync::mpsc;
     use thread_id;
-    use word_lock::WordLock;
 
     /// Representation of a deadlocked thread
     pub struct DeadlockedThread {

--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -8,12 +8,13 @@
 use crate::thread_parker::ThreadParker;
 use crate::util::UncheckedOptionExt;
 use crate::word_lock::WordLock;
-use rand::rngs::SmallRng;
-use rand::{FromEntropy, Rng};
+use core::{
+    cell::{Cell, UnsafeCell},
+    ptr,
+    sync::atomic::{AtomicPtr, AtomicUsize, Ordering},
+};
+use rand::{rngs::SmallRng, FromEntropy, Rng};
 use smallvec::SmallVec;
-use std::cell::{Cell, UnsafeCell};
-use std::ptr;
-use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 static NUM_THREADS: AtomicUsize = AtomicUsize::new(0);

--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -50,7 +50,7 @@ impl HashTable {
     }
 }
 
-#[cfg_attr(has_repr_align, repr(align(64)))]
+#[repr(align(64))]
 struct Bucket {
     // Lock protecting the queue
     mutex: WordLock,
@@ -61,12 +61,6 @@ struct Bucket {
 
     // Next time at which point be_fair should be set
     fair_timeout: UnsafeCell<FairTimeout>,
-
-    // Padding to avoid false sharing between buckets. Ideally we would just
-    // align the bucket structure to 64 bytes, but Rust doesn't support that
-    // yet. Remove this field when dropping support for Rust < 1.25
-    #[cfg(not(has_repr_align))]
-    _padding: [u8; 64],
 }
 
 impl Bucket {
@@ -77,8 +71,6 @@ impl Bucket {
             queue_head: Cell::new(ptr::null()),
             queue_tail: Cell::new(ptr::null()),
             fair_timeout: UnsafeCell::new(FairTimeout::new()),
-            #[cfg(not(has_repr_align))]
-            _padding: unsafe { ::std::mem::uninitialized() },
         }
     }
 }

--- a/core/src/spinwait.rs
+++ b/core/src/spinwait.rs
@@ -5,8 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::thread_parker;
 use std::sync::atomic::spin_loop_hint;
-use thread_parker;
 
 // Wastes some CPU time for the given number of iterations,
 // using a hint to indicate to the CPU that we are spinning.

--- a/core/src/thread_parker/generic.rs
+++ b/core/src/thread_parker/generic.rs
@@ -8,9 +8,8 @@
 //! A simple spin lock based thread parker. Used on platforms without better
 //! parking facilities available.
 
-use std::sync::atomic::{spin_loop_hint, AtomicBool, Ordering};
-use std::thread;
-use std::time::Instant;
+use core::sync::atomic::{spin_loop_hint, AtomicBool, Ordering};
+use std::{thread, time::Instant};
 
 // Helper type for putting a thread to sleep until some other thread wakes it up
 pub struct ThreadParker {

--- a/core/src/thread_parker/linux.rs
+++ b/core/src/thread_parker/linux.rs
@@ -5,11 +5,12 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use core::{
+    ptr,
+    sync::atomic::{AtomicI32, Ordering},
+};
 use libc;
-use std::ptr;
-use std::sync::atomic::{AtomicI32, Ordering};
-use std::thread;
-use std::time::Instant;
+use std::{thread, time::Instant};
 
 const FUTEX_WAIT: i32 = 0;
 const FUTEX_WAKE: i32 = 1;

--- a/core/src/thread_parker/unix.rs
+++ b/core/src/thread_parker/unix.rs
@@ -5,13 +5,17 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use libc;
-use std::cell::{Cell, UnsafeCell};
-use std::mem;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
-use std::ptr;
-use std::thread;
-use std::time::{Duration, Instant};
+use core::ptr;
+use core::{
+    cell::{Cell, UnsafeCell},
+    mem,
+};
+use libc;
+use std::{
+    thread,
+    time::{Duration, Instant},
+};
 
 // x32 Linux uses a non-standard type for tv_nsec in timespec.
 // See https://sourceware.org/bugzilla/show_bug.cgi?id=16437

--- a/core/src/thread_parker/windows/keyed_event.rs
+++ b/core/src/thread_parker/windows/keyed_event.rs
@@ -5,18 +5,26 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::mem;
-use std::ptr;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::Instant;
-
-use winapi::shared::minwindef::{TRUE, ULONG};
-use winapi::shared::ntdef::NTSTATUS;
-use winapi::shared::ntstatus::{STATUS_SUCCESS, STATUS_TIMEOUT};
-use winapi::um::handleapi::CloseHandle;
-use winapi::um::libloaderapi::{GetModuleHandleA, GetProcAddress};
-use winapi::um::winnt::{ACCESS_MASK, GENERIC_READ, GENERIC_WRITE, LPCSTR};
-use winapi::um::winnt::{BOOLEAN, HANDLE, LARGE_INTEGER, PHANDLE, PLARGE_INTEGER, PVOID};
+use core::{mem, ptr};
+use std::{
+    sync::atomic::{AtomicUsize, Ordering},
+    time::Instant,
+};
+use winapi::{
+    shared::{
+        minwindef::{TRUE, ULONG},
+        ntdef::NTSTATUS,
+        ntstatus::{STATUS_SUCCESS, STATUS_TIMEOUT},
+    },
+    um::{
+        handleapi::CloseHandle,
+        libloaderapi::{GetModuleHandleA, GetProcAddress},
+        winnt::{
+            ACCESS_MASK, BOOLEAN, GENERIC_READ, GENERIC_WRITE, HANDLE, LARGE_INTEGER, LPCSTR,
+            PHANDLE, PLARGE_INTEGER, PVOID,
+        },
+    },
+};
 
 const STATE_UNPARKED: usize = 0;
 const STATE_PARKED: usize = 1;

--- a/core/src/thread_parker/windows/mod.rs
+++ b/core/src/thread_parker/windows/mod.rs
@@ -8,7 +8,6 @@
 use std::ptr;
 use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 use std::time::Instant;
-use winapi;
 
 mod keyed_event;
 mod waitaddress;

--- a/core/src/thread_parker/windows/mod.rs
+++ b/core/src/thread_parker/windows/mod.rs
@@ -5,8 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::ptr;
-use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
+use core::{
+    ptr,
+    sync::atomic::{AtomicPtr, AtomicUsize, Ordering},
+};
 use std::time::Instant;
 
 mod keyed_event;

--- a/core/src/thread_parker/windows/waitaddress.rs
+++ b/core/src/thread_parker/windows/waitaddress.rs
@@ -5,17 +5,24 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::mem;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use core::{
+    mem,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 use std::time::Instant;
-
-use winapi::shared::basetsd::SIZE_T;
-use winapi::shared::minwindef::{BOOL, DWORD, FALSE, TRUE};
-use winapi::shared::winerror::ERROR_TIMEOUT;
-use winapi::um::errhandlingapi::GetLastError;
-use winapi::um::libloaderapi::{GetModuleHandleA, GetProcAddress};
-use winapi::um::winbase::INFINITE;
-use winapi::um::winnt::{LPCSTR, PVOID};
+use winapi::{
+    shared::{
+        basetsd::SIZE_T,
+        minwindef::{BOOL, DWORD, FALSE, TRUE},
+        winerror::ERROR_TIMEOUT,
+    },
+    um::{
+        errhandlingapi::GetLastError,
+        libloaderapi::{GetModuleHandleA, GetProcAddress},
+        winbase::INFINITE,
+        winnt::{LPCSTR, PVOID},
+    },
+};
 
 #[allow(non_snake_case)]
 pub struct WaitAddress {

--- a/core/src/word_lock.rs
+++ b/core/src/word_lock.rs
@@ -5,12 +5,12 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use spinwait::SpinWait;
+use crate::spinwait::SpinWait;
+use crate::thread_parker::ThreadParker;
 use std::cell::Cell;
 use std::mem;
 use std::ptr;
 use std::sync::atomic::{fence, AtomicUsize, Ordering};
-use thread_parker::ThreadParker;
 
 struct ThreadData {
     parker: ThreadParker,

--- a/core/src/word_lock.rs
+++ b/core/src/word_lock.rs
@@ -8,11 +8,8 @@
 use spinwait::SpinWait;
 use std::cell::Cell;
 use std::mem;
-#[cfg(not(has_localkey_try_with))]
-use std::panic;
 use std::ptr;
 use std::sync::atomic::{fence, AtomicUsize, Ordering};
-use std::thread::LocalKey;
 use thread_parker::ThreadParker;
 
 struct ThreadData {
@@ -54,23 +51,12 @@ fn with_thread_data<F, T>(f: F) -> T
 where
     F: FnOnce(&ThreadData) -> T,
 {
-    // Try to read from thread-local storage, but return None if the TLS has
-    // already been destroyed.
-    #[cfg(has_localkey_try_with)]
-    fn try_get_tls(key: &'static LocalKey<ThreadData>) -> Option<*const ThreadData> {
-        key.try_with(|x| x as *const ThreadData).ok()
-    }
-    #[cfg(not(has_localkey_try_with))]
-    fn try_get_tls(key: &'static LocalKey<ThreadData>) -> Option<*const ThreadData> {
-        panic::catch_unwind(|| key.with(|x| x as *const ThreadData)).ok()
-    }
-
     let mut thread_data_ptr = ptr::null();
     // If ThreadData is expensive to construct, then we want to use a cached
     // version in thread-local storage if possible.
     if !ThreadParker::IS_CHEAP_TO_CONSTRUCT {
         thread_local!(static THREAD_DATA: ThreadData = ThreadData::new());
-        if let Some(tls_thread_data) = try_get_tls(&THREAD_DATA) {
+        if let Ok(tls_thread_data) = THREAD_DATA.try_with(|x| x as *const ThreadData) {
             thread_data_ptr = tls_thread_data;
         }
     }

--- a/core/src/word_lock.rs
+++ b/core/src/word_lock.rs
@@ -7,10 +7,11 @@
 
 use crate::spinwait::SpinWait;
 use crate::thread_parker::ThreadParker;
-use std::cell::Cell;
-use std::mem;
-use std::ptr;
-use std::sync::atomic::{fence, AtomicUsize, Ordering};
+use core::{
+    cell::Cell,
+    mem, ptr,
+    sync::atomic::{fence, AtomicUsize, Ordering},
+};
 
 struct ThreadData {
     parker: ThreadParker,

--- a/lock_api/Cargo.toml
+++ b/lock_api/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0/MIT"
 repository = "https://github.com/Amanieu/parking_lot"
 keywords = ["mutex", "rwlock", "lock", "no_std"]
 categories = ["concurrency", "no-std"]
+edition = "2018"
 
 [dependencies]
 scopeguard = { version = "1.0", default-features = false }

--- a/lock_api/Cargo.toml
+++ b/lock_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lock_api"
-version = "0.1.5"
+version = "0.2.0"
 authors = ["Amanieu d'Antras <amanieu@gmail.com>"]
 description = "Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std."
 license = "Apache-2.0/MIT"

--- a/lock_api/src/lib.rs
+++ b/lock_api/src/lib.rs
@@ -90,9 +90,6 @@
 #[macro_use]
 extern crate scopeguard;
 
-#[cfg(feature = "owning_ref")]
-extern crate owning_ref;
-
 /// Marker type which indicates that the Guard type for a lock is `Send`.
 pub struct GuardSend(());
 
@@ -100,10 +97,10 @@ pub struct GuardSend(());
 pub struct GuardNoSend(*mut ());
 
 mod mutex;
-pub use mutex::*;
+pub use crate::mutex::*;
 
 mod remutex;
-pub use remutex::*;
+pub use crate::remutex::*;
 
 mod rwlock;
-pub use rwlock::*;
+pub use crate::rwlock::*;

--- a/lock_api/src/lib.rs
+++ b/lock_api/src/lib.rs
@@ -85,6 +85,7 @@
 
 #![no_std]
 #![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
 #![cfg_attr(feature = "nightly", feature(const_fn))]
 
 #[macro_use]

--- a/src/condvar.rs
+++ b/src/condvar.rs
@@ -5,15 +5,16 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::deadlock;
 use crate::mutex::MutexGuard;
 use crate::raw_mutex::{RawMutex, TOKEN_HANDOFF, TOKEN_NORMAL};
-use crate::util;
+use crate::{deadlock, util};
+use core::{
+    fmt, ptr,
+    sync::atomic::{AtomicPtr, Ordering},
+};
 use lock_api::RawMutex as RawMutexTrait;
 use parking_lot_core::{self, ParkResult, RequeueOp, UnparkResult, DEFAULT_PARK_TOKEN};
-use std::sync::atomic::{AtomicPtr, Ordering};
 use std::time::{Duration, Instant};
-use std::{fmt, ptr};
 
 /// A type indicating whether a timed wait on a condition variable returned
 /// due to a time out or not.

--- a/src/deadlock.rs
+++ b/src/deadlock.rs
@@ -40,13 +40,13 @@ pub(crate) use parking_lot_core::deadlock::{acquire_resource, release_resource};
 #[cfg(test)]
 #[cfg(feature = "deadlock_detection")]
 mod tests {
+    use crate::{Mutex, ReentrantMutex, RwLock};
     use std::sync::{Arc, Barrier};
     use std::thread::{self, sleep};
     use std::time::Duration;
-    use {Mutex, ReentrantMutex, RwLock};
 
     // We need to serialize these tests since deadlock detection uses global state
-    lazy_static! {
+    lazy_static::lazy_static! {
         static ref DEADLOCK_DETECTION_LOCK: Mutex<()> = Mutex::new(());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,7 @@
 
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
-#![cfg_attr(feature = "nightly", feature(const_fn))]
-#![cfg_attr(feature = "nightly", feature(integer_atomics))]
 #![cfg_attr(feature = "nightly", feature(asm))]
-#![cfg_attr(feature = "nightly", feature(time_checked_add))]
 
 mod condvar;
 mod elision;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 //! standard library. It also provides a `ReentrantMutex` type.
 
 #![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
 #![cfg_attr(feature = "nightly", feature(const_fn))]
 #![cfg_attr(feature = "nightly", feature(integer_atomics))]
 #![cfg_attr(feature = "nightly", feature(asm))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,14 +15,6 @@
 #![cfg_attr(feature = "nightly", feature(asm))]
 #![cfg_attr(feature = "nightly", feature(time_checked_add))]
 
-extern crate lock_api;
-extern crate parking_lot_core;
-
-#[cfg(test)]
-#[cfg(feature = "deadlock_detection")]
-#[macro_use]
-extern crate lazy_static;
-
 mod condvar;
 mod elision;
 mod mutex;
@@ -38,13 +30,15 @@ pub mod deadlock;
 #[cfg(not(feature = "deadlock_detection"))]
 mod deadlock;
 
-pub use condvar::{Condvar, WaitTimeoutResult};
-pub use mutex::{MappedMutexGuard, Mutex, MutexGuard};
-pub use once::{Once, OnceState, ONCE_INIT};
-pub use raw_mutex::RawMutex;
-pub use raw_rwlock::RawRwLock;
-pub use remutex::{MappedReentrantMutexGuard, RawThreadId, ReentrantMutex, ReentrantMutexGuard};
-pub use rwlock::{
+pub use self::condvar::{Condvar, WaitTimeoutResult};
+pub use self::mutex::{MappedMutexGuard, Mutex, MutexGuard};
+pub use self::once::{Once, OnceState, ONCE_INIT};
+pub use self::raw_mutex::RawMutex;
+pub use self::raw_rwlock::RawRwLock;
+pub use self::remutex::{
+    MappedReentrantMutexGuard, RawThreadId, ReentrantMutex, ReentrantMutexGuard,
+};
+pub use self::rwlock::{
     MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock, RwLockReadGuard,
     RwLockUpgradableReadGuard, RwLockWriteGuard,
 };

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -5,8 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::raw_mutex::RawMutex;
 use lock_api;
-use raw_mutex::RawMutex;
 
 /// A mutual exclusion primitive useful for protecting shared data
 ///
@@ -105,11 +105,11 @@ pub type MappedMutexGuard<'a, T> = lock_api::MappedMutexGuard<'a, RawMutex, T>;
 
 #[cfg(test)]
 mod tests {
+    use crate::{Condvar, Mutex};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::mpsc::channel;
     use std::sync::Arc;
     use std::thread;
-    use {Condvar, Mutex};
 
     struct Packet<T>(Arc<(Mutex<T>, Condvar)>);
 

--- a/src/once.rs
+++ b/src/once.rs
@@ -15,9 +15,8 @@ use std::sync::atomic::AtomicUsize as AtomicU8;
 #[cfg(not(feature = "nightly"))]
 type U8 = usize;
 use crate::util::UncheckedOptionExt;
+use core::{fmt, mem};
 use parking_lot_core::{self, SpinWait, DEFAULT_PARK_TOKEN, DEFAULT_UNPARK_TOKEN};
-use std::fmt;
-use std::mem;
 
 const DONE_BIT: U8 = 1;
 const POISON_BIT: U8 = 2;

--- a/src/raw_mutex.rs
+++ b/src/raw_mutex.rs
@@ -14,11 +14,11 @@ type U8 = u8;
 use std::sync::atomic::AtomicUsize as AtomicU8;
 #[cfg(not(feature = "nightly"))]
 type U8 = usize;
-use deadlock;
+use crate::deadlock;
+use crate::util;
 use lock_api::{GuardNoSend, RawMutex as RawMutexTrait, RawMutexFair, RawMutexTimed};
 use parking_lot_core::{self, ParkResult, SpinWait, UnparkResult, UnparkToken, DEFAULT_PARK_TOKEN};
 use std::time::{Duration, Instant};
-use util;
 
 // UnparkToken used to indicate that that the target thread should attempt to
 // lock the mutex again as soon as it is unparked.

--- a/src/raw_mutex.rs
+++ b/src/raw_mutex.rs
@@ -6,12 +6,12 @@
 // copied, modified, or distributed except according to those terms.
 
 #[cfg(feature = "nightly")]
-use std::sync::atomic::AtomicU8;
-use std::sync::atomic::Ordering;
+use core::sync::atomic::AtomicU8;
+use core::sync::atomic::Ordering;
 #[cfg(feature = "nightly")]
 type U8 = u8;
 #[cfg(not(feature = "nightly"))]
-use std::sync::atomic::AtomicUsize as AtomicU8;
+use core::sync::atomic::AtomicUsize as AtomicU8;
 #[cfg(not(feature = "nightly"))]
 type U8 = usize;
 use crate::deadlock;

--- a/src/raw_rwlock.rs
+++ b/src/raw_rwlock.rs
@@ -5,7 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use elision::{have_elision, AtomicElisionExt};
+use crate::elision::{have_elision, AtomicElisionExt};
+use crate::raw_mutex::{TOKEN_HANDOFF, TOKEN_NORMAL};
+use crate::util;
 use lock_api::{
     GuardNoSend, RawRwLock as RawRwLockTrait, RawRwLockDowngrade, RawRwLockFair,
     RawRwLockRecursive, RawRwLockRecursiveTimed, RawRwLockTimed, RawRwLockUpgrade,
@@ -14,11 +16,9 @@ use lock_api::{
 use parking_lot_core::{
     self, deadlock, FilterOp, ParkResult, ParkToken, SpinWait, UnparkResult, UnparkToken,
 };
-use raw_mutex::{TOKEN_HANDOFF, TOKEN_NORMAL};
 use std::cell::Cell;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
-use util;
 
 // This reader-writer lock implementation is based on Boost's upgrade_mutex:
 // https://github.com/boostorg/thread/blob/fc08c1fe2840baeeee143440fba31ef9e9a813c8/include/boost/thread/v2/shared_mutex.hpp#L432

--- a/src/raw_rwlock.rs
+++ b/src/raw_rwlock.rs
@@ -8,6 +8,10 @@
 use crate::elision::{have_elision, AtomicElisionExt};
 use crate::raw_mutex::{TOKEN_HANDOFF, TOKEN_NORMAL};
 use crate::util;
+use core::{
+    cell::Cell,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 use lock_api::{
     GuardNoSend, RawRwLock as RawRwLockTrait, RawRwLockDowngrade, RawRwLockFair,
     RawRwLockRecursive, RawRwLockRecursiveTimed, RawRwLockTimed, RawRwLockUpgrade,
@@ -16,8 +20,6 @@ use lock_api::{
 use parking_lot_core::{
     self, deadlock, FilterOp, ParkResult, ParkToken, SpinWait, UnparkResult, UnparkToken,
 };
-use std::cell::Cell;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 // This reader-writer lock implementation is based on Boost's upgrade_mutex:

--- a/src/remutex.rs
+++ b/src/remutex.rs
@@ -5,8 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::raw_mutex::RawMutex;
 use lock_api::{self, GetThreadId};
-use raw_mutex::RawMutex;
 
 /// Implementation of the `GetThreadId` trait for `lock_api::ReentrantMutex`.
 pub struct RawThreadId;
@@ -54,10 +54,10 @@ pub type MappedReentrantMutexGuard<'a, T> =
 
 #[cfg(test)]
 mod tests {
+    use crate::ReentrantMutex;
     use std::cell::RefCell;
     use std::sync::Arc;
     use std::thread;
-    use ReentrantMutex;
 
     #[test]
     fn smoke() {

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -5,8 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::raw_rwlock::RawRwLock;
 use lock_api;
-use raw_rwlock::RawRwLock;
 
 /// A reader-writer lock
 ///
@@ -120,14 +120,13 @@ pub type RwLockUpgradableReadGuard<'a, T> = lock_api::RwLockUpgradableReadGuard<
 
 #[cfg(test)]
 mod tests {
-    extern crate rand;
-    use self::rand::Rng;
+    use crate::{RwLock, RwLockUpgradableReadGuard, RwLockWriteGuard};
+    use rand::Rng;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::mpsc::channel;
     use std::sync::Arc;
     use std::thread;
     use std::time::Duration;
-    use {RwLock, RwLockUpgradableReadGuard, RwLockWriteGuard};
 
     #[derive(Eq, PartialEq, Debug)]
     struct NonCopy(i32);


### PR DESCRIPTION
As we discussed on IRC. Let's upgrade all these three crates to Rust 2018 edition and get rid of some legacy conditional compilation etc.

Will greatly aid the work to integrate it into libstd over at #119 