### PR TITLE
Implement Support for creating the locking primitives in a const context on stable Rust

### DIFF
--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -132,8 +132,9 @@ impl<R: RawMutex, T> Mutex<R, T> {
 }
 
 impl<R, T> Mutex<R, T> {
-    /// Creates a new mutex based on a pre-existing raw mutex. This allows
-    /// creating a mutex in a constant context on stable Rust.
+    /// Creates a new mutex based on a pre-existing raw mutex.
+    ///
+    /// This allows creating a mutex in a constant context on stable Rust.
     #[inline]
     pub const fn const_new(raw_mutex: R, val: T) -> Mutex<R, T> {
         Mutex {

--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -95,7 +95,7 @@ pub unsafe trait RawMutexTimed: RawMutex {
 /// it is protecting. The data can only be accessed through the RAII guards
 /// returned from `lock` and `try_lock`, which guarantees that the data is only
 /// ever accessed when the mutex is locked.
-pub struct Mutex<R: RawMutex, T: ?Sized> {
+pub struct Mutex<R, T: ?Sized> {
     raw: R,
     data: UnsafeCell<T>,
 }
@@ -128,6 +128,18 @@ impl<R: RawMutex, T> Mutex<R, T> {
     #[inline]
     pub fn into_inner(self) -> T {
         self.data.into_inner()
+    }
+}
+
+impl<R, T> Mutex<R, T> {
+    /// Creates a new mutex based on a pre-existing raw mutex. This allows
+    /// creating a mutex in a constant context on stable Rust.
+    #[inline]
+    pub const fn const_new(raw_mutex: R, val: T) -> Mutex<R, T> {
+        Mutex {
+            raw: raw_mutex,
+            data: UnsafeCell::new(val),
+        }
     }
 }
 

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -198,21 +198,19 @@ impl<R: RawMutex, G: GetThreadId, T> ReentrantMutex<R, G, T> {
 }
 
 impl<R, G, T> ReentrantMutex<R, G, T> {
-    /// Creates a new reentrant mutex based on a pre-existing raw reentrant
-    /// mutex and a helper to get the thread ID. This allows creating a
-    /// reentrant mutex in a constant context on stable Rust.
+    /// Creates a new reentrant mutex based on a pre-existing raw mutex and a
+    /// helper to get the thread ID.
+    ///
+    /// This allows creating a reentrant mutex in a constant context on stable
+    /// Rust.
     #[inline]
-    pub const fn const_new(
-        raw_reentrant_mutex: R,
-        get_thread_id: G,
-        val: T,
-    ) -> ReentrantMutex<R, G, T> {
+    pub const fn const_new(raw_mutex: R, get_thread_id: G, val: T) -> ReentrantMutex<R, G, T> {
         ReentrantMutex {
             data: UnsafeCell::new(val),
             raw: RawReentrantMutex {
                 owner: AtomicUsize::new(0),
                 lock_count: Cell::new(0),
-                mutex: raw_reentrant_mutex,
+                mutex: raw_mutex,
                 get_thread_id,
             },
         }

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -231,7 +231,7 @@ pub unsafe trait RawRwLockUpgradeTimed: RawRwLockUpgrade + RawRwLockTimed {
 /// allow concurrent access through readers. The RAII guards returned from the
 /// locking methods implement `Deref` (and `DerefMut` for the `write` methods)
 /// to allow access to the contained of the lock.
-pub struct RwLock<R: RawRwLock, T: ?Sized> {
+pub struct RwLock<R, T: ?Sized> {
     raw: R,
     data: UnsafeCell<T>,
 }
@@ -294,6 +294,19 @@ impl<R: RawRwLock, T> RwLock<R, T> {
     #[allow(unused_unsafe)]
     pub fn into_inner(self) -> T {
         unsafe { self.data.into_inner() }
+    }
+}
+
+impl<R, T> RwLock<R, T> {
+    /// Creates a new new instance of an `RwLock<T>` based on a pre-existing
+    /// `RawRwLock<T>`. This allows creating a `RwLock<T>` in a constant context
+    /// on stable Rust.
+    #[inline]
+    pub const fn const_new(raw_rwlock: R, val: T) -> RwLock<R, T> {
+        RwLock {
+            data: UnsafeCell::new(val),
+            raw: raw_rwlock,
+        }
     }
 }
 

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -299,8 +299,10 @@ impl<R: RawRwLock, T> RwLock<R, T> {
 
 impl<R, T> RwLock<R, T> {
     /// Creates a new new instance of an `RwLock<T>` based on a pre-existing
-    /// `RawRwLock<T>`. This allows creating a `RwLock<T>` in a constant context
-    /// on stable Rust.
+    /// `RawRwLock<T>`.
+    ///
+    /// This allows creating a `RwLock<T>` in a constant context on stable
+    /// Rust.
     #[inline]
     pub const fn const_new(raw_rwlock: R, val: T) -> RwLock<R, T> {
         RwLock {

--- a/src/fair_mutex.rs
+++ b/src/fair_mutex.rs
@@ -80,6 +80,12 @@ use lock_api;
 /// ```
 pub type FairMutex<T> = lock_api::Mutex<RawFairMutex, T>;
 
+/// Creates a new fair mutex in an unlocked state ready for use. This allows
+/// creating a fair mutex in a constant context on stable Rust.
+pub const fn new_fair_mutex<T>(val: T) -> FairMutex<T> {
+    FairMutex::const_new(<RawFairMutex as lock_api::RawMutex>::INIT, val)
+}
+
 /// An RAII implementation of a "scoped lock" of a mutex. When this structure is
 /// dropped (falls out of scope), the lock will be unlocked.
 ///

--- a/src/fair_mutex.rs
+++ b/src/fair_mutex.rs
@@ -80,9 +80,10 @@ use lock_api;
 /// ```
 pub type FairMutex<T> = lock_api::Mutex<RawFairMutex, T>;
 
-/// Creates a new fair mutex in an unlocked state ready for use. This allows
-/// creating a fair mutex in a constant context on stable Rust.
-pub const fn new_fair_mutex<T>(val: T) -> FairMutex<T> {
+/// Creates a new fair mutex in an unlocked state ready for use.
+///
+/// This allows creating a fair mutex in a constant context on stable Rust.
+pub const fn const_fair_mutex<T>(val: T) -> FairMutex<T> {
     FairMutex::const_new(<RawFairMutex as lock_api::RawMutex>::INIT, val)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@ mod elision;
 mod fair_mutex;
 mod mutex;
 mod once;
-mod raw_mutex;
 mod raw_fair_mutex;
+mod raw_mutex;
 mod raw_rwlock;
 mod remutex;
 mod rwlock;
@@ -31,17 +31,18 @@ pub mod deadlock;
 mod deadlock;
 
 pub use self::condvar::{Condvar, WaitTimeoutResult};
-pub use self::mutex::{MappedMutexGuard, Mutex, MutexGuard};
-pub use self::fair_mutex::{MappedFairMutexGuard, FairMutex, FairMutexGuard};
+pub use self::fair_mutex::{new_fair_mutex, FairMutex, FairMutexGuard, MappedFairMutexGuard};
+pub use self::mutex::{new_mutex, MappedMutexGuard, Mutex, MutexGuard};
 pub use self::once::{Once, OnceState};
-pub use self::raw_mutex::RawMutex;
 pub use self::raw_fair_mutex::RawFairMutex;
+pub use self::raw_mutex::RawMutex;
 pub use self::raw_rwlock::RawRwLock;
 pub use self::remutex::{
-    MappedReentrantMutexGuard, RawThreadId, ReentrantMutex, ReentrantMutexGuard,
+    new_reentrant_mutex, MappedReentrantMutexGuard, RawThreadId, ReentrantMutex,
+    ReentrantMutexGuard,
 };
 pub use self::rwlock::{
-    MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock, RwLockReadGuard,
+    new_rwlock, MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock, RwLockReadGuard,
     RwLockUpgradableReadGuard, RwLockWriteGuard,
 };
 pub use ::lock_api;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,18 +31,18 @@ pub mod deadlock;
 mod deadlock;
 
 pub use self::condvar::{Condvar, WaitTimeoutResult};
-pub use self::fair_mutex::{new_fair_mutex, FairMutex, FairMutexGuard, MappedFairMutexGuard};
-pub use self::mutex::{new_mutex, MappedMutexGuard, Mutex, MutexGuard};
+pub use self::fair_mutex::{const_fair_mutex, FairMutex, FairMutexGuard, MappedFairMutexGuard};
+pub use self::mutex::{const_mutex, MappedMutexGuard, Mutex, MutexGuard};
 pub use self::once::{Once, OnceState};
 pub use self::raw_fair_mutex::RawFairMutex;
 pub use self::raw_mutex::RawMutex;
 pub use self::raw_rwlock::RawRwLock;
 pub use self::remutex::{
-    new_reentrant_mutex, MappedReentrantMutexGuard, RawThreadId, ReentrantMutex,
+    const_reentrant_mutex, MappedReentrantMutexGuard, RawThreadId, ReentrantMutex,
     ReentrantMutexGuard,
 };
 pub use self::rwlock::{
-    new_rwlock, MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock, RwLockReadGuard,
+    const_rwlock, MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock, RwLockReadGuard,
     RwLockUpgradableReadGuard, RwLockWriteGuard,
 };
 pub use ::lock_api;

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -86,9 +86,10 @@ use lock_api;
 /// ```
 pub type Mutex<T> = lock_api::Mutex<RawMutex, T>;
 
-/// Creates a new mutex in an unlocked state ready for use. This allows creating
-/// a mutex in a constant context on stable Rust.
-pub const fn new_mutex<T>(val: T) -> Mutex<T> {
+/// Creates a new mutex in an unlocked state ready for use.
+///
+/// This allows creating a mutex in a constant context on stable Rust.
+pub const fn const_mutex<T>(val: T) -> Mutex<T> {
     Mutex::const_new(<RawMutex as lock_api::RawMutex>::INIT, val)
 }
 

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -86,6 +86,12 @@ use lock_api;
 /// ```
 pub type Mutex<T> = lock_api::Mutex<RawMutex, T>;
 
+/// Creates a new mutex in an unlocked state ready for use. This allows creating
+/// a mutex in a constant context on stable Rust.
+pub const fn new_mutex<T>(val: T) -> Mutex<T> {
+    Mutex::const_new(<RawMutex as lock_api::RawMutex>::INIT, val)
+}
+
 /// An RAII implementation of a "scoped lock" of a mutex. When this structure is
 /// dropped (falls out of scope), the lock will be unlocked.
 ///

--- a/src/remutex.rs
+++ b/src/remutex.rs
@@ -40,6 +40,16 @@ unsafe impl GetThreadId for RawThreadId {
 /// primitive.
 pub type ReentrantMutex<T> = lock_api::ReentrantMutex<RawMutex, RawThreadId, T>;
 
+/// Creates a new reentrant mutex in an unlocked state ready for use. This
+/// allows creating a reentrant mutex in a constant context on stable Rust.
+pub const fn new_reentrant_mutex<T>(val: T) -> ReentrantMutex<T> {
+    ReentrantMutex::const_new(
+        <RawMutex as lock_api::RawMutex>::INIT,
+        <RawThreadId as lock_api::GetThreadId>::INIT,
+        val,
+    )
+}
+
 /// An RAII implementation of a "scoped lock" of a reentrant mutex. When this structure
 /// is dropped (falls out of scope), the lock will be unlocked.
 ///

--- a/src/remutex.rs
+++ b/src/remutex.rs
@@ -40,9 +40,10 @@ unsafe impl GetThreadId for RawThreadId {
 /// primitive.
 pub type ReentrantMutex<T> = lock_api::ReentrantMutex<RawMutex, RawThreadId, T>;
 
-/// Creates a new reentrant mutex in an unlocked state ready for use. This
-/// allows creating a reentrant mutex in a constant context on stable Rust.
-pub const fn new_reentrant_mutex<T>(val: T) -> ReentrantMutex<T> {
+/// Creates a new reentrant mutex in an unlocked state ready for use.
+///
+/// This allows creating a reentrant mutex in a constant context on stable Rust.
+pub const fn const_reentrant_mutex<T>(val: T) -> ReentrantMutex<T> {
     ReentrantMutex::const_new(
         <RawMutex as lock_api::RawMutex>::INIT,
         <RawThreadId as lock_api::GetThreadId>::INIT,

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -88,9 +88,10 @@ use lock_api;
 /// ```
 pub type RwLock<T> = lock_api::RwLock<RawRwLock, T>;
 
-/// Creates a new instance of an `RwLock<T>` which is unlocked. This allows
-/// creating a `RwLock<T>` in a constant context on stable Rust.
-pub const fn new_rwlock<T>(val: T) -> RwLock<T> {
+/// Creates a new instance of an `RwLock<T>` which is unlocked.
+///
+/// This allows creating a `RwLock<T>` in a constant context on stable Rust.
+pub const fn const_rwlock<T>(val: T) -> RwLock<T> {
     RwLock::const_new(<RawRwLock as lock_api::RawRwLock>::INIT, val)
 }
 

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -88,6 +88,12 @@ use lock_api;
 /// ```
 pub type RwLock<T> = lock_api::RwLock<RawRwLock, T>;
 
+/// Creates a new instance of an `RwLock<T>` which is unlocked. This allows
+/// creating a `RwLock<T>` in a constant context on stable Rust.
+pub const fn new_rwlock<T>(val: T) -> RwLock<T> {
+    RwLock::const_new(<RawRwLock as lock_api::RawRwLock>::INIT, val)
+}
+
 /// RAII structure used to release the shared read access of a lock when
 /// dropped.
 pub type RwLockReadGuard<'a, T> = lock_api::RwLockReadGuard<'a, RawRwLock, T>;


### PR DESCRIPTION
This adds a new constructor `const_new` to lock_api's mutexes, reentrant mutexes and RwLocks that allows creating them in a constant context on stable Rust by manually passing in the underlying raw mutex / rwlock.

Additionally, various helper functions are being added to parking_lot that allow creating mutexes, reentrant mutexes, fair mutexes and RwLocks in constant contexts on stable Rust.