### PR TITLE
Use hint::unreachable_unchecked instead of Void enum

### DIFF
--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -20,13 +20,12 @@ impl<T> UncheckedOptionExt<T> for Option<T> {
     }
 }
 
-// Equivalent to intrinsics::unreachable() in release mode
+// hint::unreachable_unchecked() in release mode
 #[inline]
 unsafe fn unreachable() -> ! {
     if cfg!(debug_assertions) {
         unreachable!();
     } else {
-        enum Void {}
-        match *(1 as *const Void) {}
+        core::hint::unreachable_unchecked()
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -22,14 +22,13 @@ impl<T> UncheckedOptionExt<T> for Option<T> {
     }
 }
 
-// Equivalent to intrinsics::unreachable() in release mode
+// hint::unreachable_unchecked() in release mode
 #[inline]
 unsafe fn unreachable() -> ! {
     if cfg!(debug_assertions) {
         unreachable!();
     } else {
-        enum Void {}
-        match *(1 as *const Void) {}
+        core::hint::unreachable_unchecked()
     }
 }
 


### PR DESCRIPTION
[`hint::unreachable_unchecked`](https://doc.rust-lang.org/nightly/core/hint/fn.unreachable_unchecked.html) stabilized in 1.27.