### PR TITLE
Add unsafe safety notes to raw_rwlock.rs

### DIFF
--- a/src/raw_rwlock.rs
+++ b/src/raw_rwlock.rs
@@ -713,16 +713,15 @@ impl RawRwLock {
         // just need to wake up a potentially sleeping pending writer.
         // Using the 2nd key at addr + 1
         let addr = self as *const _ as usize + 1;
-        let callback = |result: UnparkResult| {
+        let callback = |_result: UnparkResult| {
             // Clear the WRITER_PARKED_BIT here since there can only be one
             // parked writer thread.
-            debug_assert!(!result.have_more_threads);
             self.state.fetch_and(!WRITER_PARKED_BIT, Ordering::Relaxed);
             TOKEN_NORMAL
         };
         // SAFETY:
         //   * `addr` is an address we control.
-        //   * `callback` does not panic (in non debug) or call into any function of `parking_lot`.
+        //   * `callback` does not panic or call into any function of `parking_lot`.
         unsafe {
             parking_lot_core::unpark_one(addr, callback);
         }

--- a/src/raw_rwlock.rs
+++ b/src/raw_rwlock.rs
@@ -712,16 +712,19 @@ impl RawRwLock {
     fn unlock_shared_slow(&self) {
         // At this point WRITER_PARKED_BIT is set and READER_MASK is empty. We
         // just need to wake up a potentially sleeping pending writer.
+        // Using the 2nd key at addr + 1
+        let addr = self as *const _ as usize + 1;
+        let callback = |result: UnparkResult| {
+            // Clear the WRITER_PARKED_BIT here since there can only be one
+            // parked writer thread.
+            debug_assert!(!result.have_more_threads);
+            self.state.fetch_and(!WRITER_PARKED_BIT, Ordering::Relaxed);
+            TOKEN_NORMAL
+        };
+        // SAFETY:
+        //   * `addr` is an address we control.
+        //   * `callback` does not panic (in non debug) or call into any function of `parking_lot`.
         unsafe {
-            // Using the 2nd key at addr + 1
-            let addr = self as *const _ as usize + 1;
-            let callback = |result: UnparkResult| {
-                // Clear the WRITER_PARKED_BIT here since there can only be one
-                // parked writer thread.
-                debug_assert!(!result.have_more_threads);
-                self.state.fetch_and(!WRITER_PARKED_BIT, Ordering::Relaxed);
-                TOKEN_NORMAL
-            };
             parking_lot_core::unpark_one(addr, callback);
         }
     }

--- a/src/raw_rwlock.rs
+++ b/src/raw_rwlock.rs
@@ -1046,17 +1046,13 @@ impl RawRwLock {
 
     // Common code for acquiring a lock
     #[inline]
-    fn lock_common<F, V>(
+    fn lock_common(
         &self,
         timeout: Option<Instant>,
         token: ParkToken,
-        mut try_lock: F,
-        validate: V,
-    ) -> bool
-    where
-        F: FnMut(&mut usize) -> bool,
-        V: Fn(usize) -> bool,
-    {
+        mut try_lock: impl FnMut(&mut usize) -> bool,
+        validate: impl Fn(usize) -> bool,
+    ) -> bool {
         let mut spinwait = SpinWait::new();
         let mut state = self.state.load(Ordering::Relaxed);
         loop {


### PR DESCRIPTION
Reducing the amount of expressions inside `unsafe` blocks. And adding `// SAFETY:` documentation to all remaining unsafe blocks.

Found two methods where the unsafety leaked out of methods not marked as unsafe(!). So I made them unsafe and documented what has to be upheld.

Found potential panic in closure that is not allowed to panic. But only in debug builds. What do we do about that?