### PR TITLE
Make RawReentrantMutex::is_locked public

### DIFF
--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -127,7 +127,7 @@ impl<R: RawMutex, G: GetThreadId> RawReentrantMutex<R, G> {
     }
 
     #[inline]
-    fn is_locked(&self) -> bool {
+    pub fn is_locked(&self) -> bool {
         self.mutex.is_locked()
     }
 }


### PR DESCRIPTION
I guess I missed this with the other PR :smiley: