### PR TITLE
Switch from `rustc_version` to `autocfg`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ lazy_static = "1.0"
 bincode = {version = "1.1.3"}
 
 [build-dependencies]
-rustc_version = "0.2"
+autocfg = "0.1.6"
 
 [features]
 default = []

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,6 @@
-use rustc_version::{version, Version};
-
 fn main() {
-    if version().unwrap() >= Version::parse("1.34.0").unwrap() {
+    let cfg = autocfg::new();
+    if cfg.probe_rustc_version(1, 34) {
         println!("cargo:rustc-cfg=has_sized_atomics");
         println!("cargo:rustc-cfg=has_checked_instant");
     }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@ thread-id = { version = "3.2.0", optional = true }
 backtrace = { version = "0.3.2", optional = true }
 
 [build-dependencies]
-rustc_version = "0.2"
+autocfg = "0.1.6"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.55"

--- a/core/build.rs
+++ b/core/build.rs
@@ -1,7 +1,6 @@
-use rustc_version::{version, Version};
-
 fn main() {
-    if version().unwrap() >= Version::parse("1.34.0").unwrap() {
+    let cfg = autocfg::new();
+    if cfg.probe_rustc_version(1, 34) {
         println!("cargo:rustc-cfg=has_sized_atomics");
     }
 }


### PR DESCRIPTION
The `autocfg` crate is a bit more robust in terms of how it parses
rustc's version and also doesn't have a dependency on `semver` which can
be a very weighty dependency if its `serde` feature is activated.