### PR TITLE
Fix documentation and example for `try_lock`

### DIFF
--- a/lock_api/src/lib.rs
+++ b/lock_api/src/lib.rs
@@ -47,7 +47,9 @@
 //!     }
 //!
 //!     fn try_lock(&self) -> bool {
-//!         self.0.swap(true, Ordering::Acquire)
+//!         self.0
+//!             .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+//!             .is_ok()
 //!     }
 //!
 //!     fn unlock(&self) {

--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -40,7 +40,8 @@ pub unsafe trait RawMutex {
     /// Acquires this mutex, blocking the current thread until it is able to do so.
     fn lock(&self);
 
-    /// Attempts to acquire this mutex without blocking.
+    /// Attempts to acquire this mutex without blocking. Returns `true`
+    /// if the lock was successfully acquired and `false` otherwise.
     fn try_lock(&self) -> bool;
 
     /// Unlocks this mutex.


### PR DESCRIPTION
As described in #206:

The example implementation for `try_lock` from the `lock_api` crate was incorrect and has been fixed. Additionally a description of what the `bool` returned from `try_lock` means has been added.