### PR TITLE
Add version detection for stabilized atomics and checked_add

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ lock_api = { path = "lock_api", version = "0.2" }
 rand = "0.6"
 lazy_static = "1.0"
 
+[build-dependencies]
+rustc_version = "0.2"
+
 [features]
 default = []
 owning_ref = ["lock_api/owning_ref"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+use rustc_version::{version, Version};
+
+fn main() {
+    if version().unwrap() >= Version::parse("1.34.0").unwrap() {
+        println!("cargo:rustc-cfg=has_sized_atomics");
+        println!("cargo:rustc-cfg=has_checked_instant");
+    }
+}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,6 +17,9 @@ petgraph = { version = "0.4.5", optional = true }
 thread-id = { version = "3.2.0", optional = true }
 backtrace = { version = "0.3.2", optional = true }
 
+[build-dependencies]
+rustc_version = "0.2"
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.27"
 

--- a/core/build.rs
+++ b/core/build.rs
@@ -1,0 +1,7 @@
+use rustc_version::{version, Version};
+
+fn main() {
+    if version().unwrap() >= Version::parse("1.34.0").unwrap() {
+        println!("cargo:rustc-cfg=has_sized_atomics");
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -59,7 +59,7 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(feature = "nightly", target_os = "linux"))] {
+    if #[cfg(all(has_sized_atomics, target_os = "linux"))] {
         #[path = "thread_parker/linux.rs"]
         mod thread_parker;
     } else if #[cfg(unix)] {
@@ -68,7 +68,7 @@ cfg_if! {
     } else if #[cfg(windows)] {
         #[path = "thread_parker/windows/mod.rs"]
         mod thread_parker;
-    } else if #[cfg(all(feature = "nightly", target_os = "redox"))] {
+    } else if #[cfg(all(has_sized_atomics, target_os = "redox"))] {
         #[path = "thread_parker/redox.rs"]
         mod thread_parker;
     } else if #[cfg(all(target_env = "sgx", target_vendor = "fortanix"))] {

--- a/src/once.rs
+++ b/src/once.rs
@@ -5,18 +5,21 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-#[cfg(feature = "nightly")]
-use std::sync::atomic::AtomicU8;
-use std::sync::atomic::{fence, Ordering};
-#[cfg(feature = "nightly")]
-type U8 = u8;
-#[cfg(not(feature = "nightly"))]
-use std::sync::atomic::AtomicUsize as AtomicU8;
-#[cfg(not(feature = "nightly"))]
-type U8 = usize;
 use crate::util::UncheckedOptionExt;
-use core::{fmt, mem};
+#[cfg(has_sized_atomics)]
+use core::sync::atomic::AtomicU8;
+#[cfg(not(has_sized_atomics))]
+use core::sync::atomic::AtomicUsize as AtomicU8;
+use core::{
+    fmt, mem,
+    sync::atomic::{fence, Ordering},
+};
 use parking_lot_core::{self, SpinWait, DEFAULT_PARK_TOKEN, DEFAULT_UNPARK_TOKEN};
+
+#[cfg(has_sized_atomics)]
+type U8 = u8;
+#[cfg(not(has_sized_atomics))]
+type U8 = usize;
 
 const DONE_BIT: U8 = 1;
 const POISON_BIT: U8 = 2;

--- a/src/raw_mutex.rs
+++ b/src/raw_mutex.rs
@@ -5,20 +5,20 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-#[cfg(feature = "nightly")]
+use crate::{deadlock, util};
+#[cfg(has_sized_atomics)]
 use core::sync::atomic::AtomicU8;
-use core::sync::atomic::Ordering;
-#[cfg(feature = "nightly")]
-type U8 = u8;
-#[cfg(not(feature = "nightly"))]
+#[cfg(not(has_sized_atomics))]
 use core::sync::atomic::AtomicUsize as AtomicU8;
-#[cfg(not(feature = "nightly"))]
-type U8 = usize;
-use crate::deadlock;
-use crate::util;
+use core::{sync::atomic::Ordering, time::Duration};
 use lock_api::{GuardNoSend, RawMutex as RawMutexTrait, RawMutexFair, RawMutexTimed};
 use parking_lot_core::{self, ParkResult, SpinWait, UnparkResult, UnparkToken, DEFAULT_PARK_TOKEN};
-use std::time::{Duration, Instant};
+use std::time::Instant;
+
+#[cfg(has_sized_atomics)]
+type U8 = u8;
+#[cfg(not(has_sized_atomics))]
+type U8 = usize;
 
 // UnparkToken used to indicate that that the target thread should attempt to
 // lock the mutex again as soon as it is unparked.

--- a/src/util.rs
+++ b/src/util.rs
@@ -35,9 +35,9 @@ unsafe fn unreachable() -> ! {
 
 #[inline]
 pub fn to_deadline(timeout: Duration) -> Option<Instant> {
-    #[cfg(feature = "nightly")]
+    #[cfg(has_checked_instant)]
     let deadline = Instant::now().checked_add(timeout);
-    #[cfg(not(feature = "nightly"))]
+    #[cfg(not(has_checked_instant))]
     let deadline = Some(Instant::now() + timeout);
 
     deadline


### PR DESCRIPTION
Automatically detecting Rust >= 1.34 and make good use of the now stable `AtomicU{8,32}` types as well as `Instant::checked_add`.

This has been broken out from #119 since that PR is a bit large and this commit is not really related to the crate being used in libstd. We don't really know when the libstd stuff will be merged anyway, and this could be immediately useful to anyone using `parking_lot` on the latest stable Rust.

I'm just generally against "let's just put this in the already open PR, it'll be fine". I find it usually creates more problems than it solves.