### PR TITLE
Run latest rustfmt (1.2.2-nightly)

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -39,16 +39,9 @@
 
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
+#![cfg_attr(all(target_env = "sgx", target_vendor = "fortanix"), feature(sgx_platform))]
 #![cfg_attr(
-    all(target_env = "sgx", target_vendor = "fortanix"),
-    feature(sgx_platform)
-)]
-#![cfg_attr(
-    all(
-        feature = "nightly",
-        target_arch = "wasm32",
-        target_feature = "atomics"
-    ),
+    all(feature = "nightly", target_arch = "wasm32", target_feature = "atomics"),
     feature(checked_duration_since, stdsimd)
 )]
 #![cfg_attr(

--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -47,11 +47,7 @@ impl HashTable {
             entries.push(Bucket::new(now));
         }
 
-        Box::new(HashTable {
-            entries: entries.into_boxed_slice(),
-            hash_bits,
-            _prev: prev,
-        })
+        Box::new(HashTable { entries: entries.into_boxed_slice(), hash_bits, _prev: prev })
     }
 }
 
@@ -91,10 +87,7 @@ struct FairTimeout {
 impl FairTimeout {
     #[inline]
     fn new(timeout: Instant) -> FairTimeout {
-        FairTimeout {
-            timeout,
-            rng: SmallRng::from_entropy(),
-        }
+        FairTimeout { timeout, rng: SmallRng::from_entropy() }
     }
 
     // Determine whether we should force a fair unlock, and update the timeout
@@ -186,11 +179,7 @@ fn get_hashtable() -> *mut HashTable {
     let table = HASHTABLE.load(Ordering::Acquire);
 
     // If there is no table, create one
-    if table.is_null() {
-        create_hashtable()
-    } else {
-        table
-    }
+    if table.is_null() { create_hashtable() } else { table }
 }
 
 // Get a pointer to the latest hash table, creating one if it doesn't exist yet.
@@ -229,12 +218,7 @@ unsafe fn grow_hashtable(num_threads: usize) {
         // If this fails then it means some other thread created the hash
         // table first.
         if HASHTABLE
-            .compare_exchange(
-                ptr::null_mut(),
-                new_table,
-                Ordering::Release,
-                Ordering::Relaxed,
-            )
+            .compare_exchange(ptr::null_mut(), new_table, Ordering::Release, Ordering::Relaxed)
             .is_ok()
         {
             return;
@@ -283,9 +267,7 @@ unsafe fn grow_hashtable(num_threads: usize) {
             if new_table.entries[hash].queue_tail.get().is_null() {
                 new_table.entries[hash].queue_head.set(current);
             } else {
-                (*new_table.entries[hash].queue_tail.get())
-                    .next_in_queue
-                    .set(current);
+                (*new_table.entries[hash].queue_tail.get()).next_in_queue.set(current);
             }
             new_table.entries[hash].queue_tail.set(current);
             (*current).next_in_queue.set(ptr::null());
@@ -911,9 +893,7 @@ where
     if !requeue_threads.is_null() {
         (*requeue_threads_tail).next_in_queue.set(ptr::null());
         if !bucket_to.queue_head.get().is_null() {
-            (*bucket_to.queue_tail.get())
-                .next_in_queue
-                .set(requeue_threads);
+            (*bucket_to.queue_tail.get()).next_in_queue.set(requeue_threads);
         } else {
             bucket_to.queue_head.set(requeue_threads);
         }
@@ -1313,19 +1293,9 @@ mod deadlock_impl {
 
     // normalize a cycle to start with the "smallest" node
     fn normalize_cycle<T: Ord + Copy + Clone>(input: &[T]) -> Vec<T> {
-        let min_pos = input
-            .iter()
-            .enumerate()
-            .min_by_key(|&(_, &t)| t)
-            .map(|(p, _)| p)
-            .unwrap_or(0);
-        input
-            .iter()
-            .cycle()
-            .skip(min_pos)
-            .take(input.len())
-            .cloned()
-            .collect()
+        let min_pos =
+            input.iter().enumerate().min_by_key(|&(_, &t)| t).map(|(p, _)| p).unwrap_or(0);
+        input.iter().cycle().skip(min_pos).take(input.len()).cloned().collect()
     }
 
     // returns all thread cycles in the wait graph
@@ -1337,9 +1307,7 @@ mod deadlock_impl {
         let mut cycles = HashSet::new();
         let mut path = Vec::with_capacity(g.node_bound());
         // start from threads to get the correct threads cycle
-        let threads = g
-            .nodes()
-            .filter(|n| if let &Thread(_) = n { true } else { false });
+        let threads = g.nodes().filter(|n| if let &Thread(_) = n { true } else { false });
 
         depth_first_search(g, threads, |e| match e {
             DfsEvent::Discover(Thread(n), _) => path.push(n),

--- a/core/src/word_lock.rs
+++ b/core/src/word_lock.rs
@@ -81,9 +81,7 @@ pub struct WordLock {
 }
 
 impl WordLock {
-    pub const INIT: WordLock = WordLock {
-        state: AtomicUsize::new(0),
-    };
+    pub const INIT: WordLock = WordLock { state: AtomicUsize::new(0) };
 
     #[inline]
     pub fn lock(&self) {

--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -133,20 +133,14 @@ impl<R: RawMutex, T> Mutex<R, T> {
     #[cfg(feature = "nightly")]
     #[inline]
     pub const fn new(val: T) -> Mutex<R, T> {
-        Mutex {
-            data: UnsafeCell::new(val),
-            raw: R::INIT,
-        }
+        Mutex { data: UnsafeCell::new(val), raw: R::INIT }
     }
 
     /// Creates a new mutex in an unlocked state ready for use.
     #[cfg(not(feature = "nightly"))]
     #[inline]
     pub fn new(val: T) -> Mutex<R, T> {
-        Mutex {
-            data: UnsafeCell::new(val),
-            raw: R::INIT,
-        }
+        Mutex { data: UnsafeCell::new(val), raw: R::INIT }
     }
 
     /// Consumes this mutex, returning the underlying data.
@@ -160,10 +154,7 @@ impl<R: RawMutex, T> Mutex<R, T> {
 impl<R: RawMutex, T: ?Sized> Mutex<R, T> {
     #[inline]
     fn guard(&self) -> MutexGuard<'_, R, T> {
-        MutexGuard {
-            mutex: self,
-            marker: PhantomData,
-        }
+        MutexGuard { mutex: self, marker: PhantomData }
     }
 
     /// Acquires a mutex, blocking the current thread until it is able to do so.
@@ -190,11 +181,7 @@ impl<R: RawMutex, T: ?Sized> Mutex<R, T> {
     /// This function does not block.
     #[inline]
     pub fn try_lock(&self) -> Option<MutexGuard<'_, R, T>> {
-        if self.raw.try_lock() {
-            Some(self.guard())
-        } else {
-            None
-        }
+        if self.raw.try_lock() { Some(self.guard()) } else { None }
     }
 
     /// Returns a mutable reference to the underlying data.
@@ -263,11 +250,7 @@ impl<R: RawMutexTimed, T: ?Sized> Mutex<R, T> {
     /// be unlocked when the guard is dropped.
     #[inline]
     pub fn try_lock_for(&self, timeout: R::Duration) -> Option<MutexGuard<'_, R, T>> {
-        if self.raw.try_lock_for(timeout) {
-            Some(self.guard())
-        } else {
-            None
-        }
+        if self.raw.try_lock_for(timeout) { Some(self.guard()) } else { None }
     }
 
     /// Attempts to acquire this lock until a timeout is reached.
@@ -277,11 +260,7 @@ impl<R: RawMutexTimed, T: ?Sized> Mutex<R, T> {
     /// be unlocked when the guard is dropped.
     #[inline]
     pub fn try_lock_until(&self, timeout: R::Instant) -> Option<MutexGuard<'_, R, T>> {
-        if self.raw.try_lock_until(timeout) {
-            Some(self.guard())
-        } else {
-            None
-        }
+        if self.raw.try_lock_until(timeout) { Some(self.guard()) } else { None }
     }
 }
 
@@ -311,9 +290,7 @@ impl<R: RawMutex, T: ?Sized + fmt::Debug> fmt::Debug for Mutex<R, T> {
                     }
                 }
 
-                f.debug_struct("Mutex")
-                    .field("data", &LockedPlaceholder)
-                    .finish()
+                f.debug_struct("Mutex").field("data", &LockedPlaceholder).finish()
             }
         }
     }
@@ -354,11 +331,7 @@ impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> MutexGuard<'a, R, T> {
         let raw = &s.mutex.raw;
         let data = f(unsafe { &mut *s.mutex.data.get() });
         mem::forget(s);
-        MappedMutexGuard {
-            raw,
-            data,
-            marker: PhantomData,
-        }
+        MappedMutexGuard { raw, data, marker: PhantomData }
     }
 
     /// Attempts to make  a new `MappedMutexGuard` for a component of the
@@ -381,11 +354,7 @@ impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> MutexGuard<'a, R, T> {
             None => return Err(s),
         };
         mem::forget(s);
-        Ok(MappedMutexGuard {
-            raw,
-            data,
-            marker: PhantomData,
-        })
+        Ok(MappedMutexGuard { raw, data, marker: PhantomData })
     }
 
     /// Temporarily unlocks the mutex to execute the given function.
@@ -526,11 +495,7 @@ impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> MappedMutexGuard<'a, R, T> {
         let raw = s.raw;
         let data = f(unsafe { &mut *s.data });
         mem::forget(s);
-        MappedMutexGuard {
-            raw,
-            data,
-            marker: PhantomData,
-        }
+        MappedMutexGuard { raw, data, marker: PhantomData }
     }
 
     /// Attempts to make  a new `MappedMutexGuard` for a component of the
@@ -553,11 +518,7 @@ impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> MappedMutexGuard<'a, R, T> {
             None => return Err(s),
         };
         mem::forget(s);
-        Ok(MappedMutexGuard {
-            raw,
-            data,
-            marker: PhantomData,
-        })
+        Ok(MappedMutexGuard { raw, data, marker: PhantomData })
     }
 }
 

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -52,10 +52,7 @@ impl<R: RawMutex, G: GetThreadId> RawReentrantMutex<R, G> {
         let id = self.get_thread_id.nonzero_thread_id();
         if self.owner.load(Ordering::Relaxed) == id {
             self.lock_count.set(
-                self.lock_count
-                    .get()
-                    .checked_add(1)
-                    .expect("ReentrantMutex lock count overflow"),
+                self.lock_count.get().checked_add(1).expect("ReentrantMutex lock count overflow"),
             );
         } else {
             if !try_lock() {
@@ -225,10 +222,7 @@ impl<R: RawMutex, G: GetThreadId, T> ReentrantMutex<R, G, T> {
 impl<R: RawMutex, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     #[inline]
     fn guard(&self) -> ReentrantMutexGuard<'_, R, G, T> {
-        ReentrantMutexGuard {
-            remutex: &self,
-            marker: PhantomData,
-        }
+        ReentrantMutexGuard { remutex: &self, marker: PhantomData }
     }
 
     /// Acquires a reentrant mutex, blocking the current thread until it is able
@@ -256,11 +250,7 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     /// This function does not block.
     #[inline]
     pub fn try_lock(&self) -> Option<ReentrantMutexGuard<'_, R, G, T>> {
-        if self.raw.try_lock() {
-            Some(self.guard())
-        } else {
-            None
-        }
+        if self.raw.try_lock() { Some(self.guard()) } else { None }
     }
 
     /// Returns a mutable reference to the underlying data.
@@ -329,11 +319,7 @@ impl<R: RawMutexTimed, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     /// be unlocked when the guard is dropped.
     #[inline]
     pub fn try_lock_for(&self, timeout: R::Duration) -> Option<ReentrantMutexGuard<'_, R, G, T>> {
-        if self.raw.try_lock_for(timeout) {
-            Some(self.guard())
-        } else {
-            None
-        }
+        if self.raw.try_lock_for(timeout) { Some(self.guard()) } else { None }
     }
 
     /// Attempts to acquire this lock until a timeout is reached.
@@ -343,11 +329,7 @@ impl<R: RawMutexTimed, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     /// be unlocked when the guard is dropped.
     #[inline]
     pub fn try_lock_until(&self, timeout: R::Instant) -> Option<ReentrantMutexGuard<'_, R, G, T>> {
-        if self.raw.try_lock_until(timeout) {
-            Some(self.guard())
-        } else {
-            None
-        }
+        if self.raw.try_lock_until(timeout) { Some(self.guard()) } else { None }
     }
 }
 
@@ -368,10 +350,7 @@ impl<R: RawMutex, G: GetThreadId, T> From<T> for ReentrantMutex<R, G, T> {
 impl<R: RawMutex, G: GetThreadId, T: ?Sized + fmt::Debug> fmt::Debug for ReentrantMutex<R, G, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.try_lock() {
-            Some(guard) => f
-                .debug_struct("ReentrantMutex")
-                .field("data", &&*guard)
-                .finish(),
+            Some(guard) => f.debug_struct("ReentrantMutex").field("data", &&*guard).finish(),
             None => {
                 struct LockedPlaceholder;
                 impl fmt::Debug for LockedPlaceholder {
@@ -380,9 +359,7 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized + fmt::Debug> fmt::Debug for Reentra
                     }
                 }
 
-                f.debug_struct("ReentrantMutex")
-                    .field("data", &LockedPlaceholder)
-                    .finish()
+                f.debug_struct("ReentrantMutex").field("data", &LockedPlaceholder).finish()
             }
         }
     }
