### PR TITLE
Upgrade _core dep (from parking_lot) to latest 0.6.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["concurrency"]
 edition = "2018"
 
 [dependencies]
-parking_lot_core = { path = "core", version = "0.6" }
+parking_lot_core = { path = "core", version = "0.6.2" }
 lock_api = { path = "lock_api", version = "0.3.1" }
 
 [dev-dependencies]


### PR DESCRIPTION
Fixes #181.

(To the extent that a future release, e.g. parking_lot 0.9.1, is made a replacement "minimum".)