### PR TITLE
Mark interior mutable consts as allowed

### DIFF
--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -72,7 +72,7 @@ impl Bucket {
     #[inline]
     pub fn new(timeout: Instant, seed: u32) -> Self {
         Self {
-            mutex: WordLock::INIT,
+            mutex: WordLock::new(),
             queue_head: Cell::new(ptr::null()),
             queue_tail: Cell::new(ptr::null()),
             fair_timeout: UnsafeCell::new(FairTimeout::new(timeout, seed)),
@@ -1228,7 +1228,7 @@ mod deadlock_impl {
     // Returns all detected thread wait cycles.
     // Note that once a cycle is reported it's never reported again.
     unsafe fn check_wait_graph_slow() -> Vec<Vec<DeadlockedThread>> {
-        static DEADLOCK_DETECTION_LOCK: WordLock = WordLock::INIT;
+        static DEADLOCK_DETECTION_LOCK: WordLock = WordLock::new();
         DEADLOCK_DETECTION_LOCK.lock();
 
         let mut table = get_hashtable();

--- a/core/src/word_lock.rs
+++ b/core/src/word_lock.rs
@@ -78,9 +78,12 @@ pub struct WordLock {
 }
 
 impl WordLock {
-    pub const INIT: WordLock = WordLock {
-        state: AtomicUsize::new(0),
-    };
+    /// Returns a new, unlocked, WordLock.
+    pub const fn new() -> Self {
+        WordLock {
+            state: AtomicUsize::new(0),
+        }
+    }
 
     #[inline]
     pub fn lock(&self) {

--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -28,6 +28,9 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// exclusive: a lock can't be acquired while the mutex is already locked.
 pub unsafe trait RawMutex {
     /// Initial value for an unlocked mutex.
+    // A “non-constant” const item is a legacy way to supply an initialized value to downstream
+    // static items. Can hopefully be replaced with `const fn new() -> Self` at some point.
+    #[allow(clippy::declare_interior_mutable_const)]
     const INIT: Self;
 
     /// Marker type which determines whether a lock guard should be `Send`. Use

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -37,6 +37,9 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// re-used since that thread is no longer active.
 pub unsafe trait GetThreadId {
     /// Initial value.
+    // A “non-constant” const item is a legacy way to supply an initialized value to downstream
+    // static items. Can hopefully be replaced with `const fn new() -> Self` at some point.
+    #[allow(clippy::declare_interior_mutable_const)]
     const INIT: Self;
 
     /// Returns a non-zero thread ID which identifies the current thread of

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -30,6 +30,9 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// exists.
 pub unsafe trait RawRwLock {
     /// Initial value for an unlocked `RwLock`.
+    // A “non-constant” const item is a legacy way to supply an initialized value to downstream
+    // static items. Can hopefully be replaced with `const fn new() -> Self` at some point.
+    #[allow(clippy::declare_interior_mutable_const)]
     const INIT: Self;
 
     /// Marker type which determines whether a lock guard should be `Send`. Use


### PR DESCRIPTION
Running clippy on this project gives a hard clippy `error`, not just a `warning`, about us having constants that have interior mutability. However, the lint description (https://rust-lang.github.io/rust-clippy/master/index.html#declare_interior_mutable_const) clarifies that this exact use case is the exception to the rule, and is legit.

Marking it as such in the source code and commenting on it has the following benefits:
* Clippy does not error out and give up. Making it continue analysis and give further warnings. Important to find other problems and potential code smells.
* Makes any reader that runs clippy aware of this, instead of making them think we have a bug.

It's only the `INIT`s in the traits that can't currently be made into `const fn` constructors. `WordLock` could be changed so the comment and lint disabling was not needed.