### PR TITLE
avoid deprecated spin_loop_hint

### DIFF
--- a/core/src/spinwait.rs
+++ b/core/src/spinwait.rs
@@ -6,14 +6,14 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::thread_parker;
-use std::sync::atomic::spin_loop_hint;
+use std::hint;
 
 // Wastes some CPU time for the given number of iterations,
 // using a hint to indicate to the CPU that we are spinning.
 #[inline]
 fn cpu_relax(iterations: u32) {
     for _ in 0..iterations {
-        spin_loop_hint()
+        hint::spin_loop()
     }
 }
 


### PR DESCRIPTION
I noticed some warnings when experimenting with using patched parking_lot in rustc... though somehow the warnings do not show for regular rustc builds?