@@ -426,11 +403,7 @@ impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> ReentrantMutexGu
         let raw = &s.remutex.raw;
         let data = f(unsafe { &*s.remutex.data.get() });
         mem::forget(s);
-        MappedReentrantMutexGuard {
-            raw,
-            data,
-            marker: PhantomData,
-        }
+        MappedReentrantMutexGuard { raw, data, marker: PhantomData }
     }
 
     /// Attempts to make  a new `MappedReentrantMutexGuard` for a component of the
@@ -456,11 +429,7 @@ impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> ReentrantMutexGu
             None => return Err(s),
         };
         mem::forget(s);
-        Ok(MappedReentrantMutexGuard {
-            raw,
-            data,
-            marker: PhantomData,
-        })
+        Ok(MappedReentrantMutexGuard { raw, data, marker: PhantomData })
     }
 
     /// Temporarily unlocks the mutex to execute the given function.
@@ -605,11 +574,7 @@ impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a>
         let raw = s.raw;
         let data = f(unsafe { &*s.data });
         mem::forget(s);
-        MappedReentrantMutexGuard {
-            raw,
-            data,
-            marker: PhantomData,
-        }
+        MappedReentrantMutexGuard { raw, data, marker: PhantomData }
     }
 
     /// Attempts to make  a new `MappedReentrantMutexGuard` for a component of the
