### PR TITLE
Implement own xorshift PRNG to avoid rand dependency

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 [dependencies]
 cfg-if = "0.1"
 smallvec = "0.6"
-rand = "0.6"
 petgraph = { version = "0.4.5", optional = true }
 thread-id = { version = "3.2.0", optional = true }
 backtrace = { version = "0.3.2", optional = true }

--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -95,7 +95,7 @@ impl FairTimeout {
     fn should_timeout(&mut self) -> bool {
         let now = Instant::now();
         if now > self.timeout {
-            // Random time between 0 and 1ms.
+            // Time between 0 and 1ms.
             let nanos = self.gen_u32() % 1_000_000;
             self.timeout = now + Duration::new(0, nanos);
             true


### PR DESCRIPTION
Trying to solve #138 

The PRNG implementation is stolen from https://github.com/rust-lang/rust/blob/c28084ac16af4ab594b6860958df140e7c876a13/src/libcore/slice/sort.rs#L486-L493 as pointed out in the issue.

If we are happy with the PRNG algorithm, the only question is the seed. I simply used a pointer readily available when creating the `FairTimeout`. We could potentially also use the nanos offset from the elapsed timeout as a seed. Something like:
```rust
let seed = now.duration_since(self.timeout).as_nanos() as u32;
let nanos = Self::gen_u32_with_seed(seed) % 1_000_000;
```