### PR TITLE
Add Redox thread parker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_script:
   export PATH=$HOME/.local/bin:$PATH
 - if [ "${TRAVIS_RUST_VERSION}" = "nightly" ]; then
     rustup target add x86_64-fortanix-unknown-sgx;
+    rustup target add x86_64-unknown-redox;
   fi
 
 script:
@@ -26,6 +27,7 @@ script:
 - travis-cargo --only stable test -- --features=deadlock_detection
 - travis-cargo --only beta test -- --features=deadlock_detection
 - travis-cargo --only nightly test -- --all --no-run --target x86_64-fortanix-unknown-sgx
+- travis-cargo --only nightly build -- --all --target x86_64-unknown-redox
 - travis-cargo --only nightly doc -- --all-features --no-deps -p parking_lot -p parking_lot_core -p lock_api
 - cd benchmark
 - travis-cargo build

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,6 +20,9 @@ backtrace = { version = "0.3.2", optional = true }
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.27"
 
+[target.'cfg(target_os = "redox")'.dependencies]
+redox_syscall = "0.1"
+
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winnt", "ntstatus", "minwindef",
     "winerror", "winbase", "errhandlingapi", "handleapi"] }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -64,6 +64,9 @@ cfg_if! {
     } else if #[cfg(windows)] {
         #[path = "thread_parker/windows/mod.rs"]
         mod thread_parker;
+    } else if #[cfg(all(feature = "nightly", target_os = "redox"))] {
+        #[path = "thread_parker/redox.rs"]
+        mod thread_parker;
     } else if #[cfg(all(target_env = "sgx", target_vendor = "fortanix"))] {
         #[path = "thread_parker/sgx.rs"]
         mod thread_parker;

--- a/core/src/thread_parker/redox.rs
+++ b/core/src/thread_parker/redox.rs
@@ -1,0 +1,150 @@
+// Copyright 2016 Amanieu d'Antras
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use core::{
+    ptr,
+    sync::atomic::{AtomicI32, Ordering},
+};
+use std::{thread, time::Instant};
+use syscall::{
+    call::futex,
+    data::TimeSpec,
+    error::{Error, EAGAIN, EFAULT, EINTR, ETIMEDOUT},
+    flag::{FUTEX_WAIT, FUTEX_WAKE},
+};
+
+const UNPARKED: i32 = 0;
+const PARKED: i32 = 1;
+
+// Helper type for putting a thread to sleep until some other thread wakes it up
+pub struct ThreadParker {
+    futex: AtomicI32,
+}
+
+impl ThreadParker {
+    pub const IS_CHEAP_TO_CONSTRUCT: bool = true;
+
+    #[inline]
+    pub fn new() -> ThreadParker {
+        ThreadParker {
+            futex: AtomicI32::new(UNPARKED),
+        }
+    }
+
+    // Prepares the parker. This should be called before adding it to the queue.
+    #[inline]
+    pub fn prepare_park(&self) {
+        self.futex.store(PARKED, Ordering::Relaxed);
+    }
+
+    // Checks if the park timed out. This should be called while holding the
+    // queue lock after park_until has returned false.
+    #[inline]
+    pub fn timed_out(&self) -> bool {
+        self.futex.load(Ordering::Relaxed) != UNPARKED
+    }
+
+    // Parks the thread until it is unparked. This should be called after it has
+    // been added to the queue, after unlocking the queue.
+    #[inline]
+    pub fn park(&self) {
+        while self.futex.load(Ordering::Acquire) != UNPARKED {
+            self.futex_wait(None);
+        }
+    }
+
+    // Parks the thread until it is unparked or the timeout is reached. This
+    // should be called after it has been added to the queue, after unlocking
+    // the queue. Returns true if we were unparked and false if we timed out.
+    #[inline]
+    pub fn park_until(&self, timeout: Instant) -> bool {
+        while self.futex.load(Ordering::Acquire) != UNPARKED {
+            let now = Instant::now();
+            if timeout <= now {
+                return false;
+            }
+            let diff = timeout - now;
+            if diff.as_secs() > i64::max_value() as u64 {
+                // Timeout overflowed, just sleep indefinitely
+                self.park();
+                return true;
+            }
+            let ts = TimeSpec {
+                tv_sec: diff.as_secs() as i64,
+                tv_nsec: diff.subsec_nanos() as i32,
+            };
+            self.futex_wait(Some(ts));
+        }
+        true
+    }
+
+    #[inline]
+    fn futex_wait(&self, ts: Option<TimeSpec>) {
+        let ts_ptr = ts
+            .as_ref()
+            .map(|ts_ref| ts_ref as *const _)
+            .unwrap_or(ptr::null());
+        let r = unsafe {
+            futex(
+                self.ptr(),
+                FUTEX_WAIT,
+                PARKED,
+                ts_ptr as usize,
+                ptr::null_mut(),
+            )
+        };
+        match r {
+            Ok(r) => debug_assert_eq!(r, 0),
+            Err(Error { errno }) => {
+                debug_assert!(errno == EINTR || errno == EAGAIN || errno == ETIMEDOUT);
+            }
+        }
+    }
+
+    // Locks the parker to prevent the target thread from exiting. This is
+    // necessary to ensure that thread-local ThreadData objects remain valid.
+    // This should be called while holding the queue lock.
+    #[inline]
+    pub fn unpark_lock(&self) -> UnparkHandle {
+        // We don't need to lock anything, just clear the state
+        self.futex.store(UNPARKED, Ordering::Release);
+
+        UnparkHandle { futex: self.ptr() }
+    }
+
+    #[inline]
+    fn ptr(&self) -> *mut i32 {
+        &self.futex as *const AtomicI32 as *mut i32
+    }
+}
+
+// Handle for a thread that is about to be unparked. We need to mark the thread
+// as unparked while holding the queue lock, but we delay the actual unparking
+// until after the queue lock is released.
+pub struct UnparkHandle {
+    futex: *mut i32,
+}
+
+impl UnparkHandle {
+    // Wakes up the parked thread. This should be called after the queue lock is
+    // released to avoid blocking the queue for too long.
+    #[inline]
+    pub fn unpark(self) {
+        // The thread data may have been freed at this point, but it doesn't
+        // matter since the syscall will just return EFAULT in that case.
+        let r = unsafe { futex(self.futex, FUTEX_WAKE, PARKED, 0, ptr::null_mut()) };
+        match r {
+            Ok(num_woken) => debug_assert!(num_woken == 0 || num_woken == 1),
+            Err(Error { errno }) => debug_assert_eq!(errno, EFAULT),
+        }
+    }
+}
+
+#[inline]
+pub fn thread_yield() {
+    thread::yield_now();
+}


### PR DESCRIPTION
This is in preparation for https://github.com/rust-lang/rust/pull/56410. To not make any platform regress from a good thread parking implementation to a spin lock based one, I add real `ThreadParker` implementations for them to `parking_lot`. It also simply makes `parking_lot` usable as a standalone library on Redox.

Ping @jackpot51. You seem to be the one who implemented most of the futex waiting logic in the standard library. So maybe you have some valuable input? Or you could ping someone who might be able to have a look at/help with this.

I started out with the existing `core/src/thread_parker/linux.rs` futex based implementation and basically just changed a few things to make the calls fit into how Redox expects them.

I have been able to verify that this builds, with cross compilation. But I have not yet been able to link it, nor run anything on a real Redox VM/machine. Will try to make that happen. But if someone with more Redox skills and an already set up system could help run the test suite, and maybe the benchmark sub-crate, that would be awesome.