@@ -635,11 +600,7 @@ impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a>
             None => return Err(s),
         };
         mem::forget(s);
-        Ok(MappedReentrantMutexGuard {
-            raw,
-            data,
-            marker: PhantomData,
-        })
+        Ok(MappedReentrantMutexGuard { raw, data, marker: PhantomData })
     }
 }
 

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -270,20 +270,14 @@ impl<R: RawRwLock, T> RwLock<R, T> {
     #[cfg(feature = "nightly")]
     #[inline]
     pub const fn new(val: T) -> RwLock<R, T> {
-        RwLock {
-            data: UnsafeCell::new(val),
-            raw: R::INIT,
-        }
+        RwLock { data: UnsafeCell::new(val), raw: R::INIT }
     }
 
     /// Creates a new instance of an `RwLock<T>` which is unlocked.
     #[cfg(not(feature = "nightly"))]
     #[inline]
     pub fn new(val: T) -> RwLock<R, T> {
-        RwLock {
-            data: UnsafeCell::new(val),
-            raw: R::INIT,
-        }
+        RwLock { data: UnsafeCell::new(val), raw: R::INIT }
     }
 
     /// Consumes this `RwLock`, returning the underlying data.
@@ -297,18 +291,12 @@ impl<R: RawRwLock, T> RwLock<R, T> {
 impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     #[inline]
     fn read_guard(&self) -> RwLockReadGuard<'_, R, T> {
-        RwLockReadGuard {
-            rwlock: self,
-            marker: PhantomData,
-        }
+        RwLockReadGuard { rwlock: self, marker: PhantomData }
     }
 
     #[inline]
     fn write_guard(&self) -> RwLockWriteGuard<'_, R, T> {
-        RwLockWriteGuard {
-            rwlock: self,
-            marker: PhantomData,
-        }
+        RwLockWriteGuard { rwlock: self, marker: PhantomData }
     }
 
     /// Locks this `RwLock` with shared read access, blocking the current thread
