### PR TITLE
Small cleanup, moving code, remove unused unsafe block

### DIFF
--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -96,35 +96,6 @@ pub struct Mutex<R: RawMutex, T: ?Sized> {
     data: UnsafeCell<T>,
 }
 
-// Copied and modified from serde
-#[cfg(feature = "serde")]
-impl<R, T> Serialize for Mutex<R, T>
-where
-    R: RawMutex,
-    T: Serialize + ?Sized,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.lock().serialize(serializer)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de, R, T> Deserialize<'de> for Mutex<R, T>
-where
-    R: RawMutex,
-    T: Deserialize<'de> + ?Sized,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Deserialize::deserialize(deserializer).map(Mutex::new)
-    }
-}
-
 unsafe impl<R: RawMutex + Send, T: ?Sized + Send> Send for Mutex<R, T> {}
 unsafe impl<R: RawMutex + Sync, T: ?Sized + Send> Sync for Mutex<R, T> {}
 
@@ -323,6 +294,35 @@ impl<R: RawMutex, T: ?Sized + fmt::Debug> fmt::Debug for Mutex<R, T> {
                     .finish()
             }
         }
+    }
+}
+
+// Copied and modified from serde
+#[cfg(feature = "serde")]
+impl<R, T> Serialize for Mutex<R, T>
+where
+    R: RawMutex,
+    T: Serialize + ?Sized,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.lock().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, R, T> Deserialize<'de> for Mutex<R, T>
+where
+    R: RawMutex,
+    T: Deserialize<'de> + ?Sized,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Deserialize::deserialize(deserializer).map(Mutex::new)
     }
 }
 

--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -122,9 +122,8 @@ impl<R: RawMutex, T> Mutex<R, T> {
 
     /// Consumes this mutex, returning the underlying data.
     #[inline]
-    #[allow(unused_unsafe)]
     pub fn into_inner(self) -> T {
-        unsafe { self.data.into_inner() }
+        self.data.into_inner()
     }
 }
 

--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -105,8 +105,8 @@ impl<R: RawMutex, T> Mutex<R, T> {
     #[inline]
     pub const fn new(val: T) -> Mutex<R, T> {
         Mutex {
-            data: UnsafeCell::new(val),
             raw: R::INIT,
+            data: UnsafeCell::new(val),
         }
     }
 
@@ -115,8 +115,8 @@ impl<R: RawMutex, T> Mutex<R, T> {
     #[inline]
     pub fn new(val: T) -> Mutex<R, T> {
         Mutex {
-            data: UnsafeCell::new(val),
             raw: R::INIT,
+            data: UnsafeCell::new(val),
         }
     }
 

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -147,37 +147,6 @@ pub struct ReentrantMutex<R: RawMutex, G: GetThreadId, T: ?Sized> {
     data: UnsafeCell<T>,
 }
 
-// Copied and modified from serde
-#[cfg(feature = "serde")]
-impl<R, G, T> Serialize for ReentrantMutex<R, G, T>
-where
-    R: RawMutex,
-    G: GetThreadId,
-    T: Serialize + ?Sized,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.lock().serialize(serializer)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de, R, G, T> Deserialize<'de> for ReentrantMutex<R, G, T>
-where
-    R: RawMutex,
-    G: GetThreadId,
-    T: Deserialize<'de> + ?Sized,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Deserialize::deserialize(deserializer).map(ReentrantMutex::new)
-    }
-}
-
 unsafe impl<R: RawMutex + Send, G: GetThreadId + Send, T: ?Sized + Send> Send
     for ReentrantMutex<R, G, T>
 {
@@ -396,6 +365,37 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized + fmt::Debug> fmt::Debug for Reentra
                     .finish()
             }
         }
+    }
+}
+
+// Copied and modified from serde
+#[cfg(feature = "serde")]
+impl<R, G, T> Serialize for ReentrantMutex<R, G, T>
+where
+    R: RawMutex,
+    G: GetThreadId,
+    T: Serialize + ?Sized,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.lock().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, R, G, T> Deserialize<'de> for ReentrantMutex<R, G, T>
+where
+    R: RawMutex,
+    G: GetThreadId,
+    T: Deserialize<'de> + ?Sized,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Deserialize::deserialize(deserializer).map(ReentrantMutex::new)
     }
 }
 

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -189,9 +189,8 @@ impl<R: RawMutex, G: GetThreadId, T> ReentrantMutex<R, G, T> {
 
     /// Consumes this mutex, returning the underlying data.
     #[inline]
-    #[allow(unused_unsafe)]
     pub fn into_inner(self) -> T {
-        unsafe { self.data.into_inner() }
+        self.data.into_inner()
     }
 }
 


### PR DESCRIPTION
I felt the code order:
```rust
struct Mutex {...}
impl serde::Traits for Mutex {...}
impl Mutex {...}
```
was strange/not optimal. The first thing I want to read after seeing the struct are the main methods. Constructors and similar. The fact that it implements `serde` feature is more of a niche thing that can come much later. I personally think third party trait impls basically always should come after the main impl block and impls for standard library traits.

Then I also noticed not needed `unsafe` block around `UnsafeCell::into_inner`. These lines of code has not been changed for a very long time. So I guess they were still there since before that method became safe in Rust 1.25.