### PR TITLE
Remove extern crate serde and don't wildcard import

### DIFF
--- a/lock_api/Cargo.toml
+++ b/lock_api/Cargo.toml
@@ -18,9 +18,5 @@ owning_ref = { version = "0.4", optional = true }
 # support, just pass "--features serde" when building this crate.
 serde = {version = "1.0.90", default-features = false, optional = true}
 
-[dev-dependencies]
-# Used when testing out serde support.
-bincode = {version = "1.1.3"}
-
 [features]
 nightly = []

--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -15,9 +15,7 @@ use core::ops::{Deref, DerefMut};
 use owning_ref::StableAddress;
 
 #[cfg(feature = "serde")]
-extern crate serde;
-#[cfg(feature = "serde")]
-use self::serde::*;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Basic operations for a mutex.
 ///
@@ -117,7 +115,7 @@ where
 impl<'de, R, T> Deserialize<'de> for Mutex<R, T>
 where
     R: RawMutex,
-    T: Deserialize<'de> + ?Sized
+    T: Deserialize<'de> + ?Sized,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -18,9 +18,7 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 use owning_ref::StableAddress;
 
 #[cfg(feature = "serde")]
-extern crate serde;
-#[cfg(feature = "serde")]
-use self::serde::*;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Helper trait which returns a non-zero thread ID.
 ///
@@ -166,7 +164,7 @@ impl<'de, R, G, T> Deserialize<'de> for ReentrantMutex<R, G, T>
 where
     R: RawMutex,
     G: GetThreadId,
-    T: Deserialize<'de> + ?Sized
+    T: Deserialize<'de> + ?Sized,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -15,9 +15,7 @@ use core::ops::{Deref, DerefMut};
 use owning_ref::StableAddress;
 
 #[cfg(feature = "serde")]
-extern crate serde;
-#[cfg(feature = "serde")]
-use self::serde::*;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Basic operations for a reader-writer lock.
 ///
@@ -254,7 +252,7 @@ where
 impl<'de, R, T> Deserialize<'de> for RwLock<R, T>
 where
     R: RawRwLock,
-    T: Deserialize<'de> + ?Sized
+    T: Deserialize<'de> + ?Sized,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where


### PR DESCRIPTION
Since we upgraded to Rust 2018 edition we don't need `extern crate`. I also felt it would be nicer to just import the four types we need into scope rather than a wildcard import.