### PR TITLE
RawRwLock::wait_for_readers needs an Acquire to synchronize with unlock_shared

### DIFF
--- a/src/raw_rwlock.rs
+++ b/src/raw_rwlock.rs
@@ -970,11 +970,11 @@ impl RawRwLock {
         // At this point WRITER_BIT is already set, we just need to wait for the
         // remaining readers to exit the lock.
         let mut spinwait = SpinWait::new();
-        let mut state = self.state.load(Ordering::Relaxed);
+        let mut state = self.state.load(Ordering::Acquire);
         while state & READERS_MASK != 0 {
             // Spin a few times to wait for readers to exit
             if spinwait.spin() {
-                state = self.state.load(Ordering::Relaxed);
+                state = self.state.load(Ordering::Acquire);
                 continue;
             }
 
@@ -1019,7 +1019,7 @@ impl RawRwLock {
                 // since a previous writer timing-out could have allowed
                 // another reader to sneak in before we parked.
                 ParkResult::Unparked(_) | ParkResult::Invalid => {
-                    state = self.state.load(Ordering::Relaxed);
+                    state = self.state.load(Ordering::Acquire);
                     continue;
                 }
 


### PR DESCRIPTION
This fixes the TSAN failures in the testsuite.

Fixes #257

cc @Gankra