### PR TITLE
Fix required lock_api version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["concurrency"]
 edition = "2018"
 
 [dependencies]
-parking_lot_core = { path = "core", version = "0.7.0" }
+parking_lot_core = { path = "core", version = "0.7.1" }
 lock_api = { path = "lock_api", version = "0.3.4" }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 parking_lot_core = { path = "core", version = "0.7.0" }
-lock_api = { path = "lock_api", version = "0.3.1" }
+lock_api = { path = "lock_api", version = "0.3.4" }
 
 [dev-dependencies]
 rand = "0.7"


### PR DESCRIPTION
As of https://github.com/Amanieu/parking_lot/commit/c20495bcc5b3e26cd835ec52aea917b44724d7c3 the additions to lock_api in https://github.com/Amanieu/parking_lot/commit/a9961d4ec400ef54a49183f9063ddf40f2ca23e7 are required to build parking_lot; building with lock_api 0.3.{1,2,3} fails due to missing `_::const_new` functions