@@ -338,11 +326,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     /// This function does not block.
     #[inline]
     pub fn try_read(&self) -> Option<RwLockReadGuard<'_, R, T>> {
-        if self.raw.try_lock_shared() {
-            Some(self.read_guard())
-        } else {
-            None
-        }
+        if self.raw.try_lock_shared() { Some(self.read_guard()) } else { None }
     }
 
     /// Locks this `RwLock` with exclusive write access, blocking the current
@@ -368,11 +352,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     /// This function does not block.
     #[inline]
     pub fn try_write(&self) -> Option<RwLockWriteGuard<'_, R, T>> {
-        if self.raw.try_lock_exclusive() {
-            Some(self.write_guard())
-        } else {
-            None
-        }
+        if self.raw.try_lock_exclusive() { Some(self.write_guard()) } else { None }
     }
 
     /// Returns a mutable reference to the underlying data.
@@ -474,11 +454,7 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     /// release the shared access when it is dropped.
     #[inline]
     pub fn try_read_for(&self, timeout: R::Duration) -> Option<RwLockReadGuard<'_, R, T>> {
-        if self.raw.try_lock_shared_for(timeout) {
-            Some(self.read_guard())
-        } else {
-            None
-        }
+        if self.raw.try_lock_shared_for(timeout) { Some(self.read_guard()) } else { None }
     }
 
     /// Attempts to acquire this `RwLock` with shared read access until a timeout
@@ -489,11 +465,7 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     /// release the shared access when it is dropped.
     #[inline]
     pub fn try_read_until(&self, timeout: R::Instant) -> Option<RwLockReadGuard<'_, R, T>> {
-        if self.raw.try_lock_shared_until(timeout) {
-            Some(self.read_guard())
-        } else {
-            None
-        }
+        if self.raw.try_lock_shared_until(timeout) { Some(self.read_guard()) } else { None }
     }
 
     /// Attempts to acquire this `RwLock` with exclusive write access until a
