### PR TITLE
reexport lock_api crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod deadlock;
 #[cfg(not(feature = "deadlock_detection"))]
 mod deadlock;
 
+pub use ::lock_api as lock_api;
 pub use self::condvar::{Condvar, WaitTimeoutResult};
 pub use self::mutex::{MappedMutexGuard, Mutex, MutexGuard};
 pub use self::once::{Once, OnceState};


### PR DESCRIPTION
That way, folks who use both parking_lot and lock_api will need only
one entry in Cargo.toml, one optional feature and won't suffer from
parking_lot / lock_api version mismatch.