### PR TITLE
core: Use a weaker dependency on smallvec.

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 cfg-if = "1.0.0"
-smallvec = "1.4.0"
+smallvec = "1.0"
 petgraph = { version = "0.5.1", optional = true }
 thread-id = { version = "3.3.0", optional = true }
 backtrace = { version = "0.3.49", optional = true }


### PR DESCRIPTION
Smallvec 1.4 regresses performance in Firefox, so while we fix it it'd
be nice to be able to not use the new version. parking_lot is not using
try_reserve so it can live with 1.0.