### PR TITLE
Fix feedback from libstd PR, part 1

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,7 +21,7 @@ backtrace = { version = "0.3.2", optional = true }
 rustc_version = "0.2"
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2.27"
+libc = "0.2.55"
 
 [target.'cfg(target_os = "redox")'.dependencies]
 redox_syscall = "0.1"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -49,42 +49,9 @@
     feature(thread_local, checked_duration_since)
 )]
 
-use cfg_if::cfg_if;
-
-cfg_if! {
-    if #[cfg(all(has_sized_atomics, target_os = "linux"))] {
-        #[path = "thread_parker/linux.rs"]
-        mod thread_parker;
-    } else if #[cfg(unix)] {
-        #[path = "thread_parker/unix.rs"]
-        mod thread_parker;
-    } else if #[cfg(windows)] {
-        #[path = "thread_parker/windows/mod.rs"]
-        mod thread_parker;
-    } else if #[cfg(all(has_sized_atomics, target_os = "redox"))] {
-        #[path = "thread_parker/redox.rs"]
-        mod thread_parker;
-    } else if #[cfg(all(target_env = "sgx", target_vendor = "fortanix"))] {
-        #[path = "thread_parker/sgx.rs"]
-        mod thread_parker;
-    } else if #[cfg(all(
-        feature = "nightly",
-        target_arch = "wasm32",
-        target_feature = "atomics"
-    ))] {
-        #[path = "thread_parker/wasm.rs"]
-        mod thread_parker;
-    } else if #[cfg(all(feature = "nightly", target_os = "cloudabi"))] {
-        #[path = "thread_parker/cloudabi.rs"]
-        mod thread_parker;
-    } else {
-        #[path = "thread_parker/generic.rs"]
-        mod thread_parker;
-    }
-}
-
 mod parking_lot;
 mod spinwait;
+mod thread_parker;
 mod util;
 mod word_lock;
 

