### PR TITLE
Add winapi srwlock to benchmarks

### DIFF
--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -20,3 +20,6 @@ path = "src/rwlock.rs"
 [features]
 nightly = ["parking_lot/nightly"]
 deadlock_detection = ["parking_lot/deadlock_detection"]
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["synchapi"] }


### PR DESCRIPTION
Since I saw you had pthreads in the benchmarks I figured it would make sense to add windows slim rwlocks to it too

It seems std uses srwlocks internally, but it might still make sense to add this since

 1) std could change in the future
 2) It has a fallback for windows xp which looks like it would possibly have some runtime overhead (Even if perfectly predicted the branch could still degrade performance since it would take a spot in the branch predictor right?)
 3) I see you also have pthread implementations in the benchmarks despite std using pthreads internally

With regards to point (2), I see non trivial differences between srwlock and std in an uncontended case:
![imagen](https://user-images.githubusercontent.com/24706838/97094153-976df200-1628-11eb-81e8-c514f9e61b80.png)
