### PR TITLE
fix: not panic in destructor

### DIFF
--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -1198,10 +1198,9 @@ mod deadlock_impl {
     pub unsafe fn release_resource(key: usize) {
         with_thread_data(|thread_data| {
             let resources = &mut (*thread_data.deadlock_data.resources.get());
-            match resources.iter().rposition(|x| *x == key) {
-                Some(p) => resources.swap_remove(p),
-                None => panic!("key {} not found in thread resources", key),
-            };
+            if let Some(p) = resources.iter().rposition(|x| *x == key) {
+                resources.swap_remove(p);
+            }
         });
     }
 


### PR DESCRIPTION
`release_resource` should not panic. Because `with_thread_data` may return a `ThreadData` on the stack, and it's empty.

