### PR TITLE
Upgrade rand dev dependency to 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
 
 matrix:
   include:
-    - rust: 1.31.0
+    - rust: 1.32.0
       os: linux
       script: &script
         - cargo build
@@ -49,7 +49,7 @@ matrix:
         - cargo run --release --bin rwlock -- 1 1 1 0 1 2
         - cd ..
 
-    - rust: 1.31.0
+    - rust: 1.32.0
       os: osx
       script: *script
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ parking_lot_core = { path = "core", version = "0.5" }
 lock_api = { path = "lock_api", version = "0.3" }
 
 [dev-dependencies]
-rand = "0.6"
+rand = "0.7"
 lazy_static = "1.0"
 
 # Used when testing out serde support.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ changes to the core API do not cause breaking changes for users of `parking_lot`
 
 ## Minimum Rust version
 
-The current minimum required Rust version is 1.31. Any change to this is
+The current minimum required Rust version is 1.32. Any change to this is
 considered a breaking change and will require a major version bump.
 
 ## License


### PR DESCRIPTION
The latest rand.  Also avoids some annoying crate duplicates for dev. Should not effect end users. 