### PR TITLE
Fix for two Miri issues with unit tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,7 +42,6 @@ jobs:
           - wasm32-unknown-unknown
           - x86_64-fortanix-unknown-sgx
           #- x86_64-unknown-redox
-          - x86_64-unknown-cloudabi
           #- x86_64-linux-android
     steps:
     - uses: actions/checkout@v2

--- a/src/condvar.rs
+++ b/src/condvar.rs
@@ -663,6 +663,9 @@ mod tests {
         while !c.notify_one() {
             // Wait for the thread to get into wait()
             MutexGuard::bump(&mut g);
+            // Yield, so the other thread gets a chance to do something.
+            // (At least Miri needs this, because it doesn't preempt threads.)
+            thread::yield_now();
         }
         // The thread should have been requeued to the mutex, which we wake up now.
         drop(g);

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -539,8 +539,8 @@ mod tests {
     fn test_rwlock_recursive() {
         let arc = Arc::new(RwLock::new(1));
         let arc2 = arc.clone();
-        let _lock1 = arc.read();
-        thread::spawn(move || {
+        let lock1 = arc.read();
+        let t = thread::spawn(move || {
             let _lock = arc2.write();
         });
 
@@ -554,7 +554,12 @@ mod tests {
         }
 
         // A normal read would block here since there is a pending writer
-        let _lock2 = arc.read_recursive();
+        let lock2 = arc.read_recursive();
+
+        // Unblock the thread and join it.
+        drop(lock1);
+        drop(lock2);
+        t.join().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Fixes https://github.com/Amanieu/parking_lot/issues/251

With this change, all parking_lot tests pass with Miri with https://github.com/rust-lang/miri/pull/1568 applied, except for the `webkit_queue_test`s which are too slow to complete in reasonable time with Miri. (Lowering the number of messages per producer to 100 or 10 makes them pass too.)