--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -556,9 +556,9 @@ pub unsafe fn park(
         // Invoke the pre-sleep callback
         before_sleep();
 
-        // Park our thread and determine whether we were woken up by an unpark or by
-        // our timeout. Note that this isn't precise: we can still be unparked since
-        // we are still in the queue.
+        // Park our thread and determine whether we were woken up by an unpark
+        // or by our timeout. Note that this isn't precise: we can still be
+        // unparked since we are still in the queue.
         let unparked = match timeout {
             Some(timeout) => thread_data.parker.park_until(timeout),
             None => {

--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::thread_parker::ThreadParker;
+use crate::thread_parker::{ThreadParker, ThreadParkerT, UnparkHandleT};
 use crate::util::UncheckedOptionExt;
 use crate::word_lock::WordLock;
 use core::{
@@ -1050,6 +1050,7 @@ pub mod deadlock {
 #[cfg(feature = "deadlock_detection")]
 mod deadlock_impl {
     use super::{get_hashtable, lock_bucket, with_thread_data, ThreadData, NUM_THREADS};
+    use crate::thread_parker::{ThreadParkerT, UnparkHandleT};
     use crate::word_lock::WordLock;
     use backtrace::Backtrace;
     use petgraph;

--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -181,7 +181,6 @@ fn get_hashtable() -> *mut HashTable {
 
 // Get a pointer to the latest hash table, creating one if it doesn't exist yet.
 #[cold]
-#[inline(never)]
 fn create_hashtable() -> *mut HashTable {
     let new_table = Box::into_raw(HashTable::new(LOAD_FACTOR, ptr::null()));
 

--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -395,13 +395,8 @@ unsafe fn lock_bucket_pair<'a>(key1: usize, key2: usize) -> (&'a Bucket, &'a Buc
 // Unlock a pair of buckets
 #[inline]
 unsafe fn unlock_bucket_pair(bucket1: &Bucket, bucket2: &Bucket) {
-    if bucket1 as *const _ == bucket2 as *const _ {
-        bucket1.mutex.unlock();
-    } else if bucket1 as *const _ < bucket2 as *const _ {
-        bucket2.mutex.unlock();
-        bucket1.mutex.unlock();
-    } else {
-        bucket1.mutex.unlock();
+    bucket1.mutex.unlock();
+    if !ptr::eq(bucket1, bucket2) {
         bucket2.mutex.unlock();
     }
 }

--- a/core/src/thread_parker/cloudabi.rs
+++ b/core/src/thread_parker/cloudabi.rs
@@ -23,87 +23,88 @@ struct Lock {
 }
 
 impl Lock {
-    #[inline]
     pub fn new() -> Self {
         Lock {
             lock: AtomicU32::new(abi::LOCK_UNLOCKED.0),
         }
     }
 
-    #[inline]
-    fn try_lock(&self) -> Option<LockGuard<'_>> {
+    /// # Safety
+    ///
+    /// See `Lock::lock`.
+    unsafe fn try_lock(&self) -> Option<LockGuard> {
         // Attempt to acquire the lock.
         if let Err(old) = self.lock.compare_exchange(
             abi::LOCK_UNLOCKED.0,
-            unsafe { __pthread_thread_id.0 } | abi::LOCK_WRLOCKED.0,
+            __pthread_thread_id.0 | abi::LOCK_WRLOCKED.0,
             Ordering::Acquire,
             Ordering::Relaxed,
         ) {
             // Failure. Crash upon recursive acquisition.
             debug_assert_ne!(
                 old & !abi::LOCK_KERNEL_MANAGED.0,
-                unsafe { __pthread_thread_id.0 } | abi::LOCK_WRLOCKED.0,
+                __pthread_thread_id.0 | abi::LOCK_WRLOCKED.0,
                 "Attempted to recursive write-lock a lock",
             );
             None
         } else {
-            Some(LockGuard { inner: &self })
+            Some(LockGuard { lock: &self.lock })
         }
     }
 
-    #[inline]
-    pub fn lock(&self) -> LockGuard<'_> {
+    /// # Safety
+    ///
+    /// This method is unsafe because the `LockGuard` has a raw pointer into this `Lock`
+    /// that it will access on drop to unlock the lock. So make sure the `LockGuard` goes
+    /// out of scope before the `Lock` it came from moves or goes out of scope.
+    pub unsafe fn lock(&self) -> LockGuard {
         self.try_lock().unwrap_or_else(|| {
             // Call into the kernel to acquire a write lock.
-            unsafe {
-                let subscription = abi::subscription {
-                    type_: abi::eventtype::LOCK_WRLOCK,
-                    union: abi::subscription_union {
-                        lock: abi::subscription_lock {
-                            lock: self.ptr(),
-                            lock_scope: abi::scope::PRIVATE,
-                        },
+            let subscription = abi::subscription {
+                type_: abi::eventtype::LOCK_WRLOCK,
+                union: abi::subscription_union {
+                    lock: abi::subscription_lock {
+                        lock: self.ptr(),
+                        lock_scope: abi::scope::PRIVATE,
                     },
-                    ..mem::zeroed()
-                };
-                let mut event: abi::event = mem::uninitialized();
-                let mut nevents: usize = mem::uninitialized();
-                let ret = abi::poll(&subscription, &mut event, 1, &mut nevents);
-                debug_assert_eq!(ret, abi::errno::SUCCESS);
-                debug_assert_eq!(event.error, abi::errno::SUCCESS);
-            }
-            LockGuard { inner: &self }
+                },
+                ..mem::zeroed()
+            };
+            let mut event: abi::event = mem::uninitialized();
+            let mut nevents: usize = mem::uninitialized();
+            let ret = abi::poll(&subscription, &mut event, 1, &mut nevents);
+            debug_assert_eq!(ret, abi::errno::SUCCESS);
+            debug_assert_eq!(event.error, abi::errno::SUCCESS);
+
+            LockGuard { lock: &self.lock }
         })
     }
 
-    #[inline]
     fn ptr(&self) -> *mut abi::lock {
         &self.lock as *const AtomicU32 as *mut abi::lock
     }
 }
 
-struct LockGuard<'a> {
-    inner: &'a Lock,
+struct LockGuard {
+    lock: *const AtomicU32,
 }
 
-impl LockGuard<'_> {
-    #[inline]
+impl LockGuard {
     fn ptr(&self) -> *mut abi::lock {
-        &self.inner.lock as *const AtomicU32 as *mut abi::lock
+        self.lock as *mut abi::lock
     }
 }
 
-impl Drop for LockGuard<'_> {
+impl Drop for LockGuard {
     fn drop(&mut self) {
+        let lock = unsafe { &*self.lock };
         debug_assert_eq!(
-            self.inner.lock.load(Ordering::Relaxed) & !abi::LOCK_KERNEL_MANAGED.0,
+            lock.load(Ordering::Relaxed) & !abi::LOCK_KERNEL_MANAGED.0,
             unsafe { __pthread_thread_id.0 } | abi::LOCK_WRLOCKED.0,
             "This lock is not write-locked by this thread"
         );
 
-        if !self
-            .inner
-            .lock
+        if !lock
             .compare_exchange(
                 unsafe { __pthread_thread_id.0 } | abi::LOCK_WRLOCKED.0,
                 abi::LOCK_UNLOCKED.0,
@@ -114,7 +115,7 @@ impl Drop for LockGuard<'_> {
         {
             // Lock is managed by kernelspace. Call into the kernel
             // to unblock waiting threads.
-            let ret = unsafe { abi::lock_unlock(self.ptr(), abi::scope::PRIVATE) };
+            let ret = unsafe { abi::lock_unlock(self.lock  as *mut abi::lock, abi::scope::PRIVATE) };
             debug_assert_eq!(ret, abi::errno::SUCCESS);
         }
     }
@@ -125,15 +126,13 @@ struct Condvar {
 }
 
 impl Condvar {
-    #[inline]
     pub fn new() -> Self {
         Condvar {
             condvar: AtomicU32::new(abi::CONDVAR_HAS_NO_WAITERS.0),
         }
     }
 
-    #[inline]
-    pub fn wait(&self, lock: &LockGuard<'_>) {
+    pub fn wait(&self, lock: &LockGuard) {
         unsafe {
             let subscription = abi::subscription {
                 type_: abi::eventtype::CONDVAR,
@@ -158,8 +157,7 @@ impl Condvar {
 
     /// Waits for a signal on the condvar.
     /// Returns false if it times out before anyone notified us.
-    #[inline]
-    pub fn wait_timeout(&self, lock: &LockGuard<'_>, timeout: abi::timestamp) -> bool {
+    pub fn wait_timeout(&self, lock: &LockGuard, timeout: abi::timestamp) -> bool {
         unsafe {
             let subscriptions = [
                 abi::subscription {
@@ -201,13 +199,11 @@ impl Condvar {
         false
     }
 
-    #[inline]
     pub fn notify(&self) {
         let ret = unsafe { abi::condvar_signal(self.ptr(), abi::scope::PRIVATE, 1) };
         debug_assert_eq!(ret, abi::errno::SUCCESS);
     }
 
-    #[inline]
     fn ptr(&self) -> *mut abi::condvar {
         &self.condvar as *const AtomicU32 as *mut abi::condvar
     }
@@ -221,11 +217,10 @@ pub struct ThreadParker {
 }
 
 impl super::ThreadParkerT for ThreadParker {
-    type UnparkHandle = UnparkHandle<'_>;
+    type UnparkHandle = UnparkHandle;
 
     const IS_CHEAP_TO_CONSTRUCT: bool = true;
 
-    #[inline]
     fn new() -> ThreadParker {
         ThreadParker {
             should_park: Cell::new(false),
@@ -234,13 +229,11 @@ impl super::ThreadParkerT for ThreadParker {
         }
     }
 
-    #[inline]
-    fn prepare_park(&self) {
+    unsafe fn prepare_park(&self) {
         self.should_park.set(true);
     }
 
-    #[inline]
-    fn timed_out(&self) -> bool {
+    unsafe fn timed_out(&self) -> bool {
         // We need to grab the lock here because another thread may be
         // concurrently executing UnparkHandle::unpark, which is done without
         // holding the queue lock.
@@ -248,16 +241,14 @@ impl super::ThreadParkerT for ThreadParker {
         self.should_park.get()
     }
 
-    #[inline]
-    fn park(&self) {
+    unsafe fn park(&self) {
         let guard = self.lock.lock();
         while self.should_park.get() {
             self.condvar.wait(&guard);
         }
     }
 
-    #[inline]
-    fn park_until(&self, timeout: Instant) -> bool {
+    unsafe fn park_until(&self, timeout: Instant) -> bool {
         let guard = self.lock.lock();
         while self.should_park.get() {
             if let Some(duration_left) = timeout.checked_duration_since(Instant::now()) {
@@ -275,8 +266,7 @@ impl super::ThreadParkerT for ThreadParker {
         true
     }
 
-    #[inline]
-    fn unpark_lock(&self) -> UnparkHandle<'_> {
+    unsafe fn unpark_lock(&self) -> UnparkHandle {
         let _lock_guard = self.lock.lock();
 
         UnparkHandle {
@@ -286,22 +276,19 @@ impl super::ThreadParkerT for ThreadParker {
     }
 }
 
-pub struct UnparkHandle<'a> {
+pub struct UnparkHandle {
     thread_parker: *const ThreadParker,
-    _lock_guard: LockGuard<'a>,
+    _lock_guard: LockGuard,
 }
 
-impl super::UnparkHandleT for UnparkHandle<'_> {
-    #[inline]
-    fn unpark(self) {
-        unsafe {
-            (*self.thread_parker).should_park.set(false);
+impl super::UnparkHandleT for UnparkHandle {
+    unsafe fn unpark(self) {
+        (*self.thread_parker).should_park.set(false);
 
-            // We notify while holding the lock here to avoid races with the target
-            // thread. In particular, the thread could exit after we unlock the
-            // mutex, which would make the condvar access invalid memory.
-            (*self.thread_parker).condvar.notify();
-        }
+        // We notify while holding the lock here to avoid races with the target
+        // thread. In particular, the thread could exit after we unlock the
+        // mutex, which would make the condvar access invalid memory.
+        (*self.thread_parker).condvar.notify();
     }
 }
 

--- a/core/src/thread_parker/generic.rs
+++ b/core/src/thread_parker/generic.rs
@@ -16,43 +16,37 @@ pub struct ThreadParker {
     parked: AtomicBool,
 }
 
-impl ThreadParker {
-    pub const IS_CHEAP_TO_CONSTRUCT: bool = true;
+impl super::ThreadParkerT for ThreadParker {
+    type UnparkHandle = UnparkHandle;
+
+    const IS_CHEAP_TO_CONSTRUCT: bool = true;
 
     #[inline]
-    pub fn new() -> ThreadParker {
+    fn new() -> ThreadParker {
         ThreadParker {
             parked: AtomicBool::new(false),
         }
     }
 
-    // Prepares the parker. This should be called before adding it to the queue.
     #[inline]
-    pub fn prepare_park(&self) {
+    unsafe fn prepare_park(&self) {
         self.parked.store(true, Ordering::Relaxed);
     }
 
-    // Checks if the park timed out. This should be called while holding the
-    // queue lock after park_until has returned false.
     #[inline]
-    pub fn timed_out(&self) -> bool {
+    unsafe fn timed_out(&self) -> bool {
         self.parked.load(Ordering::Relaxed) != false
     }
 
-    // Parks the thread until it is unparked. This should be called after it has
-    // been added to the queue, after unlocking the queue.
     #[inline]
-    pub fn park(&self) {
+    unsafe fn park(&self) {
         while self.parked.load(Ordering::Acquire) != false {
             spin_loop_hint();
         }
     }
 
-    // Parks the thread until it is unparked or the timeout is reached. This
-    // should be called after it has been added to the queue, after unlocking
-    // the queue. Returns true if we were unparked and false if we timed out.
     #[inline]
-    pub fn park_until(&self, timeout: Instant) -> bool {
+    unsafe fn park_until(&self, timeout: Instant) -> bool {
         while self.parked.load(Ordering::Acquire) != false {
             if Instant::now() >= timeout {
                 return false;
@@ -62,27 +56,19 @@ impl ThreadParker {
         true
     }
 
-    // Locks the parker to prevent the target thread from exiting. This is
-    // necessary to ensure that thread-local ThreadData objects remain valid.
-    // This should be called while holding the queue lock.
     #[inline]
-    pub fn unpark_lock(&self) -> UnparkHandle {
+    unsafe fn unpark_lock(&self) -> UnparkHandle {
         // We don't need to lock anything, just clear the state
         self.parked.store(false, Ordering::Release);
         UnparkHandle(())
     }
 }
 
-// Handle for a thread that is about to be unparked. We need to mark the thread
-// as unparked while holding the queue lock, but we delay the actual unparking
-// until after the queue lock is released.
 pub struct UnparkHandle(());
 
-impl UnparkHandle {
-    // Wakes up the parked thread. This should be called after the queue lock is
-    // released to avoid blocking the queue for too long.
+impl super::UnparkHandleT for UnparkHandle {
     #[inline]
-    pub fn unpark(self) {}
+    unsafe fn unpark(self) {}
 }
 
 #[inline]

--- a/core/src/thread_parker/linux.rs
+++ b/core/src/thread_parker/linux.rs
@@ -30,43 +30,37 @@ pub struct ThreadParker {
     futex: AtomicI32,
 }
 
-impl ThreadParker {
-    pub const IS_CHEAP_TO_CONSTRUCT: bool = true;
+impl super::ThreadParkerT for ThreadParker {
+    type UnparkHandle = UnparkHandle;
+
+    const IS_CHEAP_TO_CONSTRUCT: bool = true;
 
     #[inline]
-    pub fn new() -> ThreadParker {
+    fn new() -> ThreadParker {
         ThreadParker {
             futex: AtomicI32::new(0),
         }
     }
 
-    // Prepares the parker. This should be called before adding it to the queue.
     #[inline]
-    pub fn prepare_park(&self) {
+    unsafe fn prepare_park(&self) {
         self.futex.store(1, Ordering::Relaxed);
     }
 
-    // Checks if the park timed out. This should be called while holding the
-    // queue lock after park_until has returned false.
     #[inline]
-    pub fn timed_out(&self) -> bool {
+    unsafe fn timed_out(&self) -> bool {
         self.futex.load(Ordering::Relaxed) != 0
     }
 
-    // Parks the thread until it is unparked. This should be called after it has
-    // been added to the queue, after unlocking the queue.
     #[inline]
-    pub fn park(&self) {
+    unsafe fn park(&self) {
         while self.futex.load(Ordering::Acquire) != 0 {
             self.futex_wait(None);
         }
     }
 
-    // Parks the thread until it is unparked or the timeout is reached. This
-    // should be called after it has been added to the queue, after unlocking
-    // the queue. Returns true if we were unparked and false if we timed out.
     #[inline]
-    pub fn park_until(&self, timeout: Instant) -> bool {
+    unsafe fn park_until(&self, timeout: Instant) -> bool {
         while self.futex.load(Ordering::Acquire) != 0 {
             let now = Instant::now();
             if timeout <= now {
@@ -87,6 +81,19 @@ impl ThreadParker {
         true
     }
 
+    // Locks the parker to prevent the target thread from exiting. This is
+    // necessary to ensure that thread-local ThreadData objects remain valid.
+    // This should be called while holding the queue lock.
+    #[inline]
+    unsafe fn unpark_lock(&self) -> UnparkHandle {
+        // We don't need to lock anything, just clear the state
+        self.futex.store(0, Ordering::Release);
+
+        UnparkHandle { futex: &self.futex }
+    }
+}
+
+impl ThreadParker {
     #[inline]
     fn futex_wait(&self, ts: Option<libc::timespec>) {
         let ts_ptr = ts
@@ -113,31 +120,15 @@ impl ThreadParker {
             }
         }
     }
-
-    // Locks the parker to prevent the target thread from exiting. This is
-    // necessary to ensure that thread-local ThreadData objects remain valid.
-    // This should be called while holding the queue lock.
-    #[inline]
-    pub fn unpark_lock(&self) -> UnparkHandle {
-        // We don't need to lock anything, just clear the state
-        self.futex.store(0, Ordering::Release);
-
-        UnparkHandle { futex: &self.futex }
-    }
 }
 
-// Handle for a thread that is about to be unparked. We need to mark the thread
-// as unparked while holding the queue lock, but we delay the actual unparking
-// until after the queue lock is released.
 pub struct UnparkHandle {
     futex: *const AtomicI32,
 }
 
-impl UnparkHandle {
-    // Wakes up the parked thread. This should be called after the queue lock is
-    // released to avoid blocking the queue for too long.
+impl super::UnparkHandleT for UnparkHandle {
     #[inline]
-    pub fn unpark(self) {
+    unsafe fn unpark(self) {
         // The thread data may have been freed at this point, but it doesn't
         // matter since the syscall will just return EFAULT in that case.
         let r =

--- a/core/src/thread_parker/linux.rs
+++ b/core/src/thread_parker/linux.rs
@@ -128,10 +128,10 @@ impl super::UnparkHandleT for UnparkHandle {
         // The thread data may have been freed at this point, but it doesn't
         // matter since the syscall will just return EFAULT in that case.
         let r =
-            unsafe { libc::syscall(libc::SYS_futex, self.futex, libc::FUTEX_WAKE | libc::FUTEX_PRIVATE_FLAG, 1) };
+            libc::syscall(libc::SYS_futex, self.futex, libc::FUTEX_WAKE | libc::FUTEX_PRIVATE_FLAG, 1);
         debug_assert!(r == 0 || r == 1 || r == -1);
         if r == -1 {
-            debug_assert_eq!(unsafe { *libc::__errno_location() }, libc::EFAULT);
+            debug_assert_eq!(*libc::__errno_location(), libc::EFAULT);
         }
     }
 }

--- a/core/src/thread_parker/mod.rs
+++ b/core/src/thread_parker/mod.rs
@@ -52,7 +52,7 @@ pub trait UnparkHandleT {
 }
 
 cfg_if! {
-    if #[cfg(all(has_sized_atomics, target_os = "linux"))] {
+    if #[cfg(all(has_sized_atomics, any(target_os = "linux", target_os = "android")))] {
         #[path = "linux.rs"]
         mod imp;
     } else if #[cfg(unix)] {

--- a/core/src/thread_parker/mod.rs
+++ b/core/src/thread_parker/mod.rs
@@ -1,0 +1,86 @@
+use cfg_if::cfg_if;
+use std::time::Instant;
+
+/// Trait for the platform thread parker implementation.
+///
+/// All unsafe methods are unsafe because the Unix thread parker is based on
+/// pthread mutexes and condvars. Those primitives must not be moved and used
+/// from any other memory address than the one they were located at when they
+/// were initialized. As such, it's UB to call any unsafe method on
+/// `ThreadParkerT` if the implementing instance has moved since the last
+/// call to any of the unsafe methods.
+pub trait ThreadParkerT {
+    type UnparkHandle: UnparkHandleT;
+
+    const IS_CHEAP_TO_CONSTRUCT: bool;
+
+    fn new() -> Self;
+
+    /// Prepares the parker. This should be called before adding it to the queue.
+    unsafe fn prepare_park(&self);
+
+    /// Checks if the park timed out. This should be called while holding the
+    /// queue lock after park_until has returned false.
+    unsafe fn timed_out(&self) -> bool;
+
+    /// Parks the thread until it is unparked. This should be called after it has
+    /// been added to the queue, after unlocking the queue.
+    unsafe fn park(&self);
+
+    /// Parks the thread until it is unparked or the timeout is reached. This
+    /// should be called after it has been added to the queue, after unlocking
+    /// the queue. Returns true if we were unparked and false if we timed out.
+    unsafe fn park_until(&self, timeout: Instant) -> bool;
+
+    /// Locks the parker to prevent the target thread from exiting. This is
+    /// necessary to ensure that thread-local ThreadData objects remain valid.
+    /// This should be called while holding the queue lock.
+    unsafe fn unpark_lock(&self) -> Self::UnparkHandle;
+}
+
+/// Handle for a thread that is about to be unparked. We need to mark the thread
+/// as unparked while holding the queue lock, but we delay the actual unparking
+/// until after the queue lock is released.
+pub trait UnparkHandleT {
+    /// Wakes up the parked thread. This should be called after the queue lock is
+    /// released to avoid blocking the queue for too long.
+    ///
+    /// This method is unsafe for the same reason as the unsafe methods in
+    /// `ThreadParkerT`.
+    #[inline]
+    unsafe fn unpark(self);
+}
+
+cfg_if! {
+    if #[cfg(all(has_sized_atomics, target_os = "linux"))] {
+        #[path = "linux.rs"]
+        mod imp;
+    } else if #[cfg(unix)] {
+        #[path = "unix.rs"]
+        mod imp;
+    } else if #[cfg(windows)] {
+        #[path = "windows/mod.rs"]
+        mod imp;
+    } else if #[cfg(all(has_sized_atomics, target_os = "redox"))] {
+        #[path = "redox.rs"]
+        mod imp;
+    } else if #[cfg(all(target_env = "sgx", target_vendor = "fortanix"))] {
+        #[path = "sgx.rs"]
+        mod imp;
+    } else if #[cfg(all(
+        feature = "nightly",
+        target_arch = "wasm32",
+        target_feature = "atomics"
+    ))] {
+        #[path = "wasm.rs"]
+        mod imp;
+    } else if #[cfg(all(feature = "nightly", target_os = "cloudabi"))] {
+        #[path = "cloudabi.rs"]
+        mod imp;
+    } else {
+        #[path = "generic.rs"]
+        mod imp;
+    }
+}
+
+pub use self::imp::{thread_yield, ThreadParker, UnparkHandle};

--- a/core/src/thread_parker/redox.rs
+++ b/core/src/thread_parker/redox.rs
@@ -124,7 +124,7 @@ impl super::UnparkHandleT for UnparkHandle {
     unsafe fn unpark(self) {
         // The thread data may have been freed at this point, but it doesn't
         // matter since the syscall will just return EFAULT in that case.
-        let r = unsafe { futex(self.futex, FUTEX_WAKE, PARKED, 0, ptr::null_mut()) };
+        let r = futex(self.futex, FUTEX_WAKE, PARKED, 0, ptr::null_mut());
         match r {
             Ok(num_woken) => debug_assert!(num_woken == 0 || num_woken == 1),
             Err(Error { errno }) => debug_assert_eq!(errno, EFAULT),

--- a/core/src/thread_parker/redox.rs
+++ b/core/src/thread_parker/redox.rs
@@ -25,43 +25,37 @@ pub struct ThreadParker {
     futex: AtomicI32,
 }
 
-impl ThreadParker {
-    pub const IS_CHEAP_TO_CONSTRUCT: bool = true;
+impl super::ThreadParkerT for ThreadParker {
+    type UnparkHandle = UnparkHandle;
+
+    const IS_CHEAP_TO_CONSTRUCT: bool = true;
 
     #[inline]
-    pub fn new() -> ThreadParker {
+    fn new() -> ThreadParker {
         ThreadParker {
             futex: AtomicI32::new(UNPARKED),
         }
     }
 
-    // Prepares the parker. This should be called before adding it to the queue.
     #[inline]
-    pub fn prepare_park(&self) {
+    unsafe fn prepare_park(&self) {
         self.futex.store(PARKED, Ordering::Relaxed);
     }
 
-    // Checks if the park timed out. This should be called while holding the
-    // queue lock after park_until has returned false.
     #[inline]
-    pub fn timed_out(&self) -> bool {
+    unsafe fn timed_out(&self) -> bool {
         self.futex.load(Ordering::Relaxed) != UNPARKED
     }
 
-    // Parks the thread until it is unparked. This should be called after it has
-    // been added to the queue, after unlocking the queue.
     #[inline]
-    pub fn park(&self) {
+    unsafe fn park(&self) {
         while self.futex.load(Ordering::Acquire) != UNPARKED {
             self.futex_wait(None);
         }
     }
 
-    // Parks the thread until it is unparked or the timeout is reached. This
-    // should be called after it has been added to the queue, after unlocking
-    // the queue. Returns true if we were unparked and false if we timed out.
     #[inline]
-    pub fn park_until(&self, timeout: Instant) -> bool {
+    unsafe fn park_until(&self, timeout: Instant) -> bool {
         while self.futex.load(Ordering::Acquire) != UNPARKED {
             let now = Instant::now();
             if timeout <= now {
@@ -82,6 +76,16 @@ impl ThreadParker {
         true
     }
 
+    #[inline]
+    unsafe fn unpark_lock(&self) -> UnparkHandle {
+        // We don't need to lock anything, just clear the state
+        self.futex.store(UNPARKED, Ordering::Release);
+
+        UnparkHandle { futex: self.ptr() }
+    }
+}
+
+impl ThreadParker {
     #[inline]
     fn futex_wait(&self, ts: Option<TimeSpec>) {
         let ts_ptr = ts
@@ -105,35 +109,19 @@ impl ThreadParker {
         }
     }
 
-    // Locks the parker to prevent the target thread from exiting. This is
-    // necessary to ensure that thread-local ThreadData objects remain valid.
-    // This should be called while holding the queue lock.
-    #[inline]
-    pub fn unpark_lock(&self) -> UnparkHandle {
-        // We don't need to lock anything, just clear the state
-        self.futex.store(UNPARKED, Ordering::Release);
-
-        UnparkHandle { futex: self.ptr() }
-    }
-
     #[inline]
     fn ptr(&self) -> *mut i32 {
         &self.futex as *const AtomicI32 as *mut i32
     }
 }
 
-// Handle for a thread that is about to be unparked. We need to mark the thread
-// as unparked while holding the queue lock, but we delay the actual unparking
-// until after the queue lock is released.
 pub struct UnparkHandle {
     futex: *mut i32,
 }
 
-impl UnparkHandle {
-    // Wakes up the parked thread. This should be called after the queue lock is
-    // released to avoid blocking the queue for too long.
+impl super::UnparkHandleT for UnparkHandle {
     #[inline]
-    pub fn unpark(self) {
+    unsafe fn unpark(self) {
         // The thread data may have been freed at this point, but it doesn't
         // matter since the syscall will just return EFAULT in that case.
         let r = unsafe { futex(self.futex, FUTEX_WAKE, PARKED, 0, ptr::null_mut()) };

--- a/core/src/thread_parker/sgx.rs
+++ b/core/src/thread_parker/sgx.rs
@@ -25,70 +25,56 @@ pub struct ThreadParker {
     tcs: Tcs,
 }
 
-impl ThreadParker {
-    pub const IS_CHEAP_TO_CONSTRUCT: bool = true;
+impl super::ThreadParkerT for ThreadParker {
+    type UnparkHandle = UnparkHandle;
+
+    const IS_CHEAP_TO_CONSTRUCT: bool = true;
 
     #[inline]
-    pub fn new() -> ThreadParker {
+    fn new() -> ThreadParker {
         ThreadParker {
             parked: AtomicBool::new(false),
             tcs: current_tcs(),
         }
     }
 
-    // Prepares the parker. This should be called before adding it to the queue.
     #[inline]
-    pub fn prepare_park(&self) {
+    unsafe fn prepare_park(&self) {
         self.parked.store(true, Ordering::Relaxed);
     }
 
-    // Checks if the park timed out. This should be called while holding the
-    // queue lock after park_until has returned false.
     #[inline]
-    pub fn timed_out(&self) -> bool {
+    unsafe fn timed_out(&self) -> bool {
         self.parked.load(Ordering::Relaxed)
     }
 
-    // Parks the thread until it is unparked. This should be called after it has
-    // been added to the queue, after unlocking the queue.
     #[inline]
-    pub fn park(&self) {
+    unsafe fn park(&self) {
         while self.parked.load(Ordering::Acquire) {
             let result = usercalls::wait(EV_UNPARK, WAIT_INDEFINITE);
             debug_assert_eq!(result.expect("wait returned error") & EV_UNPARK, EV_UNPARK);
         }
     }
 
-    // Parks the thread until it is unparked or the timeout is reached. This
-    // should be called after it has been added to the queue, after unlocking
-    // the queue. Returns true if we were unparked and false if we timed out.
     #[inline]
-    pub fn park_until(&self, _timeout: Instant) -> bool {
+    unsafe fn park_until(&self, _timeout: Instant) -> bool {
         // FIXME: https://github.com/fortanix/rust-sgx/issues/31
         panic!("timeout not supported in SGX");
     }
 
-    // Locks the parker to prevent the target thread from exiting. This is
-    // necessary to ensure that thread-local ThreadData objects remain valid.
-    // This should be called while holding the queue lock.
     #[inline]
-    pub fn unpark_lock(&self) -> UnparkHandle {
+    unsafe fn unpark_lock(&self) -> UnparkHandle {
         // We don't need to lock anything, just clear the state
         self.parked.store(false, Ordering::Release);
         UnparkHandle(self.tcs)
     }
 }
 
-// Handle for a thread that is about to be unparked. We need to mark the thread
-// as unparked while holding the queue lock, but we delay the actual unparking
-// until after the queue lock is released.
 pub struct UnparkHandle(Tcs);
 
-impl UnparkHandle {
-    // Wakes up the parked thread. This should be called after the queue lock is
-    // released to avoid blocking the queue for too long.
+impl super::UnparkHandleT for UnparkHandle {
     #[inline]
-    pub fn unpark(self) {
+    unsafe fn unpark(self) {
         let result = usercalls::send(EV_UNPARK, Some(self.0));
         if cfg!(debug_assertions) {
             if let Err(error) = result {

--- a/core/src/thread_parker/wasm.rs
+++ b/core/src/thread_parker/wasm.rs
@@ -19,33 +19,30 @@ pub struct ThreadParker {
 const UNPARKED: i32 = 0;
 const PARKED: i32 = 1;
 
-impl ThreadParker {
-    pub const IS_CHEAP_TO_CONSTRUCT: bool = true;
+impl super::ThreadParkerT for ThreadParker {
+    type UnparkHandle = UnparkHandle;
+
+    const IS_CHEAP_TO_CONSTRUCT: bool = true;
 
     #[inline]
-    pub fn new() -> ThreadParker {
+    fn new() -> ThreadParker {
         ThreadParker {
             parked: AtomicI32::new(UNPARKED),
         }
     }
 
-    // Prepares the parker. This should be called before adding it to the queue.
     #[inline]
-    pub fn prepare_park(&self) {
+    unsafe fn prepare_park(&self) {
         self.parked.store(PARKED, Ordering::Relaxed);
     }
 
-    // Checks if the park timed out. This should be called while holding the
-    // queue lock after park_until has returned false.
     #[inline]
-    pub fn timed_out(&self) -> bool {
+    unsafe fn timed_out(&self) -> bool {
         self.parked.load(Ordering::Relaxed) == PARKED
     }
 
-    // Parks the thread until it is unparked. This should be called after it has
-    // been added to the queue, after unlocking the queue.
     #[inline]
-    pub fn park(&self) {
+    unsafe fn park(&self) {
         while self.parked.load(Ordering::Acquire) == PARKED {
             let r = unsafe { wasm32::i32_atomic_wait(self.ptr(), PARKED, -1) };
             // we should have either woken up (0) or got a not-equal due to a
@@ -54,11 +51,8 @@ impl ThreadParker {
         }
     }
 
-    // Parks the thread until it is unparked or the timeout is reached. This
-    // should be called after it has been added to the queue, after unlocking
-    // the queue. Returns true if we were unparked and false if we timed out.
     #[inline]
-    pub fn park_until(&self, timeout: Instant) -> bool {
+    unsafe fn park_until(&self, timeout: Instant) -> bool {
         while self.parked.load(Ordering::Acquire) == PARKED {
             if let Some(left) = timeout.checked_duration_since(Instant::now()) {
                 let nanos_left = i64::try_from(left.as_nanos()).unwrap_or(i64::max_value());
@@ -71,32 +65,26 @@ impl ThreadParker {
         true
     }
 
-    // Locks the parker to prevent the target thread from exiting. This is
-    // necessary to ensure that thread-local ThreadData objects remain valid.
-    // This should be called while holding the queue lock.
     #[inline]
-    pub fn unpark_lock(&self) -> UnparkHandle {
+    unsafe fn unpark_lock(&self) -> UnparkHandle {
         // We don't need to lock anything, just clear the state
         self.parked.store(UNPARKED, Ordering::Release);
         UnparkHandle(self.ptr())
     }
+}
 
+impl ThreadParker {
     #[inline]
     fn ptr(&self) -> *mut i32 {
         &self.parked as *const AtomicI32 as *mut i32
     }
 }
 
-// Handle for a thread that is about to be unparked. We need to mark the thread
-// as unparked while holding the queue lock, but we delay the actual unparking
-// until after the queue lock is released.
 pub struct UnparkHandle(*mut i32);
 
-impl UnparkHandle {
-    // Wakes up the parked thread. This should be called after the queue lock is
-    // released to avoid blocking the queue for too long.
+impl super::UnparkHandleT for UnparkHandle {
     #[inline]
-    pub fn unpark(self) {
+    unsafe fn unpark(self) {
         let num_notified = unsafe { wasm32::atomic_notify(self.0 as *mut i32, 1) };
         debug_assert!(num_notified == 0 || num_notified == 1);
     }

--- a/core/src/thread_parker/windows/mod.rs
+++ b/core/src/thread_parker/windows/mod.rs
@@ -34,7 +34,6 @@ impl Backend {
     }
 
     #[cold]
-    #[inline(never)]
     fn create() -> &'static Backend {
         // Try to create a new Backend
         let backend;

--- a/core/src/word_lock.rs
+++ b/core/src/word_lock.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::spinwait::SpinWait;
-use crate::thread_parker::ThreadParker;
+use crate::thread_parker::{ThreadParker, ThreadParkerT, UnparkHandleT};
 use core::{
     cell::Cell,
     mem, ptr,

--- a/core/src/word_lock.rs
+++ b/core/src/word_lock.rs
@@ -103,7 +103,6 @@ impl WordLock {
     }
 
     #[cold]
-    #[inline(never)]
     fn lock_slow(&self) {
         let mut spinwait = SpinWait::new();
         let mut state = self.state.load(Ordering::Relaxed);
@@ -171,7 +170,6 @@ impl WordLock {
     }
 
     #[cold]
-    #[inline(never)]
     fn unlock_slow(&self) {
         let mut state = self.state.load(Ordering::Relaxed);
         loop {

--- a/core/src/word_lock.rs
+++ b/core/src/word_lock.rs
@@ -48,10 +48,7 @@ impl ThreadData {
 
 // Invokes the given closure with a reference to the current thread `ThreadData`.
 #[inline]
-fn with_thread_data<F, T>(f: F) -> T
-where
-    F: FnOnce(&ThreadData) -> T,
-{
+fn with_thread_data<T>(f: impl FnOnce(&ThreadData) -> T) -> T {
     let mut thread_data_ptr = ptr::null();
     // If ThreadData is expensive to construct, then we want to use a cached
     // version in thread-local storage if possible.

--- a/src/condvar.rs
+++ b/src/condvar.rs
@@ -129,7 +129,6 @@ impl Condvar {
     }
 
     #[cold]
-    #[inline(never)]
     fn notify_one_slow(&self, mutex: *mut RawMutex) -> bool {
         unsafe {
             // Unpark one thread and requeue the rest onto the mutex
@@ -191,7 +190,6 @@ impl Condvar {
     }
 
     #[cold]
-    #[inline(never)]
     fn notify_all_slow(&self, mutex: *mut RawMutex) -> usize {
         unsafe {
             // Unpark one thread and requeue the rest onto the mutex

--- a/src/once.rs
+++ b/src/once.rs
@@ -209,7 +209,6 @@ impl Once {
     // currently no way to take an `FnOnce` and call it via virtual dispatch
     // without some allocation overhead.
     #[cold]
-    #[inline(never)]
     fn call_once_slow(&self, ignore_poison: bool, f: &mut dyn FnMut(OnceState)) {
         let mut spinwait = SpinWait::new();
         let mut state = self.0.load(Ordering::Relaxed);

--- a/src/raw_mutex.rs
+++ b/src/raw_mutex.rs
@@ -174,7 +174,6 @@ impl RawMutex {
     }
 
     #[cold]
-    #[inline(never)]
     fn lock_slow(&self, timeout: Option<Instant>) -> bool {
         let mut spinwait = SpinWait::new();
         let mut state = self.state.load(Ordering::Relaxed);
@@ -253,7 +252,6 @@ impl RawMutex {
     }
 
     #[cold]
-    #[inline(never)]
     fn unlock_slow(&self, force_fair: bool) {
         // Unpark one thread and leave the parked bit set if there might
         // still be parked threads on this address.
@@ -285,7 +283,6 @@ impl RawMutex {
     }
 
     #[cold]
-    #[inline(never)]
     fn bump_slow(&self) {
         unsafe { deadlock::release_resource(self as *const _ as usize) };
         self.unlock_slow(true);

--- a/src/raw_rwlock.rs
+++ b/src/raw_rwlock.rs
@@ -492,7 +492,6 @@ impl RawRwLock {
     }
 
     #[cold]
-    #[inline(never)]
     fn try_lock_shared_slow(&self, recursive: bool) -> bool {
         let mut state = self.state.load(Ordering::Relaxed);
         loop {
@@ -541,7 +540,6 @@ impl RawRwLock {
     }
 
     #[cold]
-    #[inline(never)]
     fn try_lock_upgradable_slow(&self) -> bool {
         let mut state = self.state.load(Ordering::Relaxed);
         loop {
@@ -565,7 +563,6 @@ impl RawRwLock {
     }
 
     #[cold]
-    #[inline(never)]
     fn lock_exclusive_slow(&self, timeout: Option<Instant>) -> bool {
         // Step 1: grab exclusive ownership of WRITER_BIT
         let timed_out = !self.lock_common(
@@ -600,7 +597,6 @@ impl RawRwLock {
     }
 
     #[cold]
-    #[inline(never)]
     fn unlock_exclusive_slow(&self, force_fair: bool) {
         // There are threads to unpark. Try to unpark as many as we can.
         let callback = |mut new_state, result: UnparkResult| {
@@ -626,7 +622,6 @@ impl RawRwLock {
     }
 
     #[cold]
-    #[inline(never)]
     fn lock_shared_slow(&self, recursive: bool, timeout: Option<Instant>) -> bool {
         self.lock_common(
             timeout,
@@ -676,7 +671,6 @@ impl RawRwLock {
     }
 
     #[cold]
-    #[inline(never)]
     fn unlock_shared_slow(&self) {
         // At this point WRITER_PARKED_BIT is set and READER_MASK is empty. We
         // just need to wake up a potentially sleeping pending writer.
@@ -695,7 +689,6 @@ impl RawRwLock {
     }
 
     #[cold]
-    #[inline(never)]
     fn lock_upgradable_slow(&self, timeout: Option<Instant>) -> bool {
         self.lock_common(
             timeout,
@@ -734,7 +727,6 @@ impl RawRwLock {
     }
 
     #[cold]
-    #[inline(never)]
     fn unlock_upgradable_slow(&self, force_fair: bool) {
         // Just release the lock if there are no parked threads.
         let mut state = self.state.load(Ordering::Relaxed);
@@ -801,7 +793,6 @@ impl RawRwLock {
     }
 
     #[cold]
-    #[inline(never)]
     fn try_upgrade_slow(&self) -> bool {
         let mut state = self.state.load(Ordering::Relaxed);
         loop {
@@ -821,13 +812,11 @@ impl RawRwLock {
     }
 
     #[cold]
-    #[inline(never)]
     fn upgrade_slow(&self, timeout: Option<Instant>) -> bool {
         self.wait_for_readers(timeout, ONE_READER | UPGRADABLE_BIT)
     }
 
     #[cold]
-    #[inline(never)]
     fn downgrade_slow(&self) {
         // We only reach this point if PARKED_BIT is set.
         let callback = |_, result: UnparkResult| {
@@ -841,7 +830,6 @@ impl RawRwLock {
     }
 
     #[cold]
-    #[inline(never)]
     fn downgrade_to_upgradable_slow(&self) {
         // We only reach this point if PARKED_BIT is set.
         let callback = |_, result: UnparkResult| {
@@ -855,14 +843,12 @@ impl RawRwLock {
     }
 
     #[cold]
-    #[inline(never)]
     fn bump_shared_slow(&self) {
         self.unlock_shared();
         self.lock_shared();
     }
 
     #[cold]
-    #[inline(never)]
     fn bump_exclusive_slow(&self) {
         self.deadlock_release();
         self.unlock_exclusive_slow(true);
@@ -870,7 +856,6 @@ impl RawRwLock {
     }
 
     #[cold]
-    #[inline(never)]
     fn bump_upgradable_slow(&self) {
         self.deadlock_release();
         self.unlock_upgradable_slow(true);


### PR DESCRIPTION
Here I address some of the fairly low hanging fruit from https://github.com/faern/parking_lot/pull/1

1. Simplify `unlock_bucket_pair`. https://github.com/faern/parking_lot/pull/1/files#r283107487
2. Use `impl Trait` instead of a bunch of generics around the park/unpark calls. https://github.com/faern/parking_lot/pull/1/files#diff-f0c71d8c95c3701fb57bafd0a8198201R625
3. Just re-format a comment.
4. Remove all `#[inline(never)]`. https://github.com/faern/parking_lot/pull/1/files#diff-936abe3ecea632b68dddc509e87c7c39R142
4. Create a separate trait for the `ThreadParker` and `UnparkHandle` types. So we have a single place to stick the documentation. And to better ensure all implementers have the exact same API. https://github.com/faern/parking_lot/pull/1/files#r283155912

cc @alexcrichton 