### PR TITLE
Fix compile errors on Windows due to old cfg_if version

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["concurrency"]
 edition = "2018"
 
 [dependencies]
-cfg-if = "0.1"
+cfg-if = "0.1.5"
 smallvec = "0.6"
 petgraph = { version = "0.4.5", optional = true }
 thread-id = { version = "3.2.0", optional = true }


### PR DESCRIPTION
`cfg-if 0.1.4` and below don't work correctly on Windows. I get a compile error on `parking_lot_core` due to another crate in the build forcing version `0.1.3`.