### PR TITLE
Remove the lazy_static dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ lock_api = { path = "lock_api", version = "0.3.1" }
 
 [dev-dependencies]
 rand = "0.7"
-lazy_static = "1.0"
 
 # Used when testing out serde support.
 bincode = {version = "1.1.3"}

--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ lock.
 
 There are a few restrictions when using this library on stable Rust:
 
-- You will have to use `lazy_static!` or equivalent to statically initialize `Mutex`
-  and `RwLock` types. They use generics and can't be `const fn`s on stable yet.
+- You will have to use the `const_*` functions (e.g. `const_mutex(val)`) to
+  statically initialize the locking primitives. Using e.g. `Mutex::new(val)`
+  does not work on stable Rust yet.
 - `RwLock` will not be able to take advantage of hardware lock elision for
   readers, which improves performance when there are multiple readers.
 

--- a/src/deadlock.rs
+++ b/src/deadlock.rs
@@ -46,9 +46,7 @@ mod tests {
     use std::time::Duration;
 
     // We need to serialize these tests since deadlock detection uses global state
-    lazy_static::lazy_static! {
-        static ref DEADLOCK_DETECTION_LOCK: Mutex<()> = Mutex::new(());
-    }
+    static DEADLOCK_DETECTION_LOCK: Mutex<()> = crate::const_mutex(());
 
     fn check_deadlock() -> bool {
         use parking_lot_core::deadlock::check_deadlock;


### PR DESCRIPTION
I noticed there's a few things I missed in my previous PR.

1. lazy_static is not necessary anymore. We can just use the new const constructor functions instead.
2. The README still mentions lazy_static.