### PR TITLE
Update smallvec to 1.6

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 cfg-if = "1.0.0"
-smallvec = "1.0"
+smallvec = "1.6.1"
 petgraph = { version = "0.5.1", optional = true }
 thread-id = { version = "3.3.0", optional = true }
 backtrace = { version = "0.3.49", optional = true }


### PR DESCRIPTION
Fixes #274 

There was a vulnerability found in smallvec as described in:
* https://github.com/servo/rust-smallvec/issues/252
* https://github.com/RustSec/advisory-db/pull/552

This patch updates the package version to 1.6 which is deemed safe to
use.