### PR TITLE
Optionally implement `bytemuck::Zeroable`, for safe zero-allocation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 [dependencies]
 parking_lot_core = { path = "core", version = "0.8.0" }
 lock_api = { path = "lock_api", version = "0.4.0" }
+bytemuck = { version = "1.5.1", optional = true, features = ["derive"] }
 instant = "0.1.4"
 
 [dev-dependencies]
@@ -23,6 +24,7 @@ bincode = "1.3.0"
 
 [features]
 default = []
+bytemuck_traits = ["bytemuck", "lock_api/bytemuck"]
 owning_ref = ["lock_api/owning_ref"]
 nightly = ["parking_lot_core/nightly", "lock_api/nightly"]
 deadlock_detection = ["parking_lot_core/deadlock_detection"]

--- a/lock_api/Cargo.toml
+++ b/lock_api/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["concurrency", "no-std"]
 edition = "2018"
 
 [dependencies]
+bytemuck = { version = "1.5.1", optional = true }
 scopeguard = { version = "1.1.0", default-features = false }
 owning_ref = { version = "0.4.1", optional = true }
 

--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -11,6 +11,9 @@ use core::marker::PhantomData;
 use core::mem;
 use core::ops::{Deref, DerefMut};
 
+#[cfg(feature = "bytemuck")]
+use bytemuck::Zeroable;
+
 #[cfg(feature = "owning_ref")]
 use owning_ref::StableAddress;
 
@@ -137,6 +140,8 @@ pub struct Mutex<R, T: ?Sized> {
     data: UnsafeCell<T>,
 }
 
+#[cfg(feature = "bytemuck")]
+unsafe impl<R: RawMutex + Zeroable, T: Zeroable> Zeroable for Mutex<R, T> {}
 unsafe impl<R: RawMutex + Send, T: ?Sized + Send> Send for Mutex<R, T> {}
 unsafe impl<R: RawMutex + Sync, T: ?Sized + Send> Sync for Mutex<R, T> {}
 

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -11,6 +11,9 @@ use core::marker::PhantomData;
 use core::mem;
 use core::ops::{Deref, DerefMut};
 
+#[cfg(feature = "bytemuck")]
+use bytemuck::Zeroable;
+
 #[cfg(feature = "owning_ref")]
 use owning_ref::StableAddress;
 
@@ -312,6 +315,9 @@ pub struct RwLock<R, T: ?Sized> {
     raw: R,
     data: UnsafeCell<T>,
 }
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<R: RawRwLock + Zeroable, T: Zeroable> Zeroable for RwLock<R, T> {}
 
 // Copied and modified from serde
 #[cfg(feature = "serde")]

--- a/src/raw_fair_mutex.rs
+++ b/src/raw_fair_mutex.rs
@@ -9,6 +9,7 @@ use crate::raw_mutex::RawMutex;
 use lock_api::RawMutexFair;
 
 /// Raw fair mutex type backed by the parking lot.
+#[cfg_attr(feature = "bytemuck", derive(bytemuck::Zeroable))]
 pub struct RawFairMutex(RawMutex);
 
 unsafe impl lock_api::RawMutex for RawFairMutex {

--- a/src/raw_mutex.rs
+++ b/src/raw_mutex.rs
@@ -55,6 +55,9 @@ pub struct RawMutex {
     state: AtomicU8,
 }
 
+#[cfg(feature = "bytemuck")]
+unsafe impl bytemuck::Zeroable for RawMutex {}
+
 unsafe impl lock_api::RawMutex for RawMutex {
     const INIT: RawMutex = RawMutex {
         state: AtomicU8::new(0),

--- a/src/raw_rwlock.rs
+++ b/src/raw_rwlock.rs
@@ -57,6 +57,9 @@ pub struct RawRwLock {
     state: AtomicUsize,
 }
 
+#[cfg(feature = "bytemuck")]
+unsafe impl bytemuck::Zeroable for RawRwLock {}
+
 unsafe impl lock_api::RawRwLock for RawRwLock {
     const INIT: RawRwLock = RawRwLock {
         state: AtomicUsize::new(0),


### PR DESCRIPTION
Closes #286.

We only use `derive(Zeroable)` in one place, as the atomic integer types don't implement `bytemuck::Zeroable` at time of writing. This appears to be an oversight in `bytemuck`.

The `Zeroable` trait only specifies that the type can be _created_ with an all-zeroes bit pattern, and so this cannot be abused to overwrite the locks with all-zeroes (although doing so would require `&mut` access anyway).