### PR TITLE
Support for no Instant::now()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ owning_ref = ["lock_api/owning_ref"]
 nightly = ["parking_lot_core/nightly", "lock_api/nightly"]
 deadlock_detection = ["parking_lot_core/deadlock_detection"]
 serde = ["lock_api/serde"]
+no_instant_now = ["parking_lot_core/no_instant_now"]
 
 [workspace]
 exclude = ["benchmark"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -34,4 +34,5 @@ winapi = { version = "0.3", features = ["winnt", "ntstatus", "minwindef",
 
 [features]
 nightly = []
+no_instant_now = []
 deadlock_detection = ["petgraph", "thread-id", "backtrace"]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -59,6 +59,7 @@
 mod parking_lot;
 mod spinwait;
 mod thread_parker;
+pub mod time;
 mod util;
 mod word_lock;
 

--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -6,6 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::thread_parker::{ThreadParker, ThreadParkerT, UnparkHandleT};
+use crate::time::{self, Instant};
 use crate::util::UncheckedOptionExt;
 use crate::word_lock::WordLock;
 use core::{
@@ -14,7 +15,7 @@ use core::{
     sync::atomic::{AtomicPtr, AtomicUsize, Ordering},
 };
 use smallvec::SmallVec;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 static NUM_THREADS: AtomicUsize = AtomicUsize::new(0);
 static HASHTABLE: AtomicPtr<HashTable> = AtomicPtr::new(ptr::null_mut());
@@ -40,7 +41,7 @@ impl HashTable {
         let new_size = (num_threads * LOAD_FACTOR).next_power_of_two();
         let hash_bits = 0usize.leading_zeros() - new_size.leading_zeros() - 1;
 
-        let now = Instant::now();
+        let now = time::now();
         let mut entries = Vec::with_capacity(new_size);
         for i in 0..new_size {
             // We must ensure the seed is not zero
@@ -97,7 +98,7 @@ impl FairTimeout {
     // Determine whether we should force a fair unlock, and update the timeout
     #[inline]
     fn should_timeout(&mut self) -> bool {
-        let now = Instant::now();
+        let now = time::now();
         if now > self.timeout {
             // Time between 0 and 1ms.
             let nanos = self.gen_u32() % 1_000_000;

--- a/core/src/thread_parker/generic.rs
+++ b/core/src/thread_parker/generic.rs
@@ -9,7 +9,9 @@
 //! parking facilities available.
 
 use core::sync::atomic::{spin_loop_hint, AtomicBool, Ordering};
-use std::{thread, time::Instant};
+use std::thread;
+
+use crate::time::{now, Instant};
 
 // Helper type for putting a thread to sleep until some other thread wakes it up
 pub struct ThreadParker {
@@ -48,7 +50,7 @@ impl super::ThreadParkerT for ThreadParker {
     #[inline]
     unsafe fn park_until(&self, timeout: Instant) -> bool {
         while self.parked.load(Ordering::Acquire) != false {
-            if Instant::now() >= timeout {
+            if now() >= timeout {
                 return false;
             }
             spin_loop_hint();

--- a/core/src/thread_parker/linux.rs
+++ b/core/src/thread_parker/linux.rs
@@ -5,12 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::time::{self, Instant};
 use core::{
     ptr,
     sync::atomic::{AtomicI32, Ordering},
 };
 use libc;
-use std::{thread, time::Instant};
+use std::thread;
 
 // x32 Linux uses a non-standard type for tv_nsec in timespec.
 // See https://sourceware.org/bugzilla/show_bug.cgi?id=16437
@@ -69,7 +70,7 @@ impl super::ThreadParkerT for ThreadParker {
     #[inline]
     unsafe fn park_until(&self, timeout: Instant) -> bool {
         while self.futex.load(Ordering::Acquire) != 0 {
-            let now = Instant::now();
+            let now = time::now();
             if timeout <= now {
                 return false;
             }

--- a/core/src/thread_parker/mod.rs
+++ b/core/src/thread_parker/mod.rs
@@ -1,5 +1,6 @@
 use cfg_if::cfg_if;
-use std::time::Instant;
+
+use crate::time::Instant;
 
 /// Trait for the platform thread parker implementation.
 ///

--- a/core/src/thread_parker/redox.rs
+++ b/core/src/thread_parker/redox.rs
@@ -5,6 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::time::{self, Instant};
 use core::{
     ptr,
     sync::atomic::{AtomicI32, Ordering},
@@ -57,7 +58,7 @@ impl super::ThreadParkerT for ThreadParker {
     #[inline]
     unsafe fn park_until(&self, timeout: Instant) -> bool {
         while self.futex.load(Ordering::Acquire) != UNPARKED {
-            let now = Instant::now();
+            let now = time::now();
             if timeout <= now {
                 return false;
             }

--- a/core/src/thread_parker/sgx.rs
+++ b/core/src/thread_parker/sgx.rs
@@ -5,6 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::time::Instant;
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::{
     io,
@@ -16,7 +17,6 @@ use std::{
         },
     },
     thread,
-    time::Instant,
 };
 
 // Helper type for putting a thread to sleep until some other thread wakes it up

--- a/core/src/thread_parker/unix.rs
+++ b/core/src/thread_parker/unix.rs
@@ -5,6 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::time::{self, Instant};
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 use core::ptr;
 use core::{
@@ -12,10 +13,7 @@ use core::{
     mem,
 };
 use libc;
-use std::{
-    thread,
-    time::{Duration, Instant},
-};
+use std::{thread, time::Duration};
 
 // x32 Linux uses a non-standard type for tv_nsec in timespec.
 // See https://sourceware.org/bugzilla/show_bug.cgi?id=16437
@@ -88,7 +86,7 @@ impl super::ThreadParkerT for ThreadParker {
         let r = libc::pthread_mutex_lock(self.mutex.get());
         debug_assert_eq!(r, 0);
         while self.should_park.get() {
-            let now = Instant::now();
+            let now = time::now();
             if timeout <= now {
                 let r = libc::pthread_mutex_unlock(self.mutex.get());
                 debug_assert_eq!(r, 0);

--- a/core/src/thread_parker/wasm.rs
+++ b/core/src/thread_parker/wasm.rs
@@ -8,7 +8,8 @@
 //! The wasm platform can't park when atomic support is not available.
 //! So this ThreadParker just panics on any attempt to park.
 
-use std::{thread, time::Instant};
+use crate::time::Instant;
+use std::thread;
 
 pub struct ThreadParker(());
 

--- a/core/src/thread_parker/windows/keyed_event.rs
+++ b/core/src/thread_parker/windows/keyed_event.rs
@@ -125,7 +125,7 @@ impl KeyedEvent {
 
     #[inline]
     pub unsafe fn park_until(&'static self, key: &AtomicUsize, timeout: Instant) -> bool {
-        let now = Instant::now();
+        let now = time::now();
         if timeout <= now {
             // If another thread unparked us, we need to call
             // NtWaitForKeyedEvent otherwise that thread will stay stuck at

--- a/core/src/thread_parker/windows/waitaddress.rs
+++ b/core/src/thread_parker/windows/waitaddress.rs
@@ -84,7 +84,7 @@ impl WaitAddress {
     #[inline]
     pub fn park_until(&'static self, key: &AtomicUsize, timeout: Instant) -> bool {
         while key.load(Ordering::Acquire) != 0 {
-            let now = Instant::now();
+            let now = time::now();
             if timeout <= now {
                 return false;
             }

--- a/core/src/time.rs
+++ b/core/src/time.rs
@@ -1,0 +1,50 @@
+//! Allows substitution of the `Instant` type with `Duration` when `Instant::now()` is not supported
+//! for a given target.
+
+cfg_if::cfg_if! {
+  if #[cfg(feature = "no_instant_now")] {
+     mod no_instant_now;
+     pub use self::no_instant_now::*;
+  } else {
+     mod instant_now;
+     pub use self::instant_now::*;
+  }
+}
+
+use crate::word_lock::WordLock;
+
+/// A function that can replace `std::time::Instant::now()` by instead returning an `Instant` even
+/// if `std::time::Instant::now()` does not work on a target.
+pub type NowFn = fn() -> Instant;
+
+/// Pointer to the current `NowFn` used by `now()`
+pub fn get_now_fn() -> NowFn {
+    unsafe {
+        NOW_FN_LOCK.lock();
+
+        let now_fn = NOW_FN;
+
+        NOW_FN_LOCK.unlock();
+
+        now_fn
+    }
+}
+
+/// Replaces the current `NowFn` used for `now()` with `now_fn`.
+pub fn set_now_fn(now_fn: NowFn) {
+    unsafe {
+        NOW_FN_LOCK.lock();
+
+        NOW_FN = now_fn;
+
+        NOW_FN_LOCK.unlock();
+    }
+}
+
+/// Generates an `Instant` using `NowFn` set with `set_now_fn_ptr`
+pub fn now() -> Instant {
+    get_now_fn()()
+}
+
+static NOW_FN_LOCK: WordLock = WordLock::INIT;
+static mut NOW_FN: NowFn = default_now;

--- a/core/src/time/instant_now.rs
+++ b/core/src/time/instant_now.rs
@@ -1,0 +1,15 @@
+#[cfg(check_duration_since)]
+use std::time::Duration;
+
+/// A measurement of a monotonically non-decreasing clock.
+pub type Instant = std::time::Instant;
+
+#[cfg(feature = "checked_duration_since")]
+pub fn checked_duration_since(later: Instant, earlier: Instant) -> Option<Duration> {
+    later.checked_duration_since(earlier)
+}
+
+/// Uses `std::time::Instant::now()`
+pub fn default_now() -> Instant {
+    Instant::now()
+}

--- a/core/src/time/no_instant_now.rs
+++ b/core/src/time/no_instant_now.rs
@@ -1,0 +1,11 @@
+use core::time::Duration;
+
+pub type Instant = Duration;
+
+pub fn checked_duration_since(later: Instant, earlier: Instant) -> Option<Duration> {
+    later.checked_sub(earlier)
+}
+
+pub fn default_now() -> Instant {
+    panic!("Set with `parking_lot::time::set_now_fn`.")
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,4 +40,4 @@ pub use self::rwlock::{
     MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock, RwLockReadGuard,
     RwLockUpgradableReadGuard, RwLockWriteGuard,
 };
-pub use ::lock_api;
+pub use lock_api;

--- a/src/raw_mutex.rs
+++ b/src/raw_mutex.rs
@@ -12,8 +12,8 @@ use core::sync::atomic::AtomicU8;
 use core::sync::atomic::AtomicUsize as AtomicU8;
 use core::{sync::atomic::Ordering, time::Duration};
 use lock_api::{GuardNoSend, RawMutex as RawMutexTrait, RawMutexFair, RawMutexTimed};
+use parking_lot_core::time::Instant;
 use parking_lot_core::{self, ParkResult, SpinWait, UnparkResult, UnparkToken, DEFAULT_PARK_TOKEN};
-use std::time::Instant;
 
 #[cfg(has_sized_atomics)]
 type U8 = u8;

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::time::{Duration, Instant};
+use parking_lot_core::time::{self, Instant};
+use std::time::Duration;
 
 // Option::unchecked_unwrap
 pub trait UncheckedOptionExt<T> {
@@ -35,7 +36,7 @@ unsafe fn unreachable() -> ! {
 #[inline]
 pub fn to_deadline(timeout: Duration) -> Option<Instant> {
     #[cfg(has_checked_instant)]
-    let deadline = Instant::now().checked_add(timeout);
+    let deadline = time::now().checked_add(timeout);
     #[cfg(not(has_checked_instant))]
     let deadline = Some(Instant::now() + timeout);
 


### PR DESCRIPTION
Fixes #166

For `wasm32-unknown-unknown` (and I think SGX) `Instant::now()` is not
supported because it cannot assume a time source as reported in #166.

To allow for substituting `Instant::now()` at runtime as is needed for `wasm32-unknown-unknown` targeting Web browsers that would be using `performance.now()`, have all code that hard-coded `std::time::Instant`, `std::time::Instant::now()`, and `std::time::Instant::checked_duration_since` use types and functions in `parking_lot_core::time`.

## Without `no_instant_now` feature

* `parking_lot_core::time::Instant` is `std::time::Instant`
* `parking_lot_core::time::now()` is `std::time::Instant::now()`
* `parking_lot_core::time::checked_duration_since(later, earlier)` is `std::time::Instant::checked_duration_since`

## With `no_instant_now` feature

* `parking_lot_core::time::Instant` is `std::time::Duration`.  (This was chosen as the rust `sys` for `wasm` uses `Duration` as the internal field type for `Instant`s, so it seemed safe to depend on it.) . `Instant` can't be used because it is opaque and not safely fakable when `Instant::now` can't be used because `Instant` internals vary by platform.
* `parking_lot_core::time::now()` will panic by default. `parking_lot_core::time::set_now_fn(now_fn)` must be called with a `fn() -> Instant`, such as one that defers to `performance.now()` for browsers and used `Duration::new` or one of the `from` functions to make a `Duration` that can be returned from the `Instant`.
* `parking_lot_coer::time::checked_duration_since(later, earlier)` is `std::time::Duration::checked_sub`.