### PR TITLE
add new const_fn_trait_bound feature gate

### DIFF
--- a/lock_api/src/lib.rs
+++ b/lock_api/src/lib.rs
@@ -88,7 +88,7 @@
 #![no_std]
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
-#![cfg_attr(feature = "nightly", feature(const_fn))]
+#![cfg_attr(feature = "nightly", feature(const_fn, const_fn_trait_bound))]
 
 #[macro_use]
 extern crate scopeguard;


### PR DESCRIPTION
This (and a subsequent release of `lock_api`) is needed to make https://github.com/rust-lang/rust/pull/84556 work.