### PR TITLE
Use full path to lock_api traits in other crates

### DIFF
--- a/src/condvar.rs
+++ b/src/condvar.rs
@@ -12,7 +12,7 @@ use core::{
     fmt, ptr,
     sync::atomic::{AtomicPtr, Ordering},
 };
-use lock_api::RawMutex as RawMutexTrait;
+use lock_api::RawMutex as RawMutex_;
 use parking_lot_core::{self, ParkResult, RequeueOp, UnparkResult, DEFAULT_PARK_TOKEN};
 use std::time::{Duration, Instant};
 

--- a/src/raw_mutex.rs
+++ b/src/raw_mutex.rs
@@ -11,7 +11,7 @@ use core::sync::atomic::AtomicU8;
 #[cfg(not(has_sized_atomics))]
 use core::sync::atomic::AtomicUsize as AtomicU8;
 use core::{sync::atomic::Ordering, time::Duration};
-use lock_api::{GuardNoSend, RawMutex as RawMutexTrait, RawMutexFair, RawMutexTimed};
+use lock_api::{GuardNoSend, RawMutex as RawMutex_};
 use parking_lot_core::{self, ParkResult, SpinWait, UnparkResult, UnparkToken, DEFAULT_PARK_TOKEN};
 use std::time::Instant;
 
@@ -36,7 +36,7 @@ pub struct RawMutex {
     state: AtomicU8,
 }
 
-unsafe impl RawMutexTrait for RawMutex {
+unsafe impl lock_api::RawMutex for RawMutex {
     const INIT: RawMutex = RawMutex {
         state: AtomicU8::new(0),
     };
@@ -91,7 +91,7 @@ unsafe impl RawMutexTrait for RawMutex {
     }
 }
 
-unsafe impl RawMutexFair for RawMutex {
+unsafe impl lock_api::RawMutexFair for RawMutex {
     #[inline]
     fn unlock_fair(&self) {
         unsafe { deadlock::release_resource(self as *const _ as usize) };
@@ -113,7 +113,7 @@ unsafe impl RawMutexFair for RawMutex {
     }
 }
 
-unsafe impl RawMutexTimed for RawMutex {
+unsafe impl lock_api::RawMutexTimed for RawMutex {
     type Duration = Duration;
     type Instant = Instant;
 

--- a/src/raw_rwlock.rs
+++ b/src/raw_rwlock.rs
@@ -12,11 +12,7 @@ use core::{
     cell::Cell,
     sync::atomic::{AtomicUsize, Ordering},
 };
-use lock_api::{
-    GuardNoSend, RawRwLock as RawRwLockTrait, RawRwLockDowngrade, RawRwLockFair,
-    RawRwLockRecursive, RawRwLockRecursiveTimed, RawRwLockTimed, RawRwLockUpgrade,
-    RawRwLockUpgradeDowngrade, RawRwLockUpgradeFair, RawRwLockUpgradeTimed,
-};
+use lock_api::{GuardNoSend, RawRwLock as RawRwLock_, RawRwLockUpgrade};
 use parking_lot_core::{
     self, deadlock, FilterOp, ParkResult, ParkToken, SpinWait, UnparkResult, UnparkToken,
 };
@@ -60,7 +56,7 @@ pub struct RawRwLock {
     state: AtomicUsize,
 }
 
-unsafe impl RawRwLockTrait for RawRwLock {
+unsafe impl lock_api::RawRwLock for RawRwLock {
     const INIT: RawRwLock = RawRwLock {
         state: AtomicUsize::new(0),
     };
@@ -143,7 +139,7 @@ unsafe impl RawRwLockTrait for RawRwLock {
     }
 }
 
-unsafe impl RawRwLockFair for RawRwLock {
+unsafe impl lock_api::RawRwLockFair for RawRwLock {
     #[inline]
     fn unlock_shared_fair(&self) {
         // Shared unlocking is always fair in this implementation.
@@ -180,7 +176,7 @@ unsafe impl RawRwLockFair for RawRwLock {
     }
 }
 
-unsafe impl RawRwLockDowngrade for RawRwLock {
+unsafe impl lock_api::RawRwLockDowngrade for RawRwLock {
     #[inline]
     fn downgrade(&self) {
         let state = self
@@ -194,7 +190,7 @@ unsafe impl RawRwLockDowngrade for RawRwLock {
     }
 }
 
-unsafe impl RawRwLockTimed for RawRwLock {
+unsafe impl lock_api::RawRwLockTimed for RawRwLock {
     type Duration = Duration;
     type Instant = Instant;
 
@@ -259,7 +255,7 @@ unsafe impl RawRwLockTimed for RawRwLock {
     }
 }
 
-unsafe impl RawRwLockRecursive for RawRwLock {
+unsafe impl lock_api::RawRwLockRecursive for RawRwLock {
     #[inline]
     fn lock_shared_recursive(&self) {
         if !self.try_lock_shared_fast(true) {
@@ -283,7 +279,7 @@ unsafe impl RawRwLockRecursive for RawRwLock {
     }
 }
 
-unsafe impl RawRwLockRecursiveTimed for RawRwLock {
+unsafe impl lock_api::RawRwLockRecursiveTimed for RawRwLock {
     #[inline]
     fn try_lock_shared_recursive_for(&self, timeout: Self::Duration) -> bool {
         let result = if self.try_lock_shared_fast(true) {
@@ -311,7 +307,7 @@ unsafe impl RawRwLockRecursiveTimed for RawRwLock {
     }
 }
 
-unsafe impl RawRwLockUpgrade for RawRwLock {
+unsafe impl lock_api::RawRwLockUpgrade for RawRwLock {
     #[inline]
     fn lock_upgradable(&self) {
         if !self.try_lock_upgradable_fast() {
@@ -386,7 +382,7 @@ unsafe impl RawRwLockUpgrade for RawRwLock {
     }
 }
 
-unsafe impl RawRwLockUpgradeFair for RawRwLock {
+unsafe impl lock_api::RawRwLockUpgradeFair for RawRwLock {
     #[inline]
     fn unlock_upgradable_fair(&self) {
         self.deadlock_release();
@@ -416,7 +412,7 @@ unsafe impl RawRwLockUpgradeFair for RawRwLock {
     }
 }
 
-unsafe impl RawRwLockUpgradeDowngrade for RawRwLock {
+unsafe impl lock_api::RawRwLockUpgradeDowngrade for RawRwLock {
     #[inline]
     fn downgrade_upgradable(&self) {
         let state = self.state.fetch_sub(UPGRADABLE_BIT, Ordering::Relaxed);
@@ -441,7 +437,7 @@ unsafe impl RawRwLockUpgradeDowngrade for RawRwLock {
     }
 }
 
-unsafe impl RawRwLockUpgradeTimed for RawRwLock {
+unsafe impl lock_api::RawRwLockUpgradeTimed for RawRwLock {
     #[inline]
     fn try_lock_upgradable_until(&self, timeout: Instant) -> bool {
         let result = if self.try_lock_upgradable_fast() {


### PR DESCRIPTION
My main pet peeve here was the renaming of a trait during import because it collided with an existing type. The main problem here IMO was `impl RawMutexTrait for RawMutex`. Then one has to remember that `RawMutexTrait` corresponds to `lock_api::RawMutex`. This is yet another step to take in the head when reading the code. Just using `lock_api::RawMutex` is not much longer, and it immediately makes it much more clear to the reader that the *local type* `RawMutex` implements the trait *from another crate*. Clears up the relationship with these crates a little bit.

For consistency, and for parts of my argument above, I opted to implement all traits in the same files with full paths to the traits, not just the colliding one.

If/when we drop support for Rust 1.31 and 1.32 we can change the imports to just `use lock_api::RawMutex as _` to make it even better. No name collision and no need to invent yet another name. Until then I opted for this new name that just tries to avoid the collision in the simplest way possible without adding a word that should not be there.