### PR TITLE
Create API for mutex that is always fair

### DIFF
--- a/src/fair_mutex.rs
+++ b/src/fair_mutex.rs
@@ -86,7 +86,7 @@ pub type MappedFairMutexGuard<'a, T> = lock_api::MappedMutexGuard<'a, RawFairMut
 
 #[cfg(test)]
 mod tests {
-    use crate::{Condvar, FairMutex};
+    use crate::FairMutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::mpsc::channel;
     use std::sync::Arc;
@@ -95,13 +95,8 @@ mod tests {
     #[cfg(feature = "serde")]
     use bincode::{deserialize, serialize};
 
-    struct Packet<T>(Arc<(FairMutex<T>, Condvar)>);
-
     #[derive(Eq, PartialEq, Debug)]
     struct NonCopy(i32);
-
-    unsafe impl<T: Send> Send for Packet<T> {}
-    unsafe impl<T> Sync for Packet<T> {}
 
     #[test]
     fn smoke() {
@@ -181,29 +176,6 @@ mod tests {
         let mut m = FairMutex::new(NonCopy(10));
         *m.get_mut() = NonCopy(20);
         assert_eq!(m.into_inner(), NonCopy(20));
-    }
-
-    #[test]
-    fn test_mutex_arc_condvar() {
-        let packet = Packet(Arc::new((FairMutex::new(false), Condvar::new())));
-        let packet2 = Packet(packet.0.clone());
-        let (tx, rx) = channel();
-        let _t = thread::spawn(move || {
-            // wait until parent gets in
-            rx.recv().unwrap();
-            let &(ref lock, ref cvar) = &*packet2.0;
-            let mut lock = lock.lock();
-            *lock = true;
-            cvar.notify_one();
-        });
-
-        let &(ref lock, ref cvar) = &*packet.0;
-        let mut lock = lock.lock();
-        tx.send(()).unwrap();
-        assert!(!*lock);
-        while !*lock {
-            cvar.wait(&mut lock);
-        }
     }
 
     #[test]

--- a/src/fair_mutex.rs
+++ b/src/fair_mutex.rs
@@ -239,9 +239,9 @@ mod tests {
     fn test_mutex_debug() {
         let mutex = FairMutex::new(vec![0u8, 10]);
 
-        assert_eq!(format!("{:?}", mutex), "FairMutex { data: [0, 10] }");
+        assert_eq!(format!("{:?}", mutex), "Mutex { data: [0, 10] }");
         let _lock = mutex.lock();
-        assert_eq!(format!("{:?}", mutex), "FairMutex { data: <locked> }");
+        assert_eq!(format!("{:?}", mutex), "Mutex { data: <locked> }");
     }
 
     #[cfg(feature = "serde")]

--- a/src/fair_mutex.rs
+++ b/src/fair_mutex.rs
@@ -8,7 +8,7 @@
 use crate::raw_fair_mutex::RawFairMutex;
 use lock_api;
 
-/// A always fair mutual exclusion primitive useful for protecting shared data
+/// A mutual exclusive primitive that is always fair, useful for protecting shared data
 ///
 /// This mutex will block threads waiting for the lock to become available. The
 /// mutex can also be statically initialized or created via a `new`
@@ -17,9 +17,16 @@ use lock_api;
 /// returned from `lock` and `try_lock`, which guarantees that the data is only
 /// ever accessed when the mutex is locked.
 ///
-/// This mutex is always fair.
+/// The regular mutex provided by `parking_lot` uses eventual locking fairness (after some
+/// time it will default to the fair algorithm), but eventual fairness does not provide the same
+/// garantees a always fair method would. Fair mutexes are generally slower, but sometimes needed.
+/// This wrapper was created to avoid using a unfair protocol when it's forbidden by mistake.
 ///
-/// # Differences from the standard library `FairMutex`
+/// In a fair mutex the lock is provided to whichever thread asked first. Always following the
+/// first-in first-out order. By not allowing other threads to steal the lock even if it would mean
+/// a faster execution.
+///
+/// # Differences from the standard library `Mutex`
 ///
 /// - No poisoning, the lock is released normally on panic.
 /// - Only requires 1 byte of space, whereas the standard library boxes the
@@ -29,8 +36,6 @@ use lock_api;
 /// - Inline fast path for the uncontended case.
 /// - Efficient handling of micro-contention using adaptive spinning.
 /// - Allows raw locking & unlocking without a guard.
-/// - Supports eventual fairness so that the mutex is fair on average.
-/// - Optionally allows making the mutex fair by calling `FairMutexGuard::unlock_fair`.
 ///
 /// # Examples
 ///

--- a/src/fair_mutex.rs
+++ b/src/fair_mutex.rs
@@ -17,14 +17,21 @@ use lock_api;
 /// returned from `lock` and `try_lock`, which guarantees that the data is only
 /// ever accessed when the mutex is locked.
 ///
-/// The regular mutex provided by `parking_lot` uses eventual locking fairness (after some
-/// time it will default to the fair algorithm), but eventual fairness does not provide the same
-/// garantees a always fair method would. Fair mutexes are generally slower, but sometimes needed.
-/// This wrapper was created to avoid using a unfair protocol when it's forbidden by mistake.
+/// The regular mutex provided by `parking_lot` uses eventual locking fairness
+/// (after some time it will default to the fair algorithm), but eventual
+/// fairness does not provide the same garantees a always fair method would.
+/// Fair mutexes are generally slower, but sometimes needed. This wrapper was
+/// created to avoid using a unfair protocol when it's forbidden by mistake.
 ///
-/// In a fair mutex the lock is provided to whichever thread asked first. Always following the
-/// first-in first-out order. By not allowing other threads to steal the lock even if it would mean
-/// a faster execution.
+/// In a fair mutex the lock is provided to whichever thread asked first,
+/// they form a queue and always follow the first-in first-out order. This
+/// means some thread in the queue won't be able to steal the lock and use it fast
+/// to increase throughput, at the cost of latency. Since the response time will grow
+/// for some threads that are waiting for the lock and losing to faster but later ones,
+/// but it may make sending more responses possible.
+///
+/// A fair mutex may not be interesting if threads have different priorities (this is known as
+/// priority inversion).
 ///
 /// # Differences from the standard library `Mutex`
 ///

--- a/src/fair_mutex.rs
+++ b/src/fair_mutex.rs
@@ -1,0 +1,287 @@
+// Copyright 2016 Amanieu d'Antras
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::raw_fair_mutex::RawFairMutex;
+use lock_api;
+
+/// A always fair mutual exclusion primitive useful for protecting shared data
+///
+/// This mutex will block threads waiting for the lock to become available. The
+/// mutex can also be statically initialized or created via a `new`
+/// constructor. Each mutex has a type parameter which represents the data that
+/// it is protecting. The data can only be accessed through the RAII guards
+/// returned from `lock` and `try_lock`, which guarantees that the data is only
+/// ever accessed when the mutex is locked.
+///
+/// This mutex is always fair.
+///
+/// # Differences from the standard library `FairMutex`
+///
+/// - No poisoning, the lock is released normally on panic.
+/// - Only requires 1 byte of space, whereas the standard library boxes the
+///   `FairMutex` due to platform limitations.
+/// - Can be statically constructed (requires the `const_fn` nightly feature).
+/// - Does not require any drop glue when dropped.
+/// - Inline fast path for the uncontended case.
+/// - Efficient handling of micro-contention using adaptive spinning.
+/// - Allows raw locking & unlocking without a guard.
+/// - Supports eventual fairness so that the mutex is fair on average.
+/// - Optionally allows making the mutex fair by calling `FairMutexGuard::unlock_fair`.
+///
+/// # Examples
+///
+/// ```
+/// use parking_lot::FairMutex;
+/// use std::sync::{Arc, mpsc::channel};
+/// use std::thread;
+///
+/// const N: usize = 10;
+///
+/// // Spawn a few threads to increment a shared variable (non-atomically), and
+/// // let the main thread know once all increments are done.
+/// //
+/// // Here we're using an Arc to share memory among threads, and the data inside
+/// // the Arc is protected with a mutex.
+/// let data = Arc::new(FairMutex::new(0));
+///
+/// let (tx, rx) = channel();
+/// for _ in 0..10 {
+///     let (data, tx) = (Arc::clone(&data), tx.clone());
+///     thread::spawn(move || {
+///         // The shared state can only be accessed once the lock is held.
+///         // Our non-atomic increment is safe because we're the only thread
+///         // which can access the shared state when the lock is held.
+///         let mut data = data.lock();
+///         *data += 1;
+///         if *data == N {
+///             tx.send(()).unwrap();
+///         }
+///         // the lock is unlocked here when `data` goes out of scope.
+///     });
+/// }
+///
+/// rx.recv().unwrap();
+/// ```
+pub type FairMutex<T> = lock_api::Mutex<RawFairMutex, T>;
+
+/// An RAII implementation of a "scoped lock" of a mutex. When this structure is
+/// dropped (falls out of scope), the lock will be unlocked.
+///
+/// The data protected by the mutex can be accessed through this guard via its
+/// `Deref` and `DerefMut` implementations.
+pub type FairMutexGuard<'a, T> = lock_api::MutexGuard<'a, RawFairMutex, T>;
+
+/// An RAII mutex guard returned by `FairMutexGuard::map`, which can point to a
+/// subfield of the protected data.
+///
+/// The main difference between `MappedFairMutexGuard` and `FairMutexGuard` is that the
+/// former doesn't support temporarily unlocking and re-locking, since that
+/// could introduce soundness issues if the locked object is modified by another
+/// thread.
+pub type MappedFairMutexGuard<'a, T> = lock_api::MappedMutexGuard<'a, RawFairMutex, T>;
+
+#[cfg(test)]
+mod tests {
+    use crate::{Condvar, FairMutex};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::mpsc::channel;
+    use std::sync::Arc;
+    use std::thread;
+
+    #[cfg(feature = "serde")]
+    use bincode::{deserialize, serialize};
+
+    struct Packet<T>(Arc<(FairMutex<T>, Condvar)>);
+
+    #[derive(Eq, PartialEq, Debug)]
+    struct NonCopy(i32);
+
+    unsafe impl<T: Send> Send for Packet<T> {}
+    unsafe impl<T> Sync for Packet<T> {}
+
+    #[test]
+    fn smoke() {
+        let m = FairMutex::new(());
+        drop(m.lock());
+        drop(m.lock());
+    }
+
+    #[test]
+    fn lots_and_lots() {
+        const J: u32 = 1000;
+        const K: u32 = 3;
+
+        let m = Arc::new(FairMutex::new(0));
+
+        fn inc(m: &FairMutex<u32>) {
+            for _ in 0..J {
+                *m.lock() += 1;
+            }
+        }
+
+        let (tx, rx) = channel();
+        for _ in 0..K {
+            let tx2 = tx.clone();
+            let m2 = m.clone();
+            thread::spawn(move || {
+                inc(&m2);
+                tx2.send(()).unwrap();
+            });
+            let tx2 = tx.clone();
+            let m2 = m.clone();
+            thread::spawn(move || {
+                inc(&m2);
+                tx2.send(()).unwrap();
+            });
+        }
+
+        drop(tx);
+        for _ in 0..2 * K {
+            rx.recv().unwrap();
+        }
+        assert_eq!(*m.lock(), J * K * 2);
+    }
+
+    #[test]
+    fn try_lock() {
+        let m = FairMutex::new(());
+        *m.try_lock().unwrap() = ();
+    }
+
+    #[test]
+    fn test_into_inner() {
+        let m = FairMutex::new(NonCopy(10));
+        assert_eq!(m.into_inner(), NonCopy(10));
+    }
+
+    #[test]
+    fn test_into_inner_drop() {
+        struct Foo(Arc<AtomicUsize>);
+        impl Drop for Foo {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+        let num_drops = Arc::new(AtomicUsize::new(0));
+        let m = FairMutex::new(Foo(num_drops.clone()));
+        assert_eq!(num_drops.load(Ordering::SeqCst), 0);
+        {
+            let _inner = m.into_inner();
+            assert_eq!(num_drops.load(Ordering::SeqCst), 0);
+        }
+        assert_eq!(num_drops.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn test_get_mut() {
+        let mut m = FairMutex::new(NonCopy(10));
+        *m.get_mut() = NonCopy(20);
+        assert_eq!(m.into_inner(), NonCopy(20));
+    }
+
+    #[test]
+    fn test_mutex_arc_condvar() {
+        let packet = Packet(Arc::new((FairMutex::new(false), Condvar::new())));
+        let packet2 = Packet(packet.0.clone());
+        let (tx, rx) = channel();
+        let _t = thread::spawn(move || {
+            // wait until parent gets in
+            rx.recv().unwrap();
+            let &(ref lock, ref cvar) = &*packet2.0;
+            let mut lock = lock.lock();
+            *lock = true;
+            cvar.notify_one();
+        });
+
+        let &(ref lock, ref cvar) = &*packet.0;
+        let mut lock = lock.lock();
+        tx.send(()).unwrap();
+        assert!(!*lock);
+        while !*lock {
+            cvar.wait(&mut lock);
+        }
+    }
+
+    #[test]
+    fn test_mutex_arc_nested() {
+        // Tests nested mutexes and access
+        // to underlying data.
+        let arc = Arc::new(FairMutex::new(1));
+        let arc2 = Arc::new(FairMutex::new(arc));
+        let (tx, rx) = channel();
+        let _t = thread::spawn(move || {
+            let lock = arc2.lock();
+            let lock2 = lock.lock();
+            assert_eq!(*lock2, 1);
+            tx.send(()).unwrap();
+        });
+        rx.recv().unwrap();
+    }
+
+    #[test]
+    fn test_mutex_arc_access_in_unwind() {
+        let arc = Arc::new(FairMutex::new(1));
+        let arc2 = arc.clone();
+        let _ = thread::spawn(move || {
+            struct Unwinder {
+                i: Arc<FairMutex<i32>>,
+            }
+            impl Drop for Unwinder {
+                fn drop(&mut self) {
+                    *self.i.lock() += 1;
+                }
+            }
+            let _u = Unwinder { i: arc2 };
+            panic!();
+        })
+        .join();
+        let lock = arc.lock();
+        assert_eq!(*lock, 2);
+    }
+
+    #[test]
+    fn test_mutex_unsized() {
+        let mutex: &FairMutex<[i32]> = &FairMutex::new([1, 2, 3]);
+        {
+            let b = &mut *mutex.lock();
+            b[0] = 4;
+            b[2] = 5;
+        }
+        let comp: &[i32] = &[4, 2, 5];
+        assert_eq!(&*mutex.lock(), comp);
+    }
+
+    #[test]
+    fn test_mutexguard_sync() {
+        fn sync<T: Sync>(_: T) {}
+
+        let mutex = FairMutex::new(());
+        sync(mutex.lock());
+    }
+
+    #[test]
+    fn test_mutex_debug() {
+        let mutex = FairMutex::new(vec![0u8, 10]);
+
+        assert_eq!(format!("{:?}", mutex), "FairMutex { data: [0, 10] }");
+        let _lock = mutex.lock();
+        assert_eq!(format!("{:?}", mutex), "FairMutex { data: <locked> }");
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde() {
+        let contents: Vec<u8> = vec![0, 1, 2];
+        let mutex = FairMutex::new(contents.clone());
+
+        let serialized = serialize(&mutex).unwrap();
+        let deserialized: FairMutex<Vec<u8>> = deserialize(&serialized).unwrap();
+
+        assert_eq!(*(mutex.lock()), *(deserialized.lock()));
+        assert_eq!(contents, *(deserialized.lock()));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,11 @@
 
 mod condvar;
 mod elision;
+mod fair_mutex;
 mod mutex;
 mod once;
 mod raw_mutex;
+mod raw_fair_mutex;
 mod raw_rwlock;
 mod remutex;
 mod rwlock;
@@ -30,8 +32,10 @@ mod deadlock;
 
 pub use self::condvar::{Condvar, WaitTimeoutResult};
 pub use self::mutex::{MappedMutexGuard, Mutex, MutexGuard};
+pub use self::fair_mutex::{MappedFairMutexGuard, FairMutex, FairMutexGuard};
 pub use self::once::{Once, OnceState};
 pub use self::raw_mutex::RawMutex;
+pub use self::raw_fair_mutex::RawFairMutex;
 pub use self::raw_rwlock::RawRwLock;
 pub use self::remutex::{
     MappedReentrantMutexGuard, RawThreadId, ReentrantMutex, ReentrantMutexGuard,

--- a/src/raw_fair_mutex.rs
+++ b/src/raw_fair_mutex.rs
@@ -1,0 +1,60 @@
+// Copyright 2016 Amanieu d'Antras
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::raw_mutex::RawMutex;
+use lock_api::RawMutexFair;
+
+/// Raw fair mutex type backed by the parking lot.
+pub struct RawFairMutex(RawMutex);
+
+unsafe impl lock_api::RawMutex for RawFairMutex {
+    const INIT: Self = RawFairMutex(<RawMutex as lock_api::RawMutex>::INIT);
+
+    type GuardMarker = <RawMutex as lock_api::RawMutex>::GuardMarker;
+
+    #[inline]
+    fn lock(&self) {
+        self.0.lock()
+    }
+
+    #[inline]
+    fn try_lock(&self) -> bool {
+        self.0.try_lock()
+    }
+
+    #[inline]
+    fn unlock(&self) {
+        self.unlock_fair()
+    }
+}
+
+unsafe impl lock_api::RawMutexFair for RawFairMutex {
+    #[inline]
+    fn unlock_fair(&self) {
+        self.0.unlock_fair()
+    }
+
+    #[inline]
+    fn bump(&self) {
+        self.0.bump()
+    }
+}
+
+unsafe impl lock_api::RawMutexTimed for RawFairMutex {
+    type Duration = <RawMutex as lock_api::RawMutexTimed>::Duration;
+    type Instant = <RawMutex as lock_api::RawMutexTimed>::Instant;
+
+    #[inline]
+    fn try_lock_until(&self, timeout: Self::Instant) -> bool {
+        self.0.try_lock_until(timeout)
+    }
+
+    #[inline]
+    fn try_lock_for(&self, timeout: Self::Duration) -> bool {
+        self.0.try_lock_for(timeout)
+    }
+}


### PR DESCRIPTION
Fixes #76. I don't know if there is interest in having a API for a Mutex that is always fair, but solving it at the type level seems better than requiring a state for each mutex. Fairness sometimes is required, so making type level assurances so another dev can't screw up may solve a bunch of problems, it's probably already being done by people that need it since it's just a thin wrapper. 

This implements a `FairMutex` and it's `RawFairMutex`. This could be done for RwLock too if there is interest.

Idk if the tests are required since it's literally calling something already tested, but I just copied the files and made it compile. I had to remove the Condvar test, since Condvar assumes it's a MutexGuard, and doesn't accept a FairMutexGuard.