### PR TITLE
Use llvm_asm! instead of asm!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,3 +82,10 @@ matrix:
 
 notifications:
   email: false
+
+branches:
+  # Don't build these branches
+  except:
+    # Used by bors
+    - trying.tmp
+    - staging.tmp

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,3 @@
+status = [
+  "continuous-integration/travis-ci/push",
+]

--- a/src/elision.rs
+++ b/src/elision.rs
@@ -57,11 +57,11 @@ impl AtomicElisionExt for AtomicUsize {
     fn elision_compare_exchange_acquire(&self, current: usize, new: usize) -> Result<usize, usize> {
         unsafe {
             let prev: usize;
-            asm!("xacquire; lock; cmpxchgl $2, $1"
-                 : "={eax}" (prev), "+*m" (self)
-                 : "r" (new), "{eax}" (current)
-                 : "memory"
-                 : "volatile");
+            llvm_asm!("xacquire; lock; cmpxchgl $2, $1"
+                      : "={eax}" (prev), "+*m" (self)
+                      : "r" (new), "{eax}" (current)
+                      : "memory"
+                      : "volatile");
             if prev == current {
                 Ok(prev)
             } else {
@@ -74,11 +74,11 @@ impl AtomicElisionExt for AtomicUsize {
     fn elision_compare_exchange_acquire(&self, current: usize, new: usize) -> Result<usize, usize> {
         unsafe {
             let prev: usize;
-            asm!("xacquire; lock; cmpxchgq $2, $1"
-                 : "={rax}" (prev), "+*m" (self)
-                 : "r" (new), "{rax}" (current)
-                 : "memory"
-                 : "volatile");
+            llvm_asm!("xacquire; lock; cmpxchgq $2, $1"
+                      : "={rax}" (prev), "+*m" (self)
+                      : "r" (new), "{rax}" (current)
+                      : "memory"
+                      : "volatile");
             if prev == current {
                 Ok(prev)
             } else {
@@ -92,11 +92,11 @@ impl AtomicElisionExt for AtomicUsize {
     fn elision_fetch_sub_release(&self, val: usize) -> usize {
         unsafe {
             let prev: usize;
-            asm!("xrelease; lock; xaddl $2, $1"
-                 : "=r" (prev), "+*m" (self)
-                 : "0" (val.wrapping_neg())
-                 : "memory"
-                 : "volatile");
+            llvm_asm!("xrelease; lock; xaddl $2, $1"
+                      : "=r" (prev), "+*m" (self)
+                      : "0" (val.wrapping_neg())
+                      : "memory"
+                      : "volatile");
             prev
         }
     }
@@ -105,11 +105,11 @@ impl AtomicElisionExt for AtomicUsize {
     fn elision_fetch_sub_release(&self, val: usize) -> usize {
         unsafe {
             let prev: usize;
-            asm!("xrelease; lock; xaddq $2, $1"
-                 : "=r" (prev), "+*m" (self)
-                 : "0" (val.wrapping_neg())
-                 : "memory"
-                 : "volatile");
+            llvm_asm!("xrelease; lock; xaddq $2, $1"
+                      : "=r" (prev), "+*m" (self)
+                      : "0" (val.wrapping_neg())
+                      : "memory"
+                      : "volatile");
             prev
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
-#![cfg_attr(feature = "nightly", feature(asm))]
+#![cfg_attr(feature = "nightly", feature(llvm_asm))]
 
 mod condvar;
 mod elision;


### PR DESCRIPTION
`asm!` will be deprecated soon in preparation for the new `asm!` macro, so switch to using `llvm_asm!` instead.

cc https://github.com/rust-lang/rfcs/pull/2843