@@ -504,11 +476,7 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     /// release the exclusive access when it is dropped.
     #[inline]
     pub fn try_write_for(&self, timeout: R::Duration) -> Option<RwLockWriteGuard<'_, R, T>> {
-        if self.raw.try_lock_exclusive_for(timeout) {
-            Some(self.write_guard())
-        } else {
-            None
-        }
+        if self.raw.try_lock_exclusive_for(timeout) { Some(self.write_guard()) } else { None }
     }
 
     /// Attempts to acquire this `RwLock` with exclusive write access until a
@@ -519,11 +487,7 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     /// release the exclusive access when it is dropped.
     #[inline]
     pub fn try_write_until(&self, timeout: R::Instant) -> Option<RwLockWriteGuard<'_, R, T>> {
-        if self.raw.try_lock_exclusive_until(timeout) {
-            Some(self.write_guard())
-        } else {
-            None
-        }
+        if self.raw.try_lock_exclusive_until(timeout) { Some(self.write_guard()) } else { None }
     }
 }
 
@@ -561,11 +525,7 @@ impl<R: RawRwLockRecursive, T: ?Sized> RwLock<R, T> {
     /// This function does not block.
     #[inline]
     pub fn try_read_recursive(&self) -> Option<RwLockReadGuard<'_, R, T>> {
-        if self.raw.try_lock_shared_recursive() {
-            Some(self.read_guard())
-        } else {
-            None
-        }
+        if self.raw.try_lock_shared_recursive() { Some(self.read_guard()) } else { None }
     }
 }
 
@@ -585,11 +545,7 @@ impl<R: RawRwLockRecursiveTimed, T: ?Sized> RwLock<R, T> {
         &self,
         timeout: R::Duration,
     ) -> Option<RwLockReadGuard<'_, R, T>> {
-        if self.raw.try_lock_shared_recursive_for(timeout) {
-            Some(self.read_guard())
-        } else {
-            None
-        }
+        if self.raw.try_lock_shared_recursive_for(timeout) { Some(self.read_guard()) } else { None }
     }
 
     /// Attempts to acquire this `RwLock` with shared read access until a timeout
@@ -614,10 +570,7 @@ impl<R: RawRwLockRecursiveTimed, T: ?Sized> RwLock<R, T> {
 impl<R: RawRwLockUpgrade, T: ?Sized> RwLock<R, T> {
     #[inline]
     fn upgradable_guard(&self) -> RwLockUpgradableReadGuard<'_, R, T> {
-        RwLockUpgradableReadGuard {
-            rwlock: self,
-            marker: PhantomData,
-        }
+        RwLockUpgradableReadGuard { rwlock: self, marker: PhantomData }
     }
 
     /// Locks this `RwLock` with upgradable read access, blocking the current thread
@@ -644,11 +597,7 @@ impl<R: RawRwLockUpgrade, T: ?Sized> RwLock<R, T> {
     /// This function does not block.
     #[inline]
     pub fn try_upgradable_read(&self) -> Option<RwLockUpgradableReadGuard<'_, R, T>> {
-        if self.raw.try_lock_upgradable() {
-            Some(self.upgradable_guard())
-        } else {
-            None
-        }
+        if self.raw.try_lock_upgradable() { Some(self.upgradable_guard()) } else { None }
     }
 }
 
@@ -664,11 +613,7 @@ impl<R: RawRwLockUpgradeTimed, T: ?Sized> RwLock<R, T> {
         &self,
         timeout: R::Duration,
     ) -> Option<RwLockUpgradableReadGuard<'_, R, T>> {
-        if self.raw.try_lock_upgradable_for(timeout) {
-            Some(self.upgradable_guard())
-        } else {
-            None
-        }
+        if self.raw.try_lock_upgradable_for(timeout) { Some(self.upgradable_guard()) } else { None }
     }
 
     /// Attempts to acquire this `RwLock` with upgradable read access until a timeout
@@ -716,9 +661,7 @@ impl<R: RawRwLock, T: ?Sized + fmt::Debug> fmt::Debug for RwLock<R, T> {
                     }
                 }
 
-                f.debug_struct("RwLock")
-                    .field("data", &LockedPlaceholder)
-                    .finish()
+                f.debug_struct("RwLock").field("data", &LockedPlaceholder).finish()
             }
         }
     }
@@ -756,11 +699,7 @@ impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> RwLockReadGuard<'a, R, T> {
         let raw = &s.rwlock.raw;
         let data = f(unsafe { &*s.rwlock.data.get() });
         mem::forget(s);
-        MappedRwLockReadGuard {
-            raw,
-            data,
-            marker: PhantomData,
-        }
+        MappedRwLockReadGuard { raw, data, marker: PhantomData }
     }
 
     /// Attempts to make  a new `MappedRwLockReadGuard` for a component of the
@@ -783,11 +722,7 @@ impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> RwLockReadGuard<'a, R, T> {
             None => return Err(s),
         };
         mem::forget(s);
