### PR TITLE
Replace deprecated mem::uninitialized()

### DIFF
--- a/core/build.rs
+++ b/core/build.rs
@@ -3,4 +3,7 @@ fn main() {
     if cfg.probe_rustc_version(1, 34) {
         println!("cargo:rustc-cfg=has_sized_atomics");
     }
+    if cfg.probe_rustc_version(1, 36) {
+        println!("cargo:rustc-cfg=has_maybe_uninit");
+    }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -56,6 +56,7 @@
     feature(thread_local, checked_duration_since)
 )]
 
+mod maybe_uninit;
 mod parking_lot;
 mod spinwait;
 mod thread_parker;

--- a/core/src/maybe_uninit.rs
+++ b/core/src/maybe_uninit.rs
@@ -19,22 +19,22 @@ pub union MaybeUninit<T: Copy> {
 
 #[cfg(not(has_maybe_uninit))]
 impl<T: Copy> MaybeUninit<T> {
-    #[inline(always)]
+    #[inline]
     pub fn uninit() -> MaybeUninit<T> {
         MaybeUninit { uninit: () }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn as_ptr(&self) -> *const T {
         unsafe { &*self.value as *const T }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn as_mut_ptr(&mut self) -> *mut T {
         unsafe { &mut *self.value as *mut T }
     }
 
-    #[inline(always)]
+    #[inline]
     pub unsafe fn assume_init(self) -> T {
         ManuallyDrop::into_inner(self.value)
     }

--- a/core/src/maybe_uninit.rs
+++ b/core/src/maybe_uninit.rs
@@ -1,0 +1,41 @@
+//! This module contains a re-export or vendored version of `core::mem::MaybeUninit` depending
+//! on which Rust version it's compiled for.
+//!
+//! Remove this module and use `core::mem::MaybeUninit` directly when dropping support for <1.36
+#![allow(dead_code)]
+
+#[cfg(has_maybe_uninit)]
+pub use core::mem::MaybeUninit;
+
+#[cfg(not(has_maybe_uninit))]
+use core::mem::ManuallyDrop;
+
+/// Copied from `core::mem::MaybeUninit` to support Rust older than 1.36
+#[cfg(not(has_maybe_uninit))]
+pub union MaybeUninit<T: Copy> {
+    uninit: (),
+    value: ManuallyDrop<T>,
+}
+
+#[cfg(not(has_maybe_uninit))]
+impl<T: Copy> MaybeUninit<T> {
+    #[inline(always)]
+    pub fn uninit() -> MaybeUninit<T> {
+        MaybeUninit { uninit: () }
+    }
+
+    #[inline(always)]
+    pub fn as_ptr(&self) -> *const T {
+        unsafe { &*self.value as *const T }
+    }
+
+    #[inline(always)]
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        unsafe { &mut *self.value as *mut T }
+    }
+
+    #[inline(always)]
+    pub unsafe fn assume_init(self) -> T {
+        ManuallyDrop::into_inner(self.value)
+    }
+}

--- a/core/src/thread_parker/cloudabi.rs
+++ b/core/src/thread_parker/cloudabi.rs
@@ -5,6 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::maybe_uninit::MaybeUninit;
 use cloudabi as abi;
 use core::{
     cell::Cell,
@@ -70,11 +71,11 @@ impl Lock {
                 },
                 ..mem::zeroed()
             };
-            let mut event: abi::event = mem::uninitialized();
-            let mut nevents: usize = mem::uninitialized();
-            let ret = abi::poll(&subscription, &mut event, 1, &mut nevents);
+            let mut event = MaybeUninit::<abi::event>::uninit();
+            let mut nevents: usize = 0;
+            let ret = abi::poll(&subscription, event.as_mut_ptr(), 1, &mut nevents);
             debug_assert_eq!(ret, abi::errno::SUCCESS);
-            debug_assert_eq!(event.error, abi::errno::SUCCESS);
+            debug_assert_eq!(event.assume_init().error, abi::errno::SUCCESS);
 
             LockGuard { lock: &self.lock }
         })
@@ -146,12 +147,12 @@ impl Condvar {
                 },
                 ..mem::zeroed()
             };
-            let mut event: abi::event = mem::uninitialized();
-            let mut nevents: usize = mem::uninitialized();
+            let mut event = MaybeUninit::<abi::event>::uninit();
+            let mut nevents: usize = 0;
 
-            let ret = abi::poll(&subscription, &mut event, 1, &mut nevents);
+            let ret = abi::poll(&subscription, event.as_mut_ptr(), 1, &mut nevents);
             debug_assert_eq!(ret, abi::errno::SUCCESS);
-            debug_assert_eq!(event.error, abi::errno::SUCCESS);
+            debug_assert_eq!(event.assume_init().error, abi::errno::SUCCESS);
         }
     }
 
@@ -184,11 +185,17 @@ impl Condvar {
                     ..mem::zeroed()
                 },
             ];
-            let mut events: [abi::event; 2] = mem::uninitialized();
-            let mut nevents: usize = mem::uninitialized();
+            let mut events = MaybeUninit::<[abi::event; 2]>::uninit();
+            let mut nevents: usize = 0;
 
-            let ret = abi::poll(subscriptions.as_ptr(), events.as_mut_ptr(), 2, &mut nevents);
+            let ret = abi::poll(
+                subscriptions.as_ptr(),
+                events.as_mut_ptr() as *mut _,
+                2,
+                &mut nevents,
+            );
             debug_assert_eq!(ret, abi::errno::SUCCESS);
+            let events = events.assume_init();
             for i in 0..nevents {
                 debug_assert_eq!(events[i].error, abi::errno::SUCCESS);
                 if events[i].type_ == abi::eventtype::CONDVAR {

--- a/core/src/thread_parker/unix.rs
+++ b/core/src/thread_parker/unix.rs
@@ -5,12 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::maybe_uninit::MaybeUninit;
+use core::cell::{Cell, UnsafeCell};
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 use core::ptr;
-use core::{
-    cell::{Cell, UnsafeCell},
-    mem,
-};
 use libc;
 use std::{
     thread,
@@ -137,14 +135,14 @@ impl ThreadParker {
     #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "android")))]
     #[inline]
     unsafe fn init(&self) {
-        let mut attr: libc::pthread_condattr_t = mem::uninitialized();
-        let r = libc::pthread_condattr_init(&mut attr);
+        let mut attr = MaybeUninit::<libc::pthread_condattr_t>::uninit();
+        let r = libc::pthread_condattr_init(attr.as_mut_ptr());
         debug_assert_eq!(r, 0);
-        let r = libc::pthread_condattr_setclock(&mut attr, libc::CLOCK_MONOTONIC);
+        let r = libc::pthread_condattr_setclock(attr.as_mut_ptr(), libc::CLOCK_MONOTONIC);
         debug_assert_eq!(r, 0);
-        let r = libc::pthread_cond_init(self.condvar.get(), &attr);
+        let r = libc::pthread_cond_init(self.condvar.get(), attr.as_ptr());
         debug_assert_eq!(r, 0);
-        let r = libc::pthread_condattr_destroy(&mut attr);
+        let r = libc::pthread_condattr_destroy(attr.as_mut_ptr());
         debug_assert_eq!(r, 0);
     }
 }
@@ -196,9 +194,11 @@ impl super::UnparkHandleT for UnparkHandle {
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 #[inline]
 fn timespec_now() -> libc::timespec {
-    let mut now: libc::timeval = unsafe { mem::uninitialized() };
-    let r = unsafe { libc::gettimeofday(&mut now, ptr::null_mut()) };
+    let mut now = MaybeUninit::<libc::timeval>::uninit();
+    let r = unsafe { libc::gettimeofday(now.as_mut_ptr(), ptr::null_mut()) };
     debug_assert_eq!(r, 0);
+    // SAFETY: We know `libc::gettimeofday` has initialized the value.
+    let now = unsafe { now.assume_init() };
     libc::timespec {
         tv_sec: now.tv_sec,
         tv_nsec: now.tv_usec as tv_nsec_t * 1000,
@@ -207,7 +207,7 @@ fn timespec_now() -> libc::timespec {
 #[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[inline]
 fn timespec_now() -> libc::timespec {
-    let mut now: libc::timespec = unsafe { mem::uninitialized() };
+    let mut now = MaybeUninit::<libc::timespec>::uninit();
     let clock = if cfg!(target_os = "android") {
         // Android doesn't support pthread_condattr_setclock, so we need to
         // specify the timeout in CLOCK_REALTIME.
@@ -215,9 +215,10 @@ fn timespec_now() -> libc::timespec {
     } else {
         libc::CLOCK_MONOTONIC
     };
-    let r = unsafe { libc::clock_gettime(clock, &mut now) };
+    let r = unsafe { libc::clock_gettime(clock, now.as_mut_ptr()) };
     debug_assert_eq!(r, 0);
-    now
+    // SAFETY: We know `libc::clock_gettime` has initialized the value.
+    unsafe { now.assume_init() }
 }
 
 // Converts a relative timeout into an absolute timeout in the clock used by

--- a/core/src/thread_parker/windows/keyed_event.rs
+++ b/core/src/thread_parker/windows/keyed_event.rs
@@ -5,6 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::maybe_uninit::MaybeUninit;
 use core::{mem, ptr};
 use std::{
     sync::atomic::{AtomicUsize, Ordering},
@@ -88,9 +89,9 @@ impl KeyedEvent {
                 ObjectAttributes: PVOID,
                 Flags: ULONG,
             ) -> NTSTATUS = mem::transmute(NtCreateKeyedEvent);
-            let mut handle = mem::uninitialized();
+            let mut handle = MaybeUninit::uninit();
             let status = NtCreateKeyedEvent(
-                &mut handle,
+                handle.as_mut_ptr(),
                 GENERIC_READ | GENERIC_WRITE,
                 ptr::null_mut(),
                 0,
@@ -100,7 +101,7 @@ impl KeyedEvent {
             }
 
             Some(KeyedEvent {
-                handle,
+                handle: handle.assume_init(),
                 NtReleaseKeyedEvent: mem::transmute(NtReleaseKeyedEvent),
                 NtWaitForKeyedEvent: mem::transmute(NtWaitForKeyedEvent),
             })


### PR DESCRIPTION
Follow up to #173. If we vendor the parts of `MaybeUninit` we need for the places where we use it, then we can get rid of all `mem::uninitialized` and still support Rust older than 1.36.

Because my impression is that there is no way `parking_lot` will make it into `std` while using methods `std` has deprecated and explicitly stated no one should use.

I was not able to make the vendored version `#[repr(transparent)]`.