### PR TITLE
Uses `instant::Instant` in place of `std::time::Instant`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 [dependencies]
 parking_lot_core = { path = "core", version = "0.7.1" }
 lock_api = { path = "lock_api", version = "0.3.4" }
+instant = "0.1"
 
 [dev-dependencies]
 rand = "0.7"
@@ -26,6 +27,8 @@ owning_ref = ["lock_api/owning_ref"]
 nightly = ["parking_lot_core/nightly", "lock_api/nightly"]
 deadlock_detection = ["parking_lot_core/deadlock_detection"]
 serde = ["lock_api/serde"]
+stdweb = ["instant/stdweb"]
+wasm-bindgen = ["instant/wasm-bindgen"]
 
 [workspace]
 exclude = ["benchmark"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,6 +15,7 @@ smallvec = "1.0"
 petgraph = { version = "0.5", optional = true }
 thread-id = { version = "3.2.0", optional = true }
 backtrace = { version = "0.3.2", optional = true }
+instant = "0.1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.55"

--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -4,17 +4,18 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
-use cfg_if::cfg_if;
 use crate::thread_parker::{ThreadParker, ThreadParkerT, UnparkHandleT};
 use crate::util::UncheckedOptionExt;
 use crate::word_lock::WordLock;
+use cfg_if::cfg_if;
 use core::{
     cell::{Cell, UnsafeCell},
     ptr,
     sync::atomic::{AtomicPtr, AtomicUsize, Ordering},
 };
+use instant::Instant;
 use smallvec::SmallVec;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 cfg_if! {
     if #[cfg(all(
@@ -51,7 +52,7 @@ cfg_if! {
         // See https://github.com/rust-lang/rust/blob/master/src/libstd/sys/wasm/time.rs
         type InstantType = DummyInstant;
     } else {
-        // Otherwise use `std::time::Instant`
+        // Otherwise use `instant::Instant`
         type InstantType = Instant;
     }
 }

--- a/core/src/thread_parker/cloudabi.rs
+++ b/core/src/thread_parker/cloudabi.rs
@@ -11,7 +11,8 @@ use core::{
     mem::{self, MaybeUninit},
     sync::atomic::{AtomicU32, Ordering},
 };
-use std::{convert::TryFrom, thread, time::Instant};
+use instant::Instant;
+use std::{convert::TryFrom, thread};
 
 extern "C" {
     #[thread_local]

--- a/core/src/thread_parker/generic.rs
+++ b/core/src/thread_parker/generic.rs
@@ -9,7 +9,8 @@
 //! parking facilities available.
 
 use core::sync::atomic::{spin_loop_hint, AtomicBool, Ordering};
-use std::{thread, time::Instant};
+use instant::Instant;
+use std::thread;
 
 // Helper type for putting a thread to sleep until some other thread wakes it up
 pub struct ThreadParker {

--- a/core/src/thread_parker/linux.rs
+++ b/core/src/thread_parker/linux.rs
@@ -9,8 +9,9 @@ use core::{
     ptr,
     sync::atomic::{AtomicI32, Ordering},
 };
+use instant::Instant;
 use libc;
-use std::{thread, time::Instant};
+use std::thread;
 
 // x32 Linux uses a non-standard type for tv_nsec in timespec.
 // See https://sourceware.org/bugzilla/show_bug.cgi?id=16437

--- a/core/src/thread_parker/mod.rs
+++ b/core/src/thread_parker/mod.rs
@@ -1,5 +1,5 @@
 use cfg_if::cfg_if;
-use std::time::Instant;
+use instant::Instant;
 
 /// Trait for the platform thread parker implementation.
 ///

--- a/core/src/thread_parker/redox.rs
+++ b/core/src/thread_parker/redox.rs
@@ -9,7 +9,8 @@ use core::{
     ptr,
     sync::atomic::{AtomicI32, Ordering},
 };
-use std::{thread, time::Instant};
+use instant::Instant;
+use std::thread;
 use syscall::{
     call::futex,
     data::TimeSpec,

--- a/core/src/thread_parker/sgx.rs
+++ b/core/src/thread_parker/sgx.rs
@@ -6,6 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use core::sync::atomic::{AtomicBool, Ordering};
+use instant::Instant;
 use std::{
     io,
     os::fortanix_sgx::{
@@ -16,7 +17,6 @@ use std::{
         },
     },
     thread,
-    time::Instant,
 };
 
 // Helper type for putting a thread to sleep until some other thread wakes it up

--- a/core/src/thread_parker/unix.rs
+++ b/core/src/thread_parker/unix.rs
@@ -11,11 +11,9 @@ use core::{
     cell::{Cell, UnsafeCell},
     mem::MaybeUninit,
 };
+use instant::Instant;
 use libc;
-use std::{
-    thread,
-    time::{Duration, Instant},
-};
+use std::{thread, time::Duration};
 
 // x32 Linux uses a non-standard type for tv_nsec in timespec.
 // See https://sourceware.org/bugzilla/show_bug.cgi?id=16437

--- a/core/src/thread_parker/wasm.rs
+++ b/core/src/thread_parker/wasm.rs
@@ -8,7 +8,8 @@
 //! The wasm platform can't park when atomic support is not available.
 //! So this ThreadParker just panics on any attempt to park.
 
-use std::{thread, time::Instant};
+use instant::Instant;
+use std::thread;
 
 pub struct ThreadParker(());
 

--- a/core/src/thread_parker/wasm_atomic.rs
+++ b/core/src/thread_parker/wasm_atomic.rs
@@ -9,7 +9,8 @@ use core::{
     arch::wasm32,
     sync::atomic::{AtomicI32, Ordering},
 };
-use std::{convert::TryFrom, thread, time::Instant};
+use instant::Instant;
+use std::{convert::TryFrom, thread};
 
 // Helper type for putting a thread to sleep until some other thread wakes it up
 pub struct ThreadParker {

--- a/core/src/thread_parker/windows/keyed_event.rs
+++ b/core/src/thread_parker/windows/keyed_event.rs
@@ -9,10 +9,8 @@ use core::{
     mem::{self, MaybeUninit},
     ptr,
 };
-use std::{
-    sync::atomic::{AtomicUsize, Ordering},
-    time::Instant,
-};
+use instant::Instant;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use winapi::{
     shared::{
         minwindef::{TRUE, ULONG},

--- a/core/src/thread_parker/windows/mod.rs
+++ b/core/src/thread_parker/windows/mod.rs
@@ -9,7 +9,7 @@ use core::{
     ptr,
     sync::atomic::{AtomicPtr, AtomicUsize, Ordering},
 };
-use std::time::Instant;
+use instant::Instant;
 
 mod keyed_event;
 mod waitaddress;

--- a/core/src/thread_parker/windows/waitaddress.rs
+++ b/core/src/thread_parker/windows/waitaddress.rs
@@ -9,7 +9,7 @@ use core::{
     mem,
     sync::atomic::{AtomicUsize, Ordering},
 };
-use std::time::Instant;
+use instant::Instant;
 use winapi::{
     shared::{
         basetsd::SIZE_T,

--- a/src/condvar.rs
+++ b/src/condvar.rs
@@ -12,9 +12,10 @@ use core::{
     fmt, ptr,
     sync::atomic::{AtomicPtr, Ordering},
 };
+use instant::Instant;
 use lock_api::RawMutex as RawMutex_;
 use parking_lot_core::{self, ParkResult, RequeueOp, UnparkResult, DEFAULT_PARK_TOKEN};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 /// A type indicating whether a timed wait on a condition variable returned
 /// due to a time out or not.
@@ -413,10 +414,11 @@ impl fmt::Debug for Condvar {
 #[cfg(test)]
 mod tests {
     use crate::{Condvar, Mutex, MutexGuard};
+    use instant::Instant;
     use std::sync::mpsc::channel;
     use std::sync::Arc;
     use std::thread;
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     #[test]
     fn smoke() {

--- a/src/raw_mutex.rs
+++ b/src/raw_mutex.rs
@@ -10,9 +10,9 @@ use core::{
     sync::atomic::{AtomicU8, Ordering},
     time::Duration,
 };
+use instant::Instant;
 use lock_api::{GuardNoSend, RawMutex as RawMutex_};
 use parking_lot_core::{self, ParkResult, SpinWait, UnparkResult, UnparkToken, DEFAULT_PARK_TOKEN};
-use std::time::Instant;
 
 // UnparkToken used to indicate that that the target thread should attempt to
 // lock the mutex again as soon as it is unparked.

--- a/src/raw_rwlock.rs
+++ b/src/raw_rwlock.rs
@@ -12,11 +12,12 @@ use core::{
     cell::Cell,
     sync::atomic::{AtomicUsize, Ordering},
 };
+use instant::Instant;
 use lock_api::{GuardNoSend, RawRwLock as RawRwLock_, RawRwLockUpgrade};
 use parking_lot_core::{
     self, deadlock, FilterOp, ParkResult, ParkToken, SpinWait, UnparkResult, UnparkToken,
 };
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 // This reader-writer lock implementation is based on Boost's upgrade_mutex:
 // https://github.com/boostorg/thread/blob/fc08c1fe2840baeeee143440fba31ef9e9a813c8/include/boost/thread/v2/shared_mutex.hpp#L432

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::time::{Duration, Instant};
+use instant::Instant;
+use std::time::Duration;
 
 // Option::unchecked_unwrap
 pub trait UncheckedOptionExt<T> {


### PR DESCRIPTION
Heya, I was trying out [`governor`](https://github.com/antifuchs/governor) (rate limiter) on WASM, which required `parking_lot` to use a wasm compatible `Instant` type, and I came up with this patch.

The underlying `instant::Instant` type is `std::time::Instant` when compiled without enabling the `"stdweb"` or `"wasm-bindgen"` features.

If you'd like to take it I'll be happy; I'm still trying out different rate-limiting implementations, so am not sure if I'll be using this (but if it's merged, then it's more likely that I will).