### PR TITLE
OpenBSD returns EINVAL in the same way as DragonFlyBSD.

### DIFF
--- a/core/src/thread_parker/unix.rs
+++ b/core/src/thread_parker/unix.rs
@@ -156,17 +156,9 @@ impl Drop for ThreadParker {
         // this behaviour no longer occurs. The same applies to condvars.
         unsafe {
             let r = libc::pthread_mutex_destroy(self.mutex.get());
-            if cfg!(target_os = "dragonfly") {
-                debug_assert!(r == 0 || r == libc::EINVAL);
-            } else {
-                debug_assert_eq!(r, 0);
-            }
+            debug_assert!(r == 0 || r == libc::EINVAL);
             let r = libc::pthread_cond_destroy(self.condvar.get());
-            if cfg!(target_os = "dragonfly") {
-                debug_assert!(r == 0 || r == libc::EINVAL);
-            } else {
-                debug_assert_eq!(r, 0);
-            }
+            debug_assert!(r == 0 || r == libc::EINVAL);
         }
     }
 }

--- a/core/src/thread_parker/unix.rs
+++ b/core/src/thread_parker/unix.rs
@@ -156,13 +156,13 @@ impl Drop for ThreadParker {
         // this behaviour no longer occurs. The same applies to condvars.
         unsafe {
             let r = libc::pthread_mutex_destroy(self.mutex.get());
-            if cfg!(target_os = "dragonfly") {
+            if cfg!(any(target_os = "dragonfly", target_os = "openbsd")) {
                 debug_assert!(r == 0 || r == libc::EINVAL);
             } else {
                 debug_assert_eq!(r, 0);
             }
             let r = libc::pthread_cond_destroy(self.condvar.get());
-            if cfg!(target_os = "dragonfly") {
+            if cfg!(any(target_os = "dragonfly", target_os = "openbsd")) {
                 debug_assert!(r == 0 || r == libc::EINVAL);
             } else {
                 debug_assert_eq!(r, 0);

--- a/core/src/thread_parker/unix.rs
+++ b/core/src/thread_parker/unix.rs
@@ -156,13 +156,13 @@ impl Drop for ThreadParker {
         // this behaviour no longer occurs. The same applies to condvars.
         unsafe {
             let r = libc::pthread_mutex_destroy(self.mutex.get());
-            if cfg!(any(target_os = "dragonfly", target_os = "openbsd")) {
+            if cfg!(target_os = "dragonfly") {
                 debug_assert!(r == 0 || r == libc::EINVAL);
             } else {
                 debug_assert_eq!(r, 0);
             }
             let r = libc::pthread_cond_destroy(self.condvar.get());
-            if cfg!(any(target_os = "dragonfly", target_os = "openbsd")) {
+            if cfg!(target_os = "dragonfly") {
                 debug_assert!(r == 0 || r == libc::EINVAL);
             } else {
                 debug_assert_eq!(r, 0);


### PR DESCRIPTION
Without this, `cargo test` fails on OpenBSD -current. I suspect all the BSDs have the same behaviour in this regard, but I don't have the ability to test FreeBSD or NetBSD I'm afraid.