### PR TITLE
Make locking buckets a safe operation

### DIFF
--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -17,6 +17,13 @@ use smallvec::SmallVec;
 use std::time::{Duration, Instant};
 
 static NUM_THREADS: AtomicUsize = AtomicUsize::new(0);
+
+/// Holds the pointer to the currently active `HashTable`.
+///
+/// # Safety
+///
+/// Except for the initial value of null, it must always point to a valid `HashTable` instance.
+/// Any `HashTable` this global static has ever pointed to must never be freed.
 static HASHTABLE: AtomicPtr<HashTable> = AtomicPtr::new(ptr::null_mut());
 
 // Even with 3x more buckets than threads, the memory overhead per thread is

--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -316,7 +316,8 @@ fn hash(key: usize, bits: u32) -> usize {
     key.wrapping_mul(0x9E3779B97F4A7C15) >> (64 - bits)
 }
 
-// Lock the bucket for the given key
+/// Locks the bucket for the given key and returns a reference to it.
+/// The returned bucket must be unlocked again in order to not cause deadlocks.
 #[inline]
 fn lock_bucket(key: usize) -> &'static Bucket {
     let mut bucket;
@@ -341,8 +342,9 @@ fn lock_bucket(key: usize) -> &'static Bucket {
     }
 }
 
-// Lock the bucket for the given key, but check that the key hasn't been changed
-// in the meantime due to a requeue.
+/// Locks the bucket for the given key and returns a reference to it. But checks that the key
+/// hasn't been changed in the meantime due to a requeue.
+/// The returned bucket must be unlocked again in order to not cause deadlocks.
 #[inline]
 fn lock_bucket_checked(key: &AtomicUsize) -> (usize, &'static Bucket) {
     let mut bucket;
@@ -371,7 +373,11 @@ fn lock_bucket_checked(key: &AtomicUsize) -> (usize, &'static Bucket) {
     }
 }
 
-// Lock the two buckets for the given pair of keys
+/// Locks the two buckets for the given pair of keys and returns references to them.
+/// The returned buckets must be unlocked again in order to not cause deadlocks.
+///
+/// If both keys hash to the same value, both returned references will be to the same bucket. Be
+/// careful to only unlock it once in this case, always use `unlock_bucket_pair`.
 #[inline]
 fn lock_bucket_pair(key1: usize, key2: usize) -> (&'static Bucket, &'static Bucket) {
     let mut bucket1;


### PR DESCRIPTION
There should not be anything `unsafe` about locking `HashTable` buckets. There is no input you can give it, nor state you can cause by calling other public functions in this module that will make the lock bucket functions behave unsafely. Unless I missed some aspect of course.

I first made `get_hashtable` and `create_hashtable` return static safe references instead of raw pointers, so working with the returned HashTable became a bit easier. The returned pointers are going to always point to valid HashTables anyway, so I did not see anything unsafe about it. The tables might become inactive, but they will still be there, and never unsafe to access.