### PR TITLE
lock_api: Mark unlock and friends unsafe.

### DIFF
--- a/lock_api/src/lib.rs
+++ b/lock_api/src/lib.rs
@@ -52,7 +52,7 @@
 //!             .is_ok()
 //!     }
 //!
-//!     fn unlock(&self) {
+//!     unsafe fn unlock(&self) {
 //!         self.0.store(false, Ordering::Release);
 //!     }
 //! }

--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -94,6 +94,11 @@ pub unsafe trait RawMutexFair: RawMutex {
     /// by `lock`, however it can be much more efficient in the case where there
     /// are no waiting threads.
     ///
+    /// # Safety
+    ///
+    /// This method may only be called if the mutex is held in the current context, see
+    /// the documentation of [`unlock`].
+    ///
     /// [`unlock`]: trait.RawMutex.html#tymethod.unlock
     unsafe fn bump(&self) {
         self.unlock_fair();

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -161,6 +161,8 @@ impl<R: RawMutexFair, G: GetThreadId> RawReentrantMutex<R, G> {
     /// by `lock`, however it can be much more efficient in the case where there
     /// are no waiting threads.
     ///
+    /// # Safety
+    ///
     /// This method may only be called if the mutex is held by the current thread.
     #[inline]
     pub unsafe fn bump(&self) {

--- a/src/raw_fair_mutex.rs
+++ b/src/raw_fair_mutex.rs
@@ -27,7 +27,7 @@ unsafe impl lock_api::RawMutex for RawFairMutex {
     }
 
     #[inline]
-    fn unlock(&self) {
+    unsafe fn unlock(&self) {
         self.unlock_fair()
     }
 

--- a/src/raw_fair_mutex.rs
+++ b/src/raw_fair_mutex.rs
@@ -39,12 +39,12 @@ unsafe impl lock_api::RawMutex for RawFairMutex {
 
 unsafe impl lock_api::RawMutexFair for RawFairMutex {
     #[inline]
-    fn unlock_fair(&self) {
+    unsafe fn unlock_fair(&self) {
         self.0.unlock_fair()
     }
 
     #[inline]
-    fn bump(&self) {
+    unsafe fn bump(&self) {
         self.0.bump()
     }
 }

--- a/src/raw_mutex.rs
+++ b/src/raw_mutex.rs
@@ -97,8 +97,8 @@ unsafe impl lock_api::RawMutex for RawMutex {
     }
 
     #[inline]
-    fn unlock(&self) {
-        unsafe { deadlock::release_resource(self as *const _ as usize) };
+    unsafe fn unlock(&self) {
+        deadlock::release_resource(self as *const _ as usize);
         if self
             .state
             .compare_exchange(LOCKED_BIT, 0, Ordering::Release, Ordering::Relaxed)

--- a/src/raw_mutex.rs
+++ b/src/raw_mutex.rs
@@ -118,8 +118,8 @@ unsafe impl lock_api::RawMutex for RawMutex {
 
 unsafe impl lock_api::RawMutexFair for RawMutex {
     #[inline]
-    fn unlock_fair(&self) {
-        unsafe { deadlock::release_resource(self as *const _ as usize) };
+    unsafe fn unlock_fair(&self) {
+        deadlock::release_resource(self as *const _ as usize);
         if self
             .state
             .compare_exchange(LOCKED_BIT, 0, Ordering::Release, Ordering::Relaxed)
@@ -131,7 +131,7 @@ unsafe impl lock_api::RawMutexFair for RawMutex {
     }
 
     #[inline]
-    fn bump(&self) {
+    unsafe fn bump(&self) {
         if self.state.load(Ordering::Relaxed) & PARKED_BIT != 0 {
             self.bump_slow();
         }


### PR DESCRIPTION
Methods like `unlock`, `bump`, `upgrade`, `downgrade` and similar all assume that a certain kind of lock is being held. Since the wrapper mutex and guard types in the `lock_api` crate guarantee that these APIs are always used correctly, these methods are made unsafe to allow implementers to skip checks for these conditions. This allows sound and efficient implementations of these traits.

I hope I did not forget any methods or screw up any comments.
