### PR TITLE
Remove some usage of deprecated mem::uninitialized

### DIFF
--- a/src/remutex.rs
+++ b/src/remutex.rs
@@ -17,8 +17,9 @@ unsafe impl GetThreadId for RawThreadId {
 
     fn nonzero_thread_id(&self) -> NonZeroUsize {
         // The address of a thread-local variable is guaranteed to be unique to the
-        // current thread, and is also guaranteed to be non-zero.
-        thread_local!(static KEY: u8 = unsafe { ::std::mem::uninitialized() });
+        // current thread, and is also guaranteed to be non-zero. The variable has to have a
+        // non-zero size to guarantee it has a unique address for each thread.
+        thread_local!(static KEY: u8 = 0);
         KEY.with(|x| {
             NonZeroUsize::new(x as *const _ as usize)
                 .expect("thread-local variable address is null")


### PR DESCRIPTION
`mem::uninitialized` was deprecated in 1.38. Usage is not recommended. Here I start getting rid of it in favor of the preferred `mem::MaybeUninit` type.

This PR does not yet replace all occurances of `mem::unintialized`. I wanted to get some feedback on this before I went ahead with the CloudABI thread parker as well.