### PR TITLE
Remove rust2015 style docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,6 @@ Add this to your `Cargo.toml`:
 parking_lot = "0.10"
 ```
 
-and this to your crate root:
-
-```rust
-extern crate parking_lot;
-```
-
 To enable nightly-only features, add this to your `Cargo.toml` instead:
 
 ```toml

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -53,10 +53,9 @@ use lock_api;
 /// # Examples
 ///
 /// ```
-/// use std::sync::Arc;
 /// use parking_lot::Mutex;
+/// use std::sync::{Arc, mpsc::channel};
 /// use std::thread;
-/// use std::sync::mpsc::channel;
 ///
 /// const N: usize = 10;
 ///


### PR DESCRIPTION
We juuuust had a release. But when sifting through the docs I stumbled upon a `extern crate parking_lot;`. That felt very ancient. So I removed it.

I also found an example with `use` statements that were not sorted. So very minor, but could fix it while I was at it anyway.