### PR TITLE
Upgrade benchmark crate to Rust 2018

### DIFF
--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -2,6 +2,7 @@
 name = "parking_lot-benchmark"
 version = "0.0.0"
 authors = ["Amanieu d'Antras <amanieu@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 parking_lot = {path = ".."}

--- a/benchmark/src/args.rs
+++ b/benchmark/src/args.rs
@@ -5,8 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::env;
-use std::process;
+use std::{env, process};
 
 #[derive(Copy, Clone)]
 pub struct ArgRange {

--- a/benchmark/src/mutex.rs
+++ b/benchmark/src/mutex.rs
@@ -5,18 +5,19 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate libc;
-extern crate parking_lot;
-
 mod args;
-use args::ArgRange;
+use crate::args::ArgRange;
 
 #[cfg(unix)]
 use std::cell::UnsafeCell;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Barrier};
-use std::thread;
-use std::time::Duration;
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Barrier,
+    },
+    thread,
+    time::Duration,
+};
 
 trait Mutex<T> {
     fn new(v: T) -> Self;

--- a/benchmark/src/rwlock.rs
+++ b/benchmark/src/rwlock.rs
@@ -5,19 +5,19 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate libc;
-extern crate parking_lot;
-extern crate seqlock;
-
 mod args;
-use args::ArgRange;
+use crate::args::ArgRange;
 
 #[cfg(unix)]
 use std::cell::UnsafeCell;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Barrier};
-use std::thread;
-use std::time::Duration;
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Barrier,
+    },
+    thread,
+    time::Duration,
+};
 
 trait RwLock<T> {
     fn new(v: T) -> Self;


### PR DESCRIPTION
I realized that the benchmark crate was still Rust 2015. Caused some small problems when I tried to benchmark on some exotic platforms. No reason to not upgrade it I guess.