-        Ok(MappedRwLockReadGuard {
-            raw,
-            data,
-            marker: PhantomData,
-        })
+        Ok(MappedRwLockReadGuard { raw, data, marker: PhantomData })
     }
 
     /// Temporarily unlocks the `RwLock` to execute the given function.
@@ -917,11 +852,7 @@ impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> RwLockWriteGuard<'a, R, T> {
         let raw = &s.rwlock.raw;
         let data = f(unsafe { &mut *s.rwlock.data.get() });
         mem::forget(s);
-        MappedRwLockWriteGuard {
-            raw,
-            data,
-            marker: PhantomData,
-        }
+        MappedRwLockWriteGuard { raw, data, marker: PhantomData }
     }
 
     /// Attempts to make  a new `MappedRwLockWriteGuard` for a component of the
@@ -944,11 +875,7 @@ impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> RwLockWriteGuard<'a, R, T> {
             None => return Err(s),
         };
         mem::forget(s);
-        Ok(MappedRwLockWriteGuard {
-            raw,
-            data,
-            marker: PhantomData,
-        })
+        Ok(MappedRwLockWriteGuard { raw, data, marker: PhantomData })
     }
 
     /// Temporarily unlocks the `RwLock` to execute the given function.
@@ -977,10 +904,7 @@ impl<'a, R: RawRwLockDowngrade + 'a, T: ?Sized + 'a> RwLockWriteGuard<'a, R, T> 
         s.rwlock.raw.downgrade();
         let rwlock = s.rwlock;
         mem::forget(s);
-        RwLockReadGuard {
-            rwlock,
-            marker: PhantomData,
-        }
+        RwLockReadGuard { rwlock, marker: PhantomData }
     }
 }
 
@@ -995,10 +919,7 @@ impl<'a, R: RawRwLockUpgradeDowngrade + 'a, T: ?Sized + 'a> RwLockWriteGuard<'a,
         s.rwlock.raw.downgrade_to_upgradable();
         let rwlock = s.rwlock;
         mem::forget(s);
-        RwLockUpgradableReadGuard {
-            rwlock,
-            marker: PhantomData,
-        }
+        RwLockUpgradableReadGuard { rwlock, marker: PhantomData }
     }
 }
 
@@ -1126,10 +1047,7 @@ impl<'a, R: RawRwLockUpgrade + 'a, T: ?Sized + 'a> RwLockUpgradableReadGuard<'a,
         s.rwlock.raw.upgrade();
         let rwlock = s.rwlock;
         mem::forget(s);
-        RwLockWriteGuard {
-            rwlock,
-            marker: PhantomData,
-        }
+        RwLockWriteGuard { rwlock, marker: PhantomData }
     }
 
     /// Tries to atomically upgrade an upgradable read lock into a exclusive write lock.
@@ -1139,10 +1057,7 @@ impl<'a, R: RawRwLockUpgrade + 'a, T: ?Sized + 'a> RwLockUpgradableReadGuard<'a,
         if s.rwlock.raw.try_upgrade() {
             let rwlock = s.rwlock;
             mem::forget(s);
-            Ok(RwLockWriteGuard {
-                rwlock,
-                marker: PhantomData,
-            })
+            Ok(RwLockWriteGuard { rwlock, marker: PhantomData })
         } else {
             Err(s)
         }
@@ -1207,10 +1122,7 @@ impl<'a, R: RawRwLockUpgradeDowngrade + 'a, T: ?Sized + 'a> RwLockUpgradableRead
         s.rwlock.raw.downgrade_upgradable();
         let rwlock = s.rwlock;
         mem::forget(s);
-        RwLockReadGuard {
-            rwlock,
-            marker: PhantomData,
-        }
+        RwLockReadGuard { rwlock, marker: PhantomData }
     }
 }
 
@@ -1227,10 +1139,7 @@ impl<'a, R: RawRwLockUpgradeTimed + 'a, T: ?Sized + 'a> RwLockUpgradableReadGuar
         if s.rwlock.raw.try_upgrade_for(timeout) {
             let rwlock = s.rwlock;
             mem::forget(s);
-            Ok(RwLockWriteGuard {
-                rwlock,
-                marker: PhantomData,
-            })
+            Ok(RwLockWriteGuard { rwlock, marker: PhantomData })
         } else {
             Err(s)
         }
@@ -1249,10 +1158,7 @@ impl<'a, R: RawRwLockUpgradeTimed + 'a, T: ?Sized + 'a> RwLockUpgradableReadGuar
         if s.rwlock.raw.try_upgrade_until(timeout) {
             let rwlock = s.rwlock;
             mem::forget(s);
-            Ok(RwLockWriteGuard {
-                rwlock,
-                marker: PhantomData,
-            })
+            Ok(RwLockWriteGuard { rwlock, marker: PhantomData })
         } else {
             Err(s)
         }
