### PR TITLE
Update lock_api and instant to most recent versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2018"
 
 [dependencies]
 parking_lot_core = { path = "core", version = "0.8.0" }
-lock_api = { path = "lock_api", version = "0.4.0" }
-instant = "0.1.4"
+lock_api = { path = "lock_api", version = "0.4.1" }
+instant = "0.1.7"
 
 [dev-dependencies]
 rand = "0.7.3"


### PR DESCRIPTION
lock_api is updated from 0.4.0 to 0.4.1.
instant is upsated from 0.1.4 to 0.1.7.