### PR TITLE
Staging for parking_lot 0.9.0,  _core 0.6.0 and lock_api 0.3.1 releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## parking_lot 0.9.0, parking_lot_core 0.6.0 (TBD)
+## parking_lot 0.9.0, parking_lot_core 0.6.0, lock_api 0.3.1 (TBD)
 
 - Re-export lock_api (0.3.0) from parking_lot (#150)
 - Removed (non-dev) dependency on rand crate for fairness mechanism, by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## parking_lot 0.9.0, parking_lot_core 0.6.0, lock_api 0.3.1 (TBD)
 
+- The minimum supported rust version (MSRV) is now 1.32. This was primarily
+  increased for testing with the latest _rand_ crate. Rust 1.31 may continue to
+  work normal use of these releases.
 - Re-export lock_api (0.3.1) from parking_lot (#150)
 - Removed (non-dev) dependency on rand crate for fairness mechanism, by
   including a simple xorshift PRNG in core (#144)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## parking_lot 0.9.0, parking_lot_core 0.6.0, lock_api 0.3.1 (TBD)
 
-- Re-export lock_api (0.3.0) from parking_lot (#150)
+- Re-export lock_api (0.3.1) from parking_lot (#150)
 - Removed (non-dev) dependency on rand crate for fairness mechanism, by
   including a simple xorshift PRNG in core (#144)
 - Android now uses the futex-based ThreadParker. (#140)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## parking_lot 0.9.0 (TBD)
+## parking_lot 0.9.0, parking_lot_core 0.6.0 (TBD)
 
 ## parking_lot 0.8.1 (2019-07-03, _yanked_)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,11 @@
-0.8.1 (2019-07-03)
-==================
+## parking_lot 0.8.1 (2019-07-03, _yanked_)
 
-- Re-export the lock_api crate from parking_lot. (#150)
+- Re-export the lock_api crate. (#150)
 - Removed dependency on rand crate. (#144)
 - Android now uses the futex-based ThreadParker. (#140)
 - Fixed CloudABI ThreadParker. (#140)
 
-0.8.0 (2019-05-04)
-==================
+## parking_lot 0.8.0 (2019-05-04)
 
 - Fix race conditions in deadlock detection.
 - Support for more platforms by adding ThreadParker implementations for
@@ -22,29 +20,24 @@
   (#134).
 - Add optional Serde support (#135).
 
-0.7.1 (2019-01-01)
-==================
+## parking_lot 0.7.1 (2019-01-01)
 
 - Fixed potential deadlock when upgrading a RwLock.
 - Fixed overflow panic on very long timeouts (#111).
 
-0.7.0 (2018-11-20)
-==================
+## parking_lot 0.7.0 (2018-11-20)
 
 - Return if or how many threads were notified from `Condvar::notify_*`
 
-0.6.3 (2018-07-18)
-==================
+## parking_lot 0.6.3 (2018-07-18)
 
 - Export `RawMutex`, `RawRwLock` and `RawThreadId`.
 
-0.6.2 (2018-06-18)
-==================
+## parking_lot 0.6.2 (2018-06-18)
 
 - Enable `lock_api/nightly` feature from `parking_lot/nightly` (#79)
 
-0.6.1 (2018-06-08)
-==================
+## parking_lot 0.6.1 (2018-06-08)
 
 Added missing typedefs for mapped lock guards:
 
@@ -53,8 +46,7 @@ Added missing typedefs for mapped lock guards:
 - `MappedRwLockReadGuard`
 - `MappedRwLockWriteGuard`
 
-0.6.0 (2018-06-08)
-==================
+## parking_lot 0.6.0 (2018-06-08)
 
 This release moves most of the code for type-safe `Mutex` and `RwLock` types
 into a separate crate called `lock_api`. This new crate is compatible with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   including a simple xorshift PRNG in core (#144)
 - Android now uses the futex-based ThreadParker. (#140)
 - Fixed CloudABI ThreadParker. (#140)
+- Fix race condition in ReentrantMutex (da16c2c7)
 
 ## lock_api 0.3.0 (2019-07-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - The minimum supported rust version (MSRV) is now 1.32. This was primarily
   increased for testing with the latest _rand_ crate. Rust 1.31 may continue to
-  work normal use of these releases.
+  work for normal use of these releases.
 - Re-export lock_api (0.3.1) from parking_lot (#150)
 - Removed (non-dev) dependency on rand crate for fairness mechanism, by
   including a simple xorshift PRNG in core (#144)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@
   including a simple xorshift PRNG in core (#144)
 - Android now uses the futex-based ThreadParker. (#140)
 - Fixed CloudABI ThreadParker. (#140)
-- Fix race condition in ReentrantMutex (da16c2c7)
+- Fix race condition in lock_api::ReentrantMutex (da16c2c7)
 
-## lock_api 0.3.0 (2019-07-03)
+## lock_api 0.3.0 (2019-07-03, _yanked_)
 
 - Use NonZeroUsize in GetThreadId::nonzero_thread_id (#148)
 - Debug assert lock_count in ReentrantMutex (#148)
 - Tag as `unsafe` and document some internal methods (#148)
+- This release was _yanked_ due to a regression in ReentrantMutex (da16c2c7)
 
 ## parking_lot 0.8.1 (2019-07-03, _yanked_)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## parking_lot 0.9.0 (TBD)
+
 ## parking_lot 0.8.1 (2019-07-03, _yanked_)
 
 - Re-export the lock_api crate. (#150)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,23 @@
 ## parking_lot 0.9.0, parking_lot_core 0.6.0 (TBD)
 
-## parking_lot 0.8.1 (2019-07-03, _yanked_)
-
-- Re-export the lock_api crate. (#150)
-- Removed dependency on rand crate. (#144)
+- Re-export lock_api (0.3.0) from parking_lot (#150)
+- Removed (non-dev) dependency on rand crate for fairness mechanism, by
+  including a simple xorshift PRNG in core (#144)
 - Android now uses the futex-based ThreadParker. (#140)
 - Fixed CloudABI ThreadParker. (#140)
 
-## parking_lot 0.8.0 (2019-05-04)
+## lock_api 0.3.0 (2019-07-03)
+
+- Use NonZeroUsize in GetThreadId::nonzero_thread_id (#148)
+- Debug assert lock_count in ReentrantMutex (#148)
+- Tag as `unsafe` and document some internal methods (#148)
+
+## parking_lot 0.8.1 (2019-07-03, _yanked_)
+
+- Re-export lock_api (0.3.0) from parking_lot (#150)
+- This release was _yanked_ from crates.io due to unexpected breakage (#156)
+
+## parking_lot 0.8.0, parking_lot_core 0.5.0, lock_api 0.2.0 (2019-05-04)
 
 - Fix race conditions in deadlock detection.
 - Support for more platforms by adding ThreadParker implementations for
@@ -18,8 +28,8 @@
 - Fix was_last_thread value in the timeout callback of park() (#129).
 - Support single byte Mutex/Once on stable Rust when compiler is at least
   version 1.34.
-- Make Condvar::new and Once::new const fns on stable Rust and remove ONCE_INIT
-  (#134).
+- Make Condvar::new and Once::new const fns on stable Rust and remove
+  ONCE_INIT (#134).
 - Add optional Serde support (#135).
 
 ## parking_lot 0.7.1 (2019-01-01)
@@ -27,7 +37,7 @@
 - Fixed potential deadlock when upgrading a RwLock.
 - Fixed overflow panic on very long timeouts (#111).
 
-## parking_lot 0.7.0 (2018-11-20)
+## parking_lot 0.7.0, parking_lot_core 0.4.0 (2018-11-26)
 
 - Return if or how many threads were notified from `Condvar::notify_*`
 
@@ -52,11 +62,11 @@ Added missing typedefs for mapped lock guards:
 
 This release moves most of the code for type-safe `Mutex` and `RwLock` types
 into a separate crate called `lock_api`. This new crate is compatible with
-`no_std` and provides `Mutex` and `RwLock` type-safe wrapper types from a
-raw mutex type which implements the `RawMutex` or `RawRwLock` trait. The API
-provided by the wrapper types can be extended by implementing more traits on the
-raw mutex type which provide more functionality (e.g. `RawMutexTimed`). See the
-crate documentation for more details.
+`no_std` and provides `Mutex` and `RwLock` type-safe wrapper types from a raw
+mutex type which implements the `RawMutex` or `RawRwLock` trait. The API
+provided by the wrapper types can be extended by implementing more traits on
+the raw mutex type which provide more functionality (e.g. `RawMutexTimed`). See
+the crate documentation for more details.
 
 There are also several major changes:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 parking_lot_core = { path = "core", version = "0.6" }
-lock_api = { path = "lock_api", version = "0.3" }
+lock_api = { path = "lock_api", version = "0.3.1" }
 
 [dev-dependencies]
 rand = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["concurrency"]
 edition = "2018"
 
 [dependencies]
-parking_lot_core = { path = "core", version = "0.5" }
+parking_lot_core = { path = "core", version = "0.6" }
 lock_api = { path = "lock_api", version = "0.3" }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parking_lot"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Amanieu d'Antras <amanieu@gmail.com>"]
 description = "More compact and efficient implementations of the standard synchronization primitives."
 license = "Apache-2.0/MIT"

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-parking_lot = "0.8"
+parking_lot = "0.9"
 ```
 
 and this to your crate root:
@@ -115,7 +115,7 @@ To enable nightly-only features, add this to your `Cargo.toml` instead:
 
 ```toml
 [dependencies]
-parking_lot = {version = "0.8", features = ["nightly"]}
+parking_lot = {version = "0.9", features = ["nightly"]}
 ```
 
 The experimental deadlock detector can be enabled with the

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parking_lot_core"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Amanieu d'Antras <amanieu@gmail.com>"]
 description = "An advanced API for creating custom synchronization primitives."
 license = "Apache-2.0/MIT"

--- a/lock_api/Cargo.toml
+++ b/lock_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lock_api"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Amanieu d'Antras <amanieu@gmail.com>"]
 description = "Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std."
 license = "Apache-2.0/MIT"


### PR DESCRIPTION
This includes all necessary version changes and overhauls the CHANGELOG to show more recent releases for all three crates (_parking_lot_, _parking_lot_core_, _lock_api_). Before releasing, the top  `(TBD)` should be replaced with the current date and tags for all crates added.    I also request that you add the following tags to this repo retroactively:

``` bash
git tag core-0.5.0 3259fd72e0d76e9c9a6f31ff41a996648fe9ccfa
git tag lock_api-0.1.5 2653619a613bc12dd6ab486f789d98956b65cdf0
git tag lock_api-0.2.0 3259fd72e0d76e9c9a6f31ff41a996648fe9ccfa
git tag lock_api-0.3.0 ace8280969b6362c3f3753506d90122c358de580
```

Fixes #158 