@@ -1333,11 +1239,7 @@ impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> MappedRwLockReadGuard<'a, R, T> {
         let raw = s.raw;
         let data = f(unsafe { &*s.data });
         mem::forget(s);
-        MappedRwLockReadGuard {
-            raw,
-            data,
-            marker: PhantomData,
-        }
+        MappedRwLockReadGuard { raw, data, marker: PhantomData }
     }
 
     /// Attempts to make  a new `MappedRwLockReadGuard` for a component of the
@@ -1360,11 +1262,7 @@ impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> MappedRwLockReadGuard<'a, R, T> {
             None => return Err(s),
         };
         mem::forget(s);
-        Ok(MappedRwLockReadGuard {
-            raw,
-            data,
-            marker: PhantomData,
-        })
+        Ok(MappedRwLockReadGuard { raw, data, marker: PhantomData })
     }
 }
 
@@ -1465,11 +1363,7 @@ impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> MappedRwLockWriteGuard<'a, R, T> {
         let raw = s.raw;
         let data = f(unsafe { &mut *s.data });
         mem::forget(s);
-        MappedRwLockWriteGuard {
-            raw,
-            data,
-            marker: PhantomData,
-        }
+        MappedRwLockWriteGuard { raw, data, marker: PhantomData }
     }
 
     /// Attempts to make  a new `MappedRwLockWriteGuard` for a component of the
@@ -1492,11 +1386,7 @@ impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> MappedRwLockWriteGuard<'a, R, T> {
             None => return Err(s),
         };
         mem::forget(s);
-        Ok(MappedRwLockWriteGuard {
-            raw,
-            data,
-            marker: PhantomData,
-        })
+        Ok(MappedRwLockWriteGuard { raw, data, marker: PhantomData })
     }
 }
 
@@ -1512,11 +1402,7 @@ impl<'a, R: RawRwLockDowngrade + 'a, T: ?Sized + 'a> MappedRwLockWriteGuard<'a, 
         let raw = s.raw;
         let data = s.data;
         mem::forget(s);
-        MappedRwLockReadGuard {
-            raw,
-            data,
-            marker: PhantomData,
-        }
+        MappedRwLockReadGuard { raw, data, marker: PhantomData }
     }
 }
 

--- a/src/condvar.rs
+++ b/src/condvar.rs
@@ -91,9 +91,7 @@ impl Condvar {
     /// notified.
     #[inline]
     pub const fn new() -> Condvar {
-        Condvar {
-            state: AtomicPtr::new(ptr::null_mut()),
-        }
+        Condvar { state: AtomicPtr::new(ptr::null_mut()) }
     }
 
     /// Wakes up one blocked thread on this condvar.
@@ -286,10 +284,7 @@ impl Condvar {
         mutex_guard: &mut MutexGuard<'_, T>,
         timeout: Instant,
     ) -> WaitTimeoutResult {
-        self.wait_until_internal(
-            unsafe { MutexGuard::mutex(mutex_guard).raw() },
-            Some(timeout),
-        )
+        self.wait_until_internal(unsafe { MutexGuard::mutex(mutex_guard).raw() }, Some(timeout))
     }
 
     // This is a non-generic function to reduce the monomorphization cost of
@@ -580,10 +575,8 @@ mod tests {
             let _g = m2.lock();
             c2.notify_one();
         });
-        let timeout_res = c.wait_until(
-            &mut g,
-            Instant::now() + Duration::from_millis(u32::max_value() as u64),
-        );
+        let timeout_res =
+            c.wait_until(&mut g, Instant::now() + Duration::from_millis(u32::max_value() as u64));
         assert!(!timeout_res.timed_out());
         drop(g);
     }

--- a/src/elision.rs
+++ b/src/elision.rs
@@ -25,10 +25,7 @@ pub trait AtomicElisionExt {
 // Indicates whether the target architecture supports lock elision
 #[inline]
 pub fn have_elision() -> bool {
-    cfg!(all(
-        feature = "nightly",
-        any(target_arch = "x86", target_arch = "x86_64"),
-    ))
+    cfg!(all(feature = "nightly", any(target_arch = "x86", target_arch = "x86_64"),))
 }
 
 // This implementation is never actually called because it is guarded by
@@ -62,11 +59,7 @@ impl AtomicElisionExt for AtomicUsize {
                  : "r" (new), "{eax}" (current)
                  : "memory"
                  : "volatile");
-            if prev == current {
-                Ok(prev)
-            } else {
-                Err(prev)
-            }
+            if prev == current { Ok(prev) } else { Err(prev) }
         }
     }
     #[cfg(target_pointer_width = "64")]
@@ -79,11 +72,7 @@ impl AtomicElisionExt for AtomicUsize {
                  : "r" (new), "{rax}" (current)
                  : "memory"
                  : "volatile");
-            if prev == current {
-                Ok(prev)
-            } else {
-                Err(prev)
-            }
+            if prev == current { Ok(prev) } else { Err(prev) }
         }
     }
 

--- a/src/once.rs
+++ b/src/once.rs
@@ -194,9 +194,7 @@ impl Once {
         }
 
         let mut f = Some(f);
-        self.call_once_slow(true, &mut |state| unsafe {
-            f.take().unchecked_unwrap()(state)
-        });
+        self.call_once_slow(true, &mut |state| unsafe { f.take().unchecked_unwrap()(state) });
     }
 
     // This is a non-generic function to reduce the monomorphization cost of
@@ -306,11 +304,7 @@ impl Once {
         // At this point we have the lock, so run the closure. Make sure we
         // properly clean up if the closure panicks.
         let guard = PanicGuard(self);
-        let once_state = if state & POISON_BIT != 0 {
-            OnceState::Poisoned
-        } else {
-            OnceState::New
-        };
+        let once_state = if state & POISON_BIT != 0 { OnceState::Poisoned } else { OnceState::New };
         f(once_state);
         mem::forget(guard);
 
@@ -334,9 +328,7 @@ impl Default for Once {
 
 impl fmt::Debug for Once {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Once")
-            .field("state", &self.state())
-            .finish()
+        f.debug_struct("Once").field("state", &self.state()).finish()
     }
 }
 

--- a/src/raw_mutex.rs
+++ b/src/raw_mutex.rs
@@ -37,9 +37,7 @@ pub struct RawMutex {
 }
 
 unsafe impl RawMutexTrait for RawMutex {
-    const INIT: RawMutex = RawMutex {
-        state: AtomicU8::new(0),
-    };
+    const INIT: RawMutex = RawMutex { state: AtomicU8::new(0) };
 
     type GuardMarker = GuardNoSend;
 
@@ -80,10 +78,7 @@ unsafe impl RawMutexTrait for RawMutex {
     #[inline]
     fn unlock(&self) {
         unsafe { deadlock::release_resource(self as *const _ as usize) };
-        if self
-            .state
-            .compare_exchange(LOCKED_BIT, 0, Ordering::Release, Ordering::Relaxed)
-            .is_ok()
+        if self.state.compare_exchange(LOCKED_BIT, 0, Ordering::Release, Ordering::Relaxed).is_ok()
         {
             return;
         }
@@ -95,10 +90,7 @@ unsafe impl RawMutexFair for RawMutex {
     #[inline]
     fn unlock_fair(&self) {
         unsafe { deadlock::release_resource(self as *const _ as usize) };
-        if self
-            .state
-            .compare_exchange(LOCKED_BIT, 0, Ordering::Release, Ordering::Relaxed)
-            .is_ok()
+        if self.state.compare_exchange(LOCKED_BIT, 0, Ordering::Release, Ordering::Relaxed).is_ok()
         {
             return;
         }

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -359,10 +359,7 @@ mod tests {
             let read_guard = lock.read();
 
             let read_result = lock.try_read();
-            assert!(
-                read_result.is_some(),
-                "try_read should succeed while read_guard is in scope"
-            );
+            assert!(read_result.is_some(), "try_read should succeed while read_guard is in scope");
 
             drop(read_guard);
         }
@@ -381,10 +378,7 @@ mod tests {
             let write_guard = lock.write();
 
             let read_result = lock.try_read();
-            assert!(
-                read_result.is_none(),
-                "try_read should fail while write_guard is in scope"
-            );
+            assert!(read_result.is_none(), "try_read should fail while write_guard is in scope");
 
             drop(write_guard);
         }
@@ -397,10 +391,7 @@ mod tests {
             let read_guard = lock.read();
 
             let write_result = lock.try_write();
-            assert!(
-                write_result.is_none(),
-                "try_write should fail while read_guard is in scope"
-            );
+            assert!(write_result.is_none(), "try_write should fail while read_guard is in scope");
 
             drop(read_guard);
         }
@@ -419,10 +410,7 @@ mod tests {
             let write_guard = lock.write();
 
             let write_result = lock.try_write();
-            assert!(
-                write_result.is_none(),
-                "try_write should fail while write_guard is in scope"
-            );
+            assert!(write_result.is_none(), "try_write should fail while write_guard is in scope");
 
             drop(write_guard);
         }


### PR DESCRIPTION
Apparently rustfmt changed the formatting. Running the latest version now yields this result... I can't say I like the new one better than the old. All of the`if`s that are used as expressions that became one liners are harder to read IMO. But if we want to be able to keep using a formatter at all we must adhere to it, or configure it with `rustfmt.toml` if we want to use it, but not get this result 🤷‍♂ 