### PR TITLE
Add changelog entries and bump versions for 0.10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## parking_lot 0.10.0, parking_lot_core 0.7.0, lock_api 0.3.2 (2019-11-25)
+
+- Upgrade smallvec dependency to 1.0 in parking_lot_core.
+- Replace all usage of `mem::unitialized` with `mem::MaybeUninit`.
+- The minimum required Rust version is bumped to 1.36. Because of the above two changes.
+- Make methods on `WaitTimeoutResult` and `OnceState` take `self` by value instead of reference.
+
 ## parking_lot_core 0.6.2 (2019-07-22)
 
 - Fixed compile error on Windows with old cfg_if version. (#164)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parking_lot"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Amanieu d'Antras <amanieu@gmail.com>"]
 description = "More compact and efficient implementations of the standard synchronization primitives."
 license = "Apache-2.0/MIT"
@@ -11,7 +11,7 @@ categories = ["concurrency"]
 edition = "2018"
 
 [dependencies]
-parking_lot_core = { path = "core", version = "0.6.2" }
+parking_lot_core = { path = "core", version = "0.7.0" }
 lock_api = { path = "lock_api", version = "0.3.1" }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ in the Rust standard library:
    parallelism.
 2. Since they consist of just a single atomic variable, have constant
    initializers and don't need destructors, these primitives can be used as
-    `static` global variables. The standard library primitives require
+   `static` global variables. The standard library primitives require
    dynamic initialization and thus need to be lazily initialized with
    `lazy_static!`.
 3. Uncontended lock acquisition and release is done through fast inline
@@ -87,9 +87,8 @@ lock.
 
 There are a few restrictions when using this library on stable Rust:
 
-- `Mutex` and `Once` will use 1 word of space instead of 1 byte.
-- You will have to use `lazy_static!` to statically initialize `Mutex`,
-  `Condvar` and `RwLock` types instead of `const fn`.
+- You will have to use `lazy_static!` or equivalent to statically initialize `Mutex`
+  and `RwLock` types. They use generics and can't be `const fn`s on stable yet.
 - `RwLock` will not be able to take advantage of hardware lock elision for
   readers, which improves performance when there are multiple readers.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-parking_lot = "0.9"
+parking_lot = "0.10"
 ```
 
 and this to your crate root:
@@ -114,7 +114,7 @@ To enable nightly-only features, add this to your `Cargo.toml` instead:
 
 ```toml
 [dependencies]
-parking_lot = {version = "0.9", features = ["nightly"]}
+parking_lot = { version = "0.10", features = ["nightly"] }
 ```
 
 The experimental deadlock detector can be enabled with the

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parking_lot_core"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["Amanieu d'Antras <amanieu@gmail.com>"]
 description = "An advanced API for creating custom synchronization primitives."
 license = "Apache-2.0/MIT"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -49,11 +49,11 @@
         target_arch = "wasm32",
         target_feature = "atomics"
     ),
-    feature(checked_duration_since, stdsimd)
+    feature(stdsimd)
 )]
 #![cfg_attr(
     all(feature = "nightly", target_os = "cloudabi",),
-    feature(thread_local, checked_duration_since)
+    feature(thread_local)
 )]
 
 mod parking_lot;

--- a/lock_api/Cargo.toml
+++ b/lock_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lock_api"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Amanieu d'Antras <amanieu@gmail.com>"]
 description = "Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std."
 license = "Apache-2.0/MIT"


### PR DESCRIPTION
We must first let #193 be merged. Otherwise this changelog is not even correct.

There were a lot of changes since last release. But the vast majority is reformatting and re-arranging to reduce the number of unsafe expressions. As well as adding safety invariant documentation and a few tests. These are cool improvements, but does not affect the public API. I can add something about it in the changelog if you think it's worth it.

`lock_api` only has formatting changes and a few documentation improvements, so I don't think it needs a breaking version change. But might be worth releasing anyway to get the improved documentation out.

The date in the changelog is simply tomorrow. Since I did not think we would have time to release today, and I did not want to just go with `2019-XX-YY` either. If we don't think we'll release tomorrow we can just fix that before merging this PR.