### PR TITLE
Add documentation and limit number of expressions in unsafe block for RawMutex

### DIFF
--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -1041,7 +1041,10 @@ pub mod deadlock {
 
     /// Acquire a resource identified by key in the deadlock detector
     /// Noop if deadlock_detection feature isn't enabled.
-    /// Note: Call after the resource is acquired
+    ///
+    /// # Safety
+    ///
+    /// Call after the resource is acquired
     #[inline]
     pub unsafe fn acquire_resource(_key: usize) {
         #[cfg(feature = "deadlock_detection")]
@@ -1050,9 +1053,14 @@ pub mod deadlock {
 
     /// Release a resource identified by key in the deadlock detector.
     /// Noop if deadlock_detection feature isn't enabled.
-    /// Note: Call before the resource is released
+    ///
     /// # Panics
+    ///
     /// Panics if the resource was already released or wasn't acquired in this thread.
+    ///
+    /// # Safety
+    ///
+    /// Call before the resource is released
     #[inline]
     pub unsafe fn release_resource(_key: usize) {
         #[cfg(feature = "deadlock_detection")]

--- a/core/src/thread_parker/mod.rs
+++ b/core/src/thread_parker/mod.rs
@@ -47,7 +47,6 @@ pub trait UnparkHandleT {
     ///
     /// This method is unsafe for the same reason as the unsafe methods in
     /// `ThreadParkerT`.
-    #[inline]
     unsafe fn unpark(self);
 }
 

--- a/src/raw_mutex.rs
+++ b/src/raw_mutex.rs
@@ -220,37 +220,41 @@ impl RawMutex {
             }
 
             // Park our thread until we are woken up by an unlock
-            unsafe {
-                let addr = self as *const _ as usize;
-                let validate = || self.state.load(Ordering::Relaxed) == LOCKED_BIT | PARKED_BIT;
-                let before_sleep = || {};
-                let timed_out = |_, was_last_thread| {
-                    // Clear the parked bit if we were the last parked thread
-                    if was_last_thread {
-                        self.state.fetch_and(!PARKED_BIT, Ordering::Relaxed);
-                    }
-                };
-                match parking_lot_core::park(
+            let addr = self as *const _ as usize;
+            let validate = || self.state.load(Ordering::Relaxed) == LOCKED_BIT | PARKED_BIT;
+            let before_sleep = || {};
+            let timed_out = |_, was_last_thread| {
+                // Clear the parked bit if we were the last parked thread
+                if was_last_thread {
+                    self.state.fetch_and(!PARKED_BIT, Ordering::Relaxed);
+                }
+            };
+            // SAFETY:
+            //   * `addr` is an address we control.
+            //   * `validate`/`timed_out` does not panic or call into any function of `parking_lot`.
+            //   * `before_sleep` does not call `park`, nor does it panic.
+            match unsafe {
+                parking_lot_core::park(
                     addr,
                     validate,
                     before_sleep,
                     timed_out,
                     DEFAULT_PARK_TOKEN,
                     timeout,
-                ) {
-                    // The thread that unparked us passed the lock on to us
-                    // directly without unlocking it.
-                    ParkResult::Unparked(TOKEN_HANDOFF) => return true,
+                )
+            } {
+                // The thread that unparked us passed the lock on to us
+                // directly without unlocking it.
+                ParkResult::Unparked(TOKEN_HANDOFF) => return true,
 
-                    // We were unparked normally, try acquiring the lock again
-                    ParkResult::Unparked(_) => (),
+                // We were unparked normally, try acquiring the lock again
+                ParkResult::Unparked(_) => (),
 
-                    // The validation function failed, try locking again
-                    ParkResult::Invalid => (),
+                // The validation function failed, try locking again
+                ParkResult::Invalid => (),
 
-                    // Timeout expired
-                    ParkResult::TimedOut => return false,
-                }
+                // Timeout expired
+                ParkResult::TimedOut => return false,
             }
 
             // Loop back and try locking again
@@ -263,29 +267,32 @@ impl RawMutex {
     fn unlock_slow(&self, force_fair: bool) {
         // Unpark one thread and leave the parked bit set if there might
         // still be parked threads on this address.
-        unsafe {
-            let addr = self as *const _ as usize;
-            let callback = |result: UnparkResult| {
-                // If we are using a fair unlock then we should keep the
-                // mutex locked and hand it off to the unparked thread.
-                if result.unparked_threads != 0 && (force_fair || result.be_fair) {
-                    // Clear the parked bit if there are no more parked
-                    // threads.
-                    if !result.have_more_threads {
-                        self.state.store(LOCKED_BIT, Ordering::Relaxed);
-                    }
-                    return TOKEN_HANDOFF;
+        let addr = self as *const _ as usize;
+        let callback = |result: UnparkResult| {
+            // If we are using a fair unlock then we should keep the
+            // mutex locked and hand it off to the unparked thread.
+            if result.unparked_threads != 0 && (force_fair || result.be_fair) {
+                // Clear the parked bit if there are no more parked
+                // threads.
+                if !result.have_more_threads {
+                    self.state.store(LOCKED_BIT, Ordering::Relaxed);
                 }
+                return TOKEN_HANDOFF;
+            }
 
-                // Clear the locked bit, and the parked bit as well if there
-                // are no more parked threads.
-                if result.have_more_threads {
-                    self.state.store(PARKED_BIT, Ordering::Release);
-                } else {
-                    self.state.store(0, Ordering::Release);
-                }
-                TOKEN_NORMAL
-            };
+            // Clear the locked bit, and the parked bit as well if there
+            // are no more parked threads.
+            if result.have_more_threads {
+                self.state.store(PARKED_BIT, Ordering::Release);
+            } else {
+                self.state.store(0, Ordering::Release);
+            }
+            TOKEN_NORMAL
+        };
+        // SAFETY:
+        //   * `addr` is an address we control.
+        //   * `callback` does not panic or call into any function of `parking_lot`.
+        unsafe {
             parking_lot_core::unpark_one(addr, callback);
         }
     }


### PR DESCRIPTION
Try to move not unsafe stuff out of large unsafe blocks. And keep only the unsafe call at the end in that block. Documenting the safety contract to think about in said call.

Document what the bits in `RawMutex::state`, and what all combinations of that state, means. Please verify the descriptions are correct, since you know all edge cases much better than me :)

Clippy complained about `#[inline]` on function with no body. The corresponding actual implementations still have `#[inline]`

Clippy complained about two unsafe functions with docs, but without a `# Safety` section. So I took what looked like the safety notes of those functions and formatted them according to the standard.