### PR TITLE
Add arc_lock feature, with guards that can be accessed from inside of Arc

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         channel: [1.36.0, stable, beta, nightly]
-        feature: [serde, deadlock_detection]
+        feature: [arc_lock, serde, deadlock_detection]
         exclude: 
           - feature: deadlock_detection
             channel: '1.36.0'
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: rustup default nightly
-      - run: cargo doc --workspace --features serde,deadlock_detection --no-deps -p parking_lot -p parking_lot_core -p lock_api
+      - run: cargo doc --workspace --features arc_lock,serde,deadlock_detection --no-deps -p parking_lot -p parking_lot_core -p lock_api
   benchmark:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ bincode = "1.3.0"
 
 [features]
 default = []
+arc_lock = ["lock_api/arc_lock"]
 owning_ref = ["lock_api/owning_ref"]
 nightly = ["parking_lot_core/nightly", "lock_api/nightly"]
 deadlock_detection = ["parking_lot_core/deadlock_detection"]

--- a/lock_api/Cargo.toml
+++ b/lock_api/Cargo.toml
@@ -20,3 +20,4 @@ serde = { version = "1.0.114", default-features = false, optional = true }
 
 [features]
 nightly = []
+arc_lock = []

--- a/lock_api/src/lib.rs
+++ b/lock_api/src/lib.rs
@@ -79,9 +79,11 @@
 //!
 //! # Cargo features
 //!
-//! This crate supports two cargo features:
+//! This crate supports three cargo features:
 //!
 //! - `owning_ref`: Allows your lock types to be used with the `owning_ref` crate.
+//! - `arc_lock`: Enables locking from an `Arc`. This enables types such as `ArcMutexGuard`. Note that this
+//!   requires the `alloc` crate to be present.
 //! - `nightly`: Enables nightly-only features. At the moment the only such
 //!   feature is `const fn` constructors for lock types.
 
@@ -92,6 +94,9 @@
 
 #[macro_use]
 extern crate scopeguard;
+
+#[cfg(feature = "arc_lock")]
+extern crate alloc;
 
 /// Marker type which indicates that the Guard type for a lock is `Send`.
 pub struct GuardSend(());

--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -662,9 +662,10 @@ impl<'a, R: RawMutex + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display for Mutex
 #[cfg(feature = "owning_ref")]
 unsafe impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> StableAddress for MutexGuard<'a, R, T> {}
 
-/// An RAII mutex guard returned by the `Arc` locking operations on `Mutex`. This is similar to the `MutexGuard`
-/// struct, except instead of using a reference to unlock the `Mutex` it uses an `Arc<Mutex>`. This has several
-/// advantages, most notably that it has an `'static` lifetime.
+/// An RAII mutex guard returned by the `Arc` locking operations on `Mutex`.
+/// 
+/// This is similar to the `MutexGuard` struct, except instead of using a reference to unlock the `Mutex` it 
+/// uses an `Arc<Mutex>`. This has several advantages, most notably that it has an `'static` lifetime.
 #[cfg(feature = "arc_lock")]
 #[must_use = "if unused the Mutex will immediately unlock"]
 pub struct ArcMutexGuard<R: RawMutex, T: ?Sized> {
@@ -711,8 +712,8 @@ impl<R: RawMutexFair, T: ?Sized> ArcMutexGuard<R, T> {
         }
 
         // SAFETY: make sure the Arc gets it reference decremented
-        let s = ManuallyDrop::new(s);
-        unsafe { ptr::drop_in_place(&s.rwlock) }; 
+        let mut s = ManuallyDrop::new(s);
+        unsafe { ptr::drop_in_place(&mut s.mutex) }; 
     }
 
     /// Temporarily unlocks the mutex to execute the given function.

--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -11,6 +11,9 @@ use core::marker::PhantomData;
 use core::mem;
 use core::ops::{Deref, DerefMut};
 
+#[cfg(feature = "arc_lock")]
+use alloc::sync::Arc;
+
 #[cfg(feature = "owning_ref")]
 use owning_ref::StableAddress;
 
@@ -286,6 +289,45 @@ impl<R: RawMutex, T: ?Sized> Mutex<R, T> {
     pub fn data_ptr(&self) -> *mut T {
         self.data.get()
     }
+
+    /// # Safety
+    ///
+    /// The lock needs to be held for the behavior of this function to be defined.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    unsafe fn guard_arc(this: &Arc<Self>) -> ArcMutexGuard<R, T> {
+        ArcMutexGuard {
+            mutex: this.clone(),
+            marker: PhantomData,
+        }
+    }
+
+    /// Acquires a lock through an `Arc`.
+    ///
+    /// This method is similar to the `lock` method; however, it requires the `Mutex` to be inside of an `Arc`
+    /// and the resulting mutex guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn lock_arc(this: &Arc<Self>) -> ArcMutexGuard<R, T> {
+        this.raw.lock();
+        // SAFETY: the locking guarantee is upheld
+        unsafe { Self::guard_arc(this) }
+    }
+
+    /// Attempts to acquire a lock through an `Arc`.
+    ///
+    /// This method is similar to the `try_lock` method; however, it requires the `Mutex` to be inside of an
+    /// `Arc` and the resulting mutex guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn try_lock_arc(this: &Arc<Self>) -> Option<ArcMutexGuard<R, T>> {
+        if this.raw.try_lock() {
+            // SAFETY: locking guarantee is upheld
+            Some(unsafe { Self::guard_arc(this) })
+        } else {
+            None
+        }
+    }
 }
 
 impl<R: RawMutexFair, T: ?Sized> Mutex<R, T> {
@@ -332,6 +374,39 @@ impl<R: RawMutexTimed, T: ?Sized> Mutex<R, T> {
         if self.raw.try_lock_until(timeout) {
             // SAFETY: The lock is held, as required.
             Some(unsafe { self.guard() })
+        } else {
+            None
+        }
+    }
+
+    /// Attempts to acquire this lock through an `Arc` until a timeout is reached.
+    ///
+    /// This method is similar to the `try_lock_for` method; however, it requires the `Mutex` to be inside of an
+    /// `Arc` and the resulting mutex guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn try_lock_for_arc(this: &Arc<Self>, timeout: R::Duration) -> Option<ArcMutexGuard<R, T>> {
+        if this.raw.try_lock_for(timeout) {
+            // SAFETY: locking guarantee is upheld
+            Some(unsafe { Self::guard_arc(this) })
+        } else {
+            None
+        }
+    }
+
+    /// Attempts to acquire this lock through an `Arc` until a timeout is reached.
+    ///
+    /// This method is similar to the `try_lock_until` method; however, it requires the `Mutex` to be inside of
+    /// an `Arc` and the resulting mutex guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn try_lock_until_arc(
+        this: &Arc<Self>,
+        timeout: R::Instant,
+    ) -> Option<ArcMutexGuard<R, T>> {
+        if this.raw.try_lock_until(timeout) {
+            // SAFETY: locking guarantee is upheld
+            Some(unsafe { Self::guard_arc(this) })
         } else {
             None
         }
@@ -582,6 +657,112 @@ impl<'a, R: RawMutex + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display for Mutex
 
 #[cfg(feature = "owning_ref")]
 unsafe impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> StableAddress for MutexGuard<'a, R, T> {}
+
+/// An RAII mutex guard returned by the `Arc` locking operations on `Mutex`. This is similar to the `MutexGuard`
+/// struct, except instead of using a reference to unlock the `Mutex` it uses an `Arc<Mutex>`. This has several
+/// advantages, most notably that it has an `'static` lifetime.
+#[cfg(feature = "arc_lock")]
+#[must_use = "if unused the Mutex will immediately unlock"]
+pub struct ArcMutexGuard<R: RawMutex, T: ?Sized> {
+    mutex: Arc<Mutex<R, T>>,
+    marker: PhantomData<R::GuardMarker>,
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawMutex, T: ?Sized> ArcMutexGuard<R, T> {
+    /// Returns a reference to the `Mutex` this is guarding, contained in its `Arc`.
+    #[inline]
+    pub fn mutex(&self) -> &Arc<Mutex<R, T>> {
+        &self.mutex
+    }
+
+    /// Temporarily unlocks the mutex to execute the given function.
+    ///
+    /// This is safe because `&mut` guarantees that there exist no other
+    /// references to the data protected by the mutex.
+    #[inline]
+    pub fn unlocked<F, U>(s: &mut Self, f: F) -> U
+    where
+        F: FnOnce() -> U,
+    {
+        // Safety: A MutexGuard always holds the lock.
+        unsafe {
+            s.mutex.raw.unlock();
+        }
+        defer!(s.mutex.raw.lock());
+        f()
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawMutexFair, T: ?Sized> ArcMutexGuard<R, T> {
+    /// Unlocks the mutex using a fair unlock protocol.
+    ///
+    /// This is functionally identical to the `unlock_fair` method on [`MutexGuard`].
+    #[inline]
+    pub fn unlock_fair(s: Self) {
+        // Safety: A MutexGuard always holds the lock.
+        unsafe {
+            s.mutex.raw.unlock_fair();
+        }
+        mem::forget(s);
+    }
+
+    /// Temporarily unlocks the mutex to execute the given function.
+    ///
+    /// This is functionally identical to the `unlocked_fair` method on [`MutexGuard`].
+    #[inline]
+    pub fn unlocked_fair<F, U>(s: &mut Self, f: F) -> U
+    where
+        F: FnOnce() -> U,
+    {
+        // Safety: A MutexGuard always holds the lock.
+        unsafe {
+            s.mutex.raw.unlock_fair();
+        }
+        defer!(s.mutex.raw.lock());
+        f()
+    }
+
+    /// Temporarily yields the mutex to a waiting thread if there is one.
+    ///
+    /// This is functionally identical to the `bump` method on [`MutexGuard`].
+    #[inline]
+    pub fn bump(s: &mut Self) {
+        // Safety: A MutexGuard always holds the lock.
+        unsafe {
+            s.mutex.raw.bump();
+        }
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawMutex, T: ?Sized> Deref for ArcMutexGuard<R, T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        unsafe { &*self.mutex.data.get() }
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawMutex, T: ?Sized> DerefMut for ArcMutexGuard<R, T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.mutex.data.get() }
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawMutex, T: ?Sized> Drop for ArcMutexGuard<R, T> {
+    #[inline]
+    fn drop(&mut self) {
+        // Safety: A MutexGuard always holds the lock.
+        unsafe {
+            self.mutex.raw.unlock();
+        }
+    }
+}
 
 /// An RAII mutex guard returned by `MutexGuard::map`, which can point to a
 /// subfield of the protected data.

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -789,6 +789,7 @@ pub struct ArcReentrantMutexGuard<R: RawMutex, G: GetThreadId, T: ?Sized> {
     marker: PhantomData<GuardNoSend>,
 }
 
+#[cfg(feature = "arc_lock")]
 impl<R: RawMutex, G: GetThreadId, T: ?Sized> ArcReentrantMutexGuard<R, G, T> {
     /// Returns a reference to the `ReentrantMutex` this object is guarding, contained in its `Arc`.
     pub fn remutex(s: &Self) -> &Arc<ReentrantMutex<R, G, T>> {
@@ -813,6 +814,7 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> ArcReentrantMutexGuard<R, G, T> {
     }
 }
 
+#[cfg(feature = "arc_lock")]
 impl<R: RawMutexFair, G: GetThreadId, T: ?Sized>
     ArcReentrantMutexGuard<R, G, T>
 {
@@ -856,6 +858,7 @@ impl<R: RawMutexFair, G: GetThreadId, T: ?Sized>
     }
 }
 
+#[cfg(feature = "arc_lock")]
 impl<R: RawMutex, G: GetThreadId, T: ?Sized> Deref
     for ArcReentrantMutexGuard<R, G, T>
 {
@@ -866,8 +869,9 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> Deref
     }
 }
 
+#[cfg(feature = "arc_lock")]
 impl<R: RawMutex, G: GetThreadId, T: ?Sized> Drop
-    for ReentrantMutexGuard<R, G, T>
+    for ArcReentrantMutexGuard<R, G, T>
 {
     #[inline]
     fn drop(&mut self) {

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -783,9 +783,11 @@ unsafe impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> StableAdd
 {
 }
 
-/// An RAII mutex guard returned by the `Arc` locking operations on `ReentrantMutex`. This is similar to the 
-/// `ReentrantMutexGuard` struct, except instead of using a reference to unlock the `Mutex` it uses an 
-/// `Arc<ReentrantMutex>`. This has several advantages, most notably that it has an `'static` lifetime.
+/// An RAII mutex guard returned by the `Arc` locking operations on `ReentrantMutex`. 
+/// 
+/// This is similar to the `ReentrantMutexGuard` struct, except instead of using a reference to unlock the 
+/// `Mutex` it uses an `Arc<ReentrantMutex>`. This has several advantages, most notably that it has an `'static`
+/// lifetime.
 #[cfg(feature = "arc_lock")]
 #[must_use = "if unused the ReentrantMutex will immediately unlock"]
 pub struct ArcReentrantMutexGuard<R: RawMutex, G: GetThreadId, T: ?Sized> {
@@ -833,8 +835,8 @@ impl<R: RawMutexFair, G: GetThreadId, T: ?Sized>
         }
 
         // SAFETY: ensure that the Arc's refcount is decremented
-        let s = ManuallyDrop::new(s);
-        unsafe { ptr::drop_in_place(&s.rwlock) };
+        let mut s = ManuallyDrop::new(s);
+        unsafe { ptr::drop_in_place(&mut s.remutex) };
     }
 
     /// Temporarily unlocks the mutex to execute the given function.

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -19,6 +19,9 @@ use core::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
+#[cfg(feature = "arc_lock")]
+use alloc::sync::Arc;
+
 #[cfg(feature = "owning_ref")]
 use owning_ref::StableAddress;
 
@@ -392,6 +395,45 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     pub fn data_ptr(&self) -> *mut T {
         self.data.get()
     }
+
+    /// # Safety
+    /// 
+    /// The lock must be held before calling this method.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    unsafe fn guard_arc(this: &Arc<Self>) -> ArcReentrantMutexGuard<R, G, T> {
+        ArcReentrantMutexGuard {
+            remutex: this.clone(),
+            marker: PhantomData,
+        }
+    }
+
+    /// Acquires a reentrant mutex through an `Arc`.
+    /// 
+    /// This method is similar to the `lock` method; however, it requires the `ReentrantMutex` to be inside of an
+    /// `Arc` and the resulting mutex guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn lock_arc(this: &Arc<Self>) -> ArcReentrantMutexGuard<R, G, T> {
+        this.raw.lock();
+        // SAFETY: locking guarantee is upheld
+        unsafe { Self::guard_arc(this) }
+    }
+
+    /// Attempts to acquire a reentrant mutex through an `Arc`.
+    /// 
+    /// This method is similar to the `try_lock` method; however, it requires the `ReentrantMutex` to be inside
+    /// of an `Arc` and the resulting mutex guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn try_lock_arc(this: &Arc<Self>) -> Option<ArcReentrantMutexGuard<R, G, T>> {
+        if this.raw.try_lock() {
+            // SAFETY: locking guarantee is upheld
+            Some(unsafe { Self::guard_arc(this) })
+        } else {
+            None
+        }
+    }
 }
 
 impl<R: RawMutexFair, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
@@ -438,6 +480,36 @@ impl<R: RawMutexTimed, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
         if self.raw.try_lock_until(timeout) {
             // SAFETY: The lock is held, as required.
             Some(unsafe { self.guard() })
+        } else {
+            None
+        }
+    }
+
+    /// Attempts to acquire this lock until a timeout is reached, through an `Arc`.
+    /// 
+    /// This method is similar to the `try_lock_for` method; however, it requires the `ReentrantMutex` to be
+    /// inside of an `Arc` and the resulting mutex guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn try_lock_for_arc(this: &Arc<Self>, timeout: R::Duration) -> Option<ArcReentrantMutexGuard<R, G, T>> {
+        if this.raw.try_lock_for(timeout) {
+            // SAFETY: locking guarantee is upheld
+            Some(unsafe { Self::guard_arc(this) })
+        } else {
+            None
+        }
+    }
+
+    /// Attempts to acquire this lock until a timeout is reached, through an `Arc`.
+    /// 
+    /// This method is similar to the `try_lock_until` method; however, it requires the `ReentrantMutex` to be
+    /// inside of an `Arc` and the resulting mutex guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn try_lock_until_arc(this: &Arc<Self>, timeout: R::Instant) -> Option<ArcReentrantMutexGuard<R, G, T>> {
+        if this.raw.try_lock_until(timeout) {
+            // SAFETY: locking guarantee is upheld
+            Some(unsafe { Self::guard_arc(this) })
         } else {
             None
         }
@@ -660,6 +732,7 @@ impl<'a, R: RawMutexFair + 'a, G: GetThreadId + 'a, T: ?Sized + 'a>
             s.remutex.raw.bump();
         }
     }
+
 }
 
 impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> Deref
@@ -704,6 +777,105 @@ impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: fmt::Display + ?Sized + 'a> f
 unsafe impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> StableAddress
     for ReentrantMutexGuard<'a, R, G, T>
 {
+}
+
+/// An RAII mutex guard returned by the `Arc` locking operations on `ReentrantMutex`. This is similar to the 
+/// `ReentrantMutexGuard` struct, except instead of using a reference to unlock the `Mutex` it uses an 
+/// `Arc<ReentrantMutex>`. This has several advantages, most notably that it has an `'static` lifetime.
+#[cfg(feature = "arc_lock")]
+#[must_use = "if unused the ReentrantMutex will immediately unlock"]
+pub struct ArcReentrantMutexGuard<R: RawMutex, G: GetThreadId, T: ?Sized> {
+    remutex: Arc<ReentrantMutex<R, G, T>>,
+    marker: PhantomData<GuardNoSend>,
+}
+
+impl<R: RawMutex, G: GetThreadId, T: ?Sized> ArcReentrantMutexGuard<R, G, T> {
+    /// Returns a reference to the `ReentrantMutex` this object is guarding, contained in its `Arc`.
+    pub fn remutex(s: &Self) -> &Arc<ReentrantMutex<R, G, T>> {
+        &s.remutex
+    }
+
+    /// Temporarily unlocks the mutex to execute the given function.
+    ///
+    /// This is safe because `&mut` guarantees that there exist no other
+    /// references to the data protected by the mutex.
+    #[inline]
+    pub fn unlocked<F, U>(s: &mut Self, f: F) -> U
+    where
+        F: FnOnce() -> U,
+    {
+        // Safety: A ReentrantMutexGuard always holds the lock.
+        unsafe {
+            s.remutex.raw.unlock();
+        }
+        defer!(s.remutex.raw.lock());
+        f()
+    }
+}
+
+impl<R: RawMutexFair, G: GetThreadId, T: ?Sized>
+    ArcReentrantMutexGuard<R, G, T>
+{
+    /// Unlocks the mutex using a fair unlock protocol.
+    ///
+    /// This is functionally identical to the `unlock_fair` method on [`ReentrantMutexGuard`].
+    #[inline]
+    pub fn unlock_fair(s: Self) {
+        // Safety: A ReentrantMutexGuard always holds the lock
+        unsafe {
+            s.remutex.raw.unlock_fair();
+        }
+        mem::forget(s);
+    }
+
+    /// Temporarily unlocks the mutex to execute the given function.
+    ///
+    /// This is functionally identical to the `unlocked_fair` method on [`ReentrantMutexGuard`].
+    #[inline]
+    pub fn unlocked_fair<F, U>(s: &mut Self, f: F) -> U
+    where
+        F: FnOnce() -> U,
+    {
+        // Safety: A ReentrantMutexGuard always holds the lock
+        unsafe {
+            s.remutex.raw.unlock_fair();
+        }
+        defer!(s.remutex.raw.lock());
+        f()
+    }
+
+    /// Temporarily yields the mutex to a waiting thread if there is one.
+    ///
+    /// This is functionally equivalent to the `bump` method on [`ReentrantMutexGuard`].
+    #[inline]
+    pub fn bump(s: &mut Self) {
+        // Safety: A ReentrantMutexGuard always holds the lock
+        unsafe {
+            s.remutex.raw.bump();
+        }
+    }
+}
+
+impl<R: RawMutex, G: GetThreadId, T: ?Sized> Deref
+    for ArcReentrantMutexGuard<R, G, T>
+{
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        unsafe { &*self.remutex.data.get() }
+    }
+}
+
+impl<R: RawMutex, G: GetThreadId, T: ?Sized> Drop
+    for ReentrantMutexGuard<R, G, T>
+{
+    #[inline]
+    fn drop(&mut self) {
+        // Safety: A ReentrantMutexGuard always holds the lock.
+        unsafe {
+            self.remutex.raw.unlock();
+        }
+    }
 }
 
 /// An RAII mutex guard returned by `ReentrantMutexGuard::map`, which can point to a

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -11,6 +11,13 @@ use core::marker::PhantomData;
 use core::mem;
 use core::ops::{Deref, DerefMut};
 
+#[cfg(feature = "arc_lock")]
+use alloc::sync::Arc;
+#[cfg(feature = "arc_lock")]
+use core::mem::ManuallyDrop;
+#[cfg(feature = "arc_lock")]
+use core::ptr;
+
 #[cfg(feature = "owning_ref")]
 use owning_ref::StableAddress;
 
@@ -557,6 +564,84 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     pub fn data_ptr(&self) -> *mut T {
         self.data.get()
     }
+
+    /// # Safety
+    ///
+    /// The lock must be held when calling this method.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    unsafe fn read_guard_arc(this: &Arc<Self>) -> ArcRwLockReadGuard<R, T> {
+        ArcRwLockReadGuard {
+            rwlock: this.clone(),
+            marker: PhantomData,
+        }
+    }
+
+    /// # Safety
+    ///
+    /// The lock must be held when calling this method.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    unsafe fn write_guard_arc(this: &Arc<Self>) -> ArcRwLockWriteGuard<R, T> {
+        ArcRwLockWriteGuard {
+            rwlock: this.clone(),
+            marker: PhantomData,
+        }
+    }
+
+    /// Locks this `RwLock` with read access, through an `Arc`.
+    /// 
+    /// This method is similar to the `read` method; however, it requires the `RwLock` to be inside of an `Arc`
+    /// and the resulting read guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn read_arc(this: &Arc<Self>) -> ArcRwLockReadGuard<R, T> {
+        this.raw.lock_shared();
+        // SAFETY: locking guarantee is upheld
+        unsafe { Self::read_guard_arc(this) }
+    }
+
+    /// Attempts to lock this `RwLock` with read access, through an `Arc`.
+    /// 
+    /// This method is similar to the `try_read` method; however, it requires the `RwLock` to be inside of an 
+    /// `Arc` and the resulting read guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn try_read_arc(this: &Arc<Self>) -> Option<ArcRwLockReadGuard<R, T>> {
+        if this.raw.try_lock_shared() {
+            // SAFETY: locking guarantee is upheld
+            Some(unsafe { Self::read_guard_arc(this) })
+        } else {
+            None
+        }
+    }
+
+    /// Locks this `RwLock` with write access, through an `Arc`.
+    /// 
+    /// This method is similar to the `write` method; however, it requires the `RwLock` to be inside of an `Arc`
+    /// and the resulting write guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn write_arc(this: &Arc<Self>) -> ArcRwLockWriteGuard<R, T> {
+        this.raw.lock_exclusive();
+        // SAFETY: locking guarantee is upheld
+        unsafe { Self::write_guard_arc(this) }
+    }
+
+    /// Attempts to lock this `RwLock` with writ access, through an `Arc`.
+    /// 
+    /// This method is similar to the `try_write` method; however, it requires the `RwLock` to be inside of an 
+    /// `Arc` and the resulting write guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn try_write_arc(this: &Arc<Self>) -> Option<ArcRwLockWriteGuard<R, T>> {
+        if this.raw.try_lock_exclusive() {
+            // SAFETY: locking guarantee is upheld
+            Some(unsafe { Self::write_guard_arc(this) })
+        } else {
+            None
+        }
+    }
 }
 
 impl<R: RawRwLockFair, T: ?Sized> RwLock<R, T> {
@@ -657,6 +742,66 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
             None
         }
     }
+
+    /// Attempts to acquire this `RwLock` with read access until a timeout is reached, through an `Arc`.
+    /// 
+    /// This method is similar to the `try_read_for` method; however, it requires the `RwLock` to be inside of an
+    /// `Arc` and the resulting read guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn try_read_arc_for(this: &Arc<Self>, timeout: R::Duration) -> Option<ArcRwLockReadGuard<R, T>> {
+        if this.raw.try_lock_shared_for(timeout) {
+            // SAFETY: locking guarantee is upheld
+            Some(unsafe { Self::read_guard_arc(this) })
+        } else {
+            None
+        }
+    }
+
+    /// Attempts to acquire this `RwLock` with read access until a timeout is reached, through an `Arc`.
+    /// 
+    /// This method is similar to the `try_read_until` method; however, it requires the `RwLock` to be inside of
+    /// an `Arc` and the resulting read guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn try_read_arc_until(this: &Arc<Self>, timeout: R::Instant) -> Option<ArcRwLockReadGuard<R, T>> {
+        if this.raw.try_lock_shared_until(timeout) {
+            // SAFETY: locking guarantee is upheld
+            Some(unsafe { Self::read_guard_arc(this) })
+        } else {
+            None
+        }
+    }
+
+    /// Attempts to acquire this `RwLock` with write access until a timeout is reached, through an `Arc`.
+    /// 
+    /// This method is similar to the `try_write_for` method; however, it requires the `RwLock` to be inside of
+    /// an `Arc` and the resulting write guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn try_write_arc_for(this: &Arc<Self>, timeout: R::Duration) -> Option<ArcRwLockWriteGuard<R, T>> {
+        if this.raw.try_lock_exclusive_for(timeout) {
+            // SAFETY: locking guarantee is upheld
+            Some(unsafe { Self::write_guard_arc(this) })
+        } else {
+            None
+        }
+    }
+
+    /// Attempts to acquire this `RwLock` with read access until a timeout is reached, through an `Arc`.
+    /// 
+    /// This method is similar to the `try_write_until` method; however, it requires the `RwLock` to be inside of
+    /// an `Arc` and the resulting read guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn try_write_arc_until(this: &Arc<Self>, timeout: R::Instant) -> Option<ArcRwLockWriteGuard<R, T>> {
+        if this.raw.try_lock_exclusive_until(timeout) {
+            // SAFETY: locking guarantee is upheld
+            Some(unsafe { Self::write_guard_arc(this) })
+        } else {
+            None
+        }
+    }
 }
 
 impl<R: RawRwLockRecursive, T: ?Sized> RwLock<R, T> {
@@ -701,6 +846,33 @@ impl<R: RawRwLockRecursive, T: ?Sized> RwLock<R, T> {
             None
         }
     }
+
+    /// Locks this `RwLock` with shared read access, through an `Arc`.
+    /// 
+    /// This method is similar to the `read_recursive` method; however, it requires the `RwLock` to be inside of
+    /// an `Arc` and the resulting read guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn read_recursive_arc(this: &Arc<Self>) -> ArcRwLockReadGuard<R, T> {
+        this.raw.lock_shared_recursive();
+        // SAFETY: locking guarantee is upheld
+        unsafe { Self::read_guard_arc(this) }
+    }
+
+    /// Attempts to lock this `RwLock` with shared read access, through an `Arc`.
+    /// 
+    /// This method is similar to the `try_read_recursive` method; however, it requires the `RwLock` to be inside
+    /// of an `Arc` and the resulting read guard has no lifetime requirements.   
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn try_read_recursive_arc(this: &Arc<Self>) -> Option<ArcRwLockReadGuard<R, T>> {
+        if this.raw.try_lock_shared_recursive() {
+            // SAFETY: locking guarantee is upheld
+            Some(unsafe { Self::read_guard_arc(this) })
+        } else {
+            None
+        }
+    }
 }
 
 impl<R: RawRwLockRecursiveTimed, T: ?Sized> RwLock<R, T> {
@@ -741,6 +913,36 @@ impl<R: RawRwLockRecursiveTimed, T: ?Sized> RwLock<R, T> {
         if self.raw.try_lock_shared_recursive_until(timeout) {
             // SAFETY: The lock is held, as required.
             Some(unsafe { self.read_guard() })
+        } else {
+            None
+        }
+    }
+
+    /// Attempts to lock this `RwLock` with read access until a timeout is reached, through an `Arc`.
+    ///
+    /// This method is similar to the `try_read_recursive_for` method; however, it requires the `RwLock` to be
+    /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn try_read_recursive_for_arc(this: &Arc<Self>, timeout: R::Duration) -> Option<ArcRwLockReadGuard<R, T>> {
+        if this.raw.try_lock_shared_recursive_for(timeout) {
+            // SAFETY: locking guarantee is upheld
+            Some(unsafe { Self::read_guard_arc(this) })
+        } else {
+            None
+        }
+    }
+
+    /// Attempts to lock this `RwLock` with read access until a timeout is reached, through an `Arc`.
+    ///
+    /// This method is similar to the `try_read_recursive_until` method; however, it requires the `RwLock` to be
+    /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn try_read_recursive_until_arc(this: &Arc<Self>, timeout: R::Instant) -> Option<ArcRwLockReadGuard<R, T>> {
+        if this.raw.try_lock_shared_recursive_until(timeout) {
+            // SAFETY: locking guarantee is upheld
+            Some(unsafe { Self::read_guard_arc(this) })
         } else {
             None
         }
@@ -791,6 +993,45 @@ impl<R: RawRwLockUpgrade, T: ?Sized> RwLock<R, T> {
             None
         }
     }
+
+    /// # Safety
+    /// 
+    /// The lock must be held when calling this method.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    unsafe fn upgradable_guard_arc(this: &Arc<Self>) -> ArcRwLockUpgradableReadGuard<R, T> {
+        ArcRwLockUpgradableReadGuard {
+            rwlock: this.clone(),
+            marker: PhantomData 
+        }
+    }
+
+    /// Locks this `RwLock` with upgradable read access, through an `Arc`.
+    /// 
+    /// This method is similar to the `upgradable_read` method; however, it requires the `RwLock` to be
+    /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn upgradable_read_arc(this: &Arc<Self>) -> ArcRwLockUpgradableReadGuard<R, T> {
+        this.raw.lock_upgradable();
+        // SAFETY: locking guarantee is upheld
+        unsafe { Self::upgradable_guard_arc(this) }
+    }
+
+    /// Attempts to lock this `RwLock` with upgradable read access, through an `Arc`.
+    /// 
+    /// This method is similar to the `try_upgradable_read` method; however, it requires the `RwLock` to be
+    /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn try_upgradable_read_arc(this: &Arc<Self>) -> Option<ArcRwLockUpgradableReadGuard<R, T>> {
+        if this.raw.try_lock_upgradable() {
+            // SAFETY: locking guarantee is upheld
+            Some(unsafe { Self::upgradable_guard_arc(this) })
+        } else {
+            None
+        }
+    }
 }
 
 impl<R: RawRwLockUpgradeTimed, T: ?Sized> RwLock<R, T> {
@@ -827,6 +1068,42 @@ impl<R: RawRwLockUpgradeTimed, T: ?Sized> RwLock<R, T> {
         if self.raw.try_lock_upgradable_until(timeout) {
             // SAFETY: The lock is held, as required.
             Some(unsafe { self.upgradable_guard() })
+        } else {
+            None
+        }
+    }
+
+    /// Attempts to lock this `RwLock` with upgradable access until a timeout is reached, through an `Arc`.
+    /// 
+    /// This method is similar to the `try_upgradable_read_for` method; however, it requires the `RwLock` to be
+    /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn try_upgradable_read_for_arc(
+        this: &Arc<Self>,
+        timeout: R::Duration,
+    ) -> Option<ArcRwLockUpgradableReadGuard<R, T>> {
+        if this.raw.try_lock_upgradable_for(timeout) {
+            // SAFETY: locking guarantee is upheld
+            Some(unsafe { Self::upgradable_guard_arc(this) })
+        } else {
+            None
+        }
+    }
+
+    /// Attempts to lock this `RwLock` with upgradable access until a timeout is reached, through an `Arc`.
+    /// 
+    /// This method is similar to the `try_upgradable_read_until` method; however, it requires the `RwLock` to be
+    /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
+    #[cfg(feature = "arc_lock")]
+    #[inline]
+    pub fn try_upgradable_read_until_arc(
+        this: &Arc<Self>,
+        timeout: R::Instant,
+    ) -> Option<ArcRwLockUpgradableReadGuard<R, T>> {
+        if this.raw.try_lock_upgradable_until(timeout) {
+            // SAFETY: locking guarantee is upheld
+            Some(unsafe { Self::upgradable_guard_arc(this) })
         } else {
             None
         }
@@ -1040,6 +1317,118 @@ impl<'a, R: RawRwLock + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
 
 #[cfg(feature = "owning_ref")]
 unsafe impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> StableAddress for RwLockReadGuard<'a, R, T> {}
+
+/// An RAII rwlock guard returned by the `Arc` locking operations on `RwLock`. This is similar to the
+/// `RwLockReadGuard` struct, except instead of using a reference to unlock the `RwLock` it uses an 
+/// `Arc<RwLock>`. This has several advantages, most notably that it has an `'static` lifetime.
+#[cfg(feature = "arc_lock")]
+#[must_use = "if unused the RwLock will immediately unlock"]
+pub struct ArcRwLockReadGuard<R: RawRwLock, T: ?Sized> {
+    rwlock: Arc<RwLock<R, T>>,
+    marker: PhantomData<R::GuardMarker>,
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLock, T: ?Sized> ArcRwLockReadGuard<R, T> {
+    /// Returns a reference to the rwlock, contained in its `Arc`.
+    pub fn rwlock(s: &Self) -> &Arc<RwLock<R, T>> {
+        &s.rwlock
+    }
+
+    /// Temporarily unlocks the `RwLock` to execute the given function.
+    ///
+    /// This is functionally identical to the `unlocked` method on [`RwLockReadGuard`].
+    #[inline]
+    pub fn unlocked<F, U>(s: &mut Self, f: F) -> U
+    where
+        F: FnOnce() -> U,
+    {
+        // Safety: An RwLockReadGuard always holds a shared lock.
+        unsafe {
+            s.rwlock.raw.unlock_shared();
+        }
+        defer!(s.rwlock.raw.lock_shared());
+        f()
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLockFair, T: ?Sized> ArcRwLockReadGuard<R, T> {
+    /// Unlocks the `RwLock` using a fair unlock protocol.
+    ///
+    /// This is functionally identical to the `unlock_fair` method on [`RwLockReadGuard`].
+    #[inline]
+    pub fn unlock_fair(s: Self) {
+        // Safety: An RwLockReadGuard always holds a shared lock.
+        unsafe {
+            s.rwlock.raw.unlock_shared_fair();
+        }
+        mem::forget(s);
+    }
+
+    /// Temporarily unlocks the `RwLock` to execute the given function.
+    ///
+    /// This is functionally identical to the `unlocked_fair` method on [`RwLockReadGuard`].
+    #[inline]
+    pub fn unlocked_fair<F, U>(s: &mut Self, f: F) -> U
+    where
+        F: FnOnce() -> U,
+    {
+        // Safety: An RwLockReadGuard always holds a shared lock.
+        unsafe {
+            s.rwlock.raw.unlock_shared_fair();
+        }
+        defer!(s.rwlock.raw.lock_shared());
+        f()
+    }
+
+    /// Temporarily yields the `RwLock` to a waiting thread if there is one.
+    ///
+    /// This is functionally identical to the `bump` method on [`RwLockReadGuard`].
+    #[inline]
+    pub fn bump(s: &mut Self) {
+        // Safety: An RwLockReadGuard always holds a shared lock.
+        unsafe {
+            s.rwlock.raw.bump_shared();
+        }
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLock, T: ?Sized> Deref for ArcRwLockReadGuard<R, T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        unsafe { &*self.rwlock.data.get() }
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLock, T: ?Sized> Drop for ArcRwLockReadGuard<R, T> {
+    #[inline]
+    fn drop(&mut self) {
+        // Safety: An RwLockReadGuard always holds a shared lock.
+        unsafe {
+            self.rwlock.raw.unlock_shared();
+        }
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLock, T: fmt::Debug + ?Sized> fmt::Debug for ArcRwLockReadGuard<R, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLock, T: fmt::Display + ?Sized> fmt::Display
+    for ArcRwLockReadGuard<R, T>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (**self).fmt(f)
+    }
+}
 
 /// RAII structure used to release the exclusive write access of a lock when
 /// dropped.
@@ -1261,6 +1650,175 @@ impl<'a, R: RawRwLock + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
 
 #[cfg(feature = "owning_ref")]
 unsafe impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> StableAddress for RwLockWriteGuard<'a, R, T> {}
+
+/// An RAII rwlock guard returned by the `Arc` locking operations on `RwLock`. This is similar to the
+/// `RwLockWriteGuard` struct, except instead of using a reference to unlock the `RwLock` it uses an 
+/// `Arc<RwLock>`. This has several advantages, most notably that it has an `'static` lifetime.
+#[cfg(feature = "arc_lock")]
+#[must_use = "if unused the RwLock will immediately unlock"]
+pub struct ArcRwLockWriteGuard<R: RawRwLock, T: ?Sized> {
+    rwlock: Arc<RwLock<R, T>>,
+    marker: PhantomData<R::GuardMarker>,
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLock, T: ?Sized> ArcRwLockWriteGuard<R, T> {
+    /// Returns a reference to the rwlock, contained in its `Arc`.
+    pub fn rwlock(s: &Self) -> &Arc<RwLock<R, T>> {
+        &s.rwlock
+    }
+
+    /// Temporarily unlocks the `RwLock` to execute the given function.
+    ///
+    /// This is functionally equivalent to the `unlocked` method on [`RwLockWriteGuard`].
+    #[inline]
+    pub fn unlocked<F, U>(s: &mut Self, f: F) -> U
+    where
+        F: FnOnce() -> U,
+    {
+        // Safety: An RwLockWriteGuard always holds a shared lock.
+        unsafe {
+            s.rwlock.raw.unlock_exclusive();
+        }
+        defer!(s.rwlock.raw.lock_exclusive());
+        f()
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLockDowngrade, T: ?Sized> ArcRwLockWriteGuard<R, T> {
+    /// Atomically downgrades a write lock into a read lock without allowing any
+    /// writers to take exclusive access of the lock in the meantime.
+    ///
+    /// This is functionally equivalent to the `downgrade` method on [`RwLockWriteGuard`].
+    pub fn downgrade(s: Self) -> ArcRwLockReadGuard<R, T> {
+        // Safety: An RwLockWriteGuard always holds an exclusive lock.
+        unsafe {
+            s.rwlock.raw.downgrade();
+        }
+
+        // SAFETY: prevent the arc's refcount from changing using ManuallyDrop and ptr::read
+        let s = ManuallyDrop::new(s);
+        let rwlock = unsafe { ptr::read(&s.rwlock) };
+
+        ArcRwLockReadGuard {
+            rwlock,
+            marker: PhantomData,
+        }
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLockUpgradeDowngrade, T: ?Sized> ArcRwLockWriteGuard<R, T> {
+    /// Atomically downgrades a write lock into an upgradable read lock without allowing any
+    /// writers to take exclusive access of the lock in the meantime.
+    ///
+    /// This is functionally identical to the `downgrade_to_upgradable` method on [`RwLockWriteGuard`].
+    pub fn downgrade_to_upgradable(s: Self) -> ArcRwLockUpgradableReadGuard<R, T> {
+        // Safety: An RwLockWriteGuard always holds an exclusive lock.
+        unsafe {
+            s.rwlock.raw.downgrade_to_upgradable();
+        }
+
+        // SAFETY: same as above
+        let s = ManuallyDrop::new(s);
+        let rwlock = unsafe { ptr::read(&s.rwlock) };
+
+        ArcRwLockUpgradableReadGuard {
+            rwlock,
+            marker: PhantomData,
+        }
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLockFair, T: ?Sized> ArcRwLockWriteGuard<R, T> {
+    /// Unlocks the `RwLock` using a fair unlock protocol.
+    ///
+    /// This is functionally equivalent to the `unlock_fair` method on [`RwLockWriteGuard`].
+    #[inline]
+    pub fn unlock_fair(s: Self) {
+        // Safety: An RwLockWriteGuard always holds an exclusive lock.
+        unsafe {
+            s.rwlock.raw.unlock_exclusive_fair();
+        }
+
+        // SAFETY: prevent the Arc from leaking memory
+        let s = ManuallyDrop::new(s);
+        let _ = unsafe { ptr::read(&s.rwlock) };
+    }
+
+    /// Temporarily unlocks the `RwLock` to execute the given function.
+    ///
+    /// This is functionally equivalent to the `unlocked_fair` method on [`RwLockWriteGuard`].
+    #[inline]
+    pub fn unlocked_fair<F, U>(s: &mut Self, f: F) -> U
+    where
+        F: FnOnce() -> U,
+    {
+        // Safety: An RwLockWriteGuard always holds an exclusive lock.
+        unsafe {
+            s.rwlock.raw.unlock_exclusive_fair();
+        }
+        defer!(s.rwlock.raw.lock_exclusive());
+        f()
+    }
+
+    /// Temporarily yields the `RwLock` to a waiting thread if there is one.
+    ///
+    /// This method is functionally equivalent to the `bump` method on [`RwLockWriteGuard`]. 
+    #[inline]
+    pub fn bump(s: &mut Self) {
+        // Safety: An RwLockWriteGuard always holds an exclusive lock.
+        unsafe {
+            s.rwlock.raw.bump_exclusive();
+        }
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLock, T: ?Sized> Deref for ArcRwLockWriteGuard<R, T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        unsafe { &*self.rwlock.data.get() }
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLock, T: ?Sized> DerefMut for ArcRwLockWriteGuard<R, T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.rwlock.data.get() }
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLock, T: ?Sized> Drop for ArcRwLockWriteGuard<R, T> {
+    #[inline]
+    fn drop(&mut self) {
+        // Safety: An RwLockWriteGuard always holds an exclusive lock.
+        unsafe {
+            self.rwlock.raw.unlock_exclusive();
+        }
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLock, T: fmt::Debug + ?Sized> fmt::Debug for ArcRwLockWriteGuard<R, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLock, T: fmt::Display + ?Sized> fmt::Display
+    for ArcRwLockWriteGuard<R, T>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (**self).fmt(f)
+    }
+}
 
 /// RAII structure used to release the upgradable read access of a lock when
 /// dropped.
@@ -1494,6 +2052,240 @@ unsafe impl<'a, R: RawRwLockUpgrade + 'a, T: ?Sized + 'a> StableAddress
     for RwLockUpgradableReadGuard<'a, R, T>
 {
 }
+
+/// An RAII rwlock guard returned by the `Arc` locking operations on `RwLock`. This is similar to the
+/// `RwLockUpgradableReadGuard` struct, except instead of using a reference to unlock the `RwLock` it uses an 
+/// `Arc<RwLock>`. This has several advantages, most notably that it has an `'static` lifetime.
+#[cfg(feature = "arc_lock")]
+#[must_use = "if unused the RwLock will immediately unlock"]
+pub struct ArcRwLockUpgradableReadGuard<R: RawRwLockUpgrade, T: ?Sized> {
+    rwlock: Arc<RwLock<R, T>>,
+    marker: PhantomData<R::GuardMarker>,
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLockUpgrade , T: ?Sized> ArcRwLockUpgradableReadGuard<R, T> {
+    /// Returns a reference to the rwlock, contained in its original `Arc`.
+    pub fn rwlock(s: &Self) -> &Arc<RwLock<R, T>> {
+        &s.rwlock
+    }
+
+    /// Temporarily unlocks the `RwLock` to execute the given function.
+    ///
+    /// This is functionally identical to the `unlocked` method on [`RwLockUpgradableReadGuard`].
+    #[inline]
+    pub fn unlocked<F, U>(s: &mut Self, f: F) -> U
+    where
+        F: FnOnce() -> U,
+    {
+        // Safety: An RwLockUpgradableReadGuard always holds an upgradable lock.
+        unsafe {
+            s.rwlock.raw.unlock_upgradable();
+        }
+        defer!(s.rwlock.raw.lock_upgradable());
+        f()
+    }
+
+    /// Atomically upgrades an upgradable read lock lock into a exclusive write lock,
+    /// blocking the current thread until it can be acquired.
+    pub fn upgrade(s: Self) -> ArcRwLockWriteGuard<R, T> {
+        // Safety: An RwLockUpgradableReadGuard always holds an upgradable lock.
+        unsafe {
+            s.rwlock.raw.upgrade();
+        }
+
+        // SAFETY: avoid incrementing or decrementing the refcount using ManuallyDrop and reading the Arc out
+        //         of the struct
+        let s = ManuallyDrop::new(s);
+        let rwlock = unsafe { ptr::read(&s.rwlock) };
+
+        ArcRwLockWriteGuard {
+            rwlock,
+            marker: PhantomData,
+        }
+    }
+
+    /// Tries to atomically upgrade an upgradable read lock into a exclusive write lock.
+    ///
+    /// If the access could not be granted at this time, then the current guard is returned.
+    pub fn try_upgrade(s: Self) -> Result<ArcRwLockWriteGuard<R, T>, Self> {
+        // Safety: An RwLockUpgradableReadGuard always holds an upgradable lock.
+        if unsafe { s.rwlock.raw.try_upgrade() } {
+            // SAFETY: same as above
+            let s = ManuallyDrop::new(s);
+            let rwlock = unsafe { ptr::read(&s.rwlock) };
+
+            Ok(ArcRwLockWriteGuard {
+                rwlock,
+                marker: PhantomData,
+            })
+        } else {
+            Err(s)
+        }
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLockUpgradeFair, T: ?Sized> ArcRwLockUpgradableReadGuard<R, T> {
+    /// Unlocks the `RwLock` using a fair unlock protocol.
+    ///
+    /// This is functionally identical to the `unlock_fair` method on [`RwLockUpgradableReadGuard`].
+    #[inline]
+    pub fn unlock_fair(s: Self) {
+        // Safety: An RwLockUpgradableReadGuard always holds an upgradable lock.
+        unsafe {
+            s.rwlock.raw.unlock_upgradable_fair();
+        }
+
+        // SAFETY: make sure we decrement the refcount properly
+        let s = ManuallyDrop::new(s);
+        let _ = unsafe { ptr::read(&s.rwlock) };
+    }
+
+    /// Temporarily unlocks the `RwLock` to execute the given function.
+    ///
+    /// This is functionally equivalent to the `unlocked_fair` method on [`RwLockUpgradableReadGuard`].
+    #[inline]
+    pub fn unlocked_fair<F, U>(s: &mut Self, f: F) -> U
+    where
+        F: FnOnce() -> U,
+    {
+        // Safety: An RwLockUpgradableReadGuard always holds an upgradable lock.
+        unsafe {
+            s.rwlock.raw.unlock_upgradable_fair();
+        }
+        defer!(s.rwlock.raw.lock_upgradable());
+        f()
+    }
+
+    /// Temporarily yields the `RwLock` to a waiting thread if there is one.
+    ///
+    /// This method is functionally equivalent to calling `bump` on [`RwLockUpgradableReadGuard`].
+    #[inline]
+    pub fn bump(s: &mut Self) {
+        // Safety: An RwLockUpgradableReadGuard always holds an upgradable lock.
+        unsafe {
+            s.rwlock.raw.bump_upgradable();
+        }
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLockUpgradeDowngrade, T: ?Sized> ArcRwLockUpgradableReadGuard<R, T> {
+    /// Atomically downgrades an upgradable read lock lock into a shared read lock
+    /// without allowing any writers to take exclusive access of the lock in the
+    /// meantime.
+    ///
+    /// Note that if there are any writers currently waiting to take the lock
+    /// then other readers may not be able to acquire the lock even if it was
+    /// downgraded.
+    pub fn downgrade(s: Self) -> ArcRwLockReadGuard<R, T> {
+        // Safety: An RwLockUpgradableReadGuard always holds an upgradable lock.
+        unsafe {
+            s.rwlock.raw.downgrade_upgradable();
+        }
+
+        // SAFETY: use ManuallyDrop and ptr::read to ensure the refcount is not changed
+        let s = ManuallyDrop::new(s);
+        let rwlock = unsafe { ptr::read(&s.rwlock) };
+
+        ArcRwLockReadGuard {
+            rwlock,
+            marker: PhantomData,
+        }
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLockUpgradeTimed, T: ?Sized> ArcRwLockUpgradableReadGuard<R, T> {
+    /// Tries to atomically upgrade an upgradable read lock into a exclusive
+    /// write lock, until a timeout is reached.
+    ///
+    /// If the access could not be granted before the timeout expires, then
+    /// the current guard is returned.
+    pub fn try_upgrade_for(
+        s: Self,
+        timeout: R::Duration,
+    ) -> Result<ArcRwLockWriteGuard<R, T>, Self> {
+        // Safety: An RwLockUpgradableReadGuard always holds an upgradable lock.
+        if unsafe { s.rwlock.raw.try_upgrade_for(timeout) } {
+            // SAFETY: same as above
+            let s = ManuallyDrop::new(s);
+            let rwlock = unsafe { ptr::read(&s.rwlock) };
+
+            Ok(ArcRwLockWriteGuard {
+                rwlock,
+                marker: PhantomData,
+            })
+        } else {
+            Err(s)
+        }
+    }
+
+    /// Tries to atomically upgrade an upgradable read lock into a exclusive
+    /// write lock, until a timeout is reached.
+    ///
+    /// If the access could not be granted before the timeout expires, then
+    /// the current guard is returned.
+    #[inline]
+    pub fn try_upgrade_until(
+        s: Self,
+        timeout: R::Instant,
+    ) -> Result<ArcRwLockWriteGuard<R, T>, Self> {
+        // Safety: An RwLockUpgradableReadGuard always holds an upgradable lock.
+        if unsafe { s.rwlock.raw.try_upgrade_until(timeout) } {
+            // SAFETY: same as above
+            let s = ManuallyDrop::new(s);
+            let rwlock = unsafe { ptr::read(&s.rwlock) };
+
+            Ok(ArcRwLockWriteGuard {
+                rwlock,
+                marker: PhantomData,
+            })
+        } else {
+            Err(s)
+        }
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLockUpgrade, T: ?Sized> Deref for ArcRwLockUpgradableReadGuard<R, T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        unsafe { &*self.rwlock.data.get() }
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLockUpgrade, T: ?Sized> Drop for ArcRwLockUpgradableReadGuard<R, T> {
+    #[inline]
+    fn drop(&mut self) {
+        // Safety: An RwLockUpgradableReadGuard always holds an upgradable lock.
+        unsafe {
+            self.rwlock.raw.unlock_upgradable();
+        }
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLockUpgrade, T: fmt::Debug + ?Sized> fmt::Debug
+    for ArcRwLockUpgradableReadGuard<R, T>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+#[cfg(feature = "arc_lock")]
+impl<R: RawRwLockUpgrade, T: fmt::Display + ?Sized> fmt::Display
+    for ArcRwLockUpgradableReadGuard<R, T>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (**self).fmt(f)
+    }
+}
+
 
 /// An RAII read lock guard returned by `RwLockReadGuard::map`, which can point to a
 /// subfield of the protected data.

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -570,9 +570,9 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     /// The lock must be held when calling this method.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    unsafe fn read_guard_arc(this: &Arc<Self>) -> ArcRwLockReadGuard<R, T> {
+    unsafe fn read_guard_arc(self: &Arc<Self>) -> ArcRwLockReadGuard<R, T> {
         ArcRwLockReadGuard {
-            rwlock: this.clone(),
+            rwlock: self.clone(),
             marker: PhantomData,
         }
     }
@@ -582,9 +582,9 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     /// The lock must be held when calling this method.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    unsafe fn write_guard_arc(this: &Arc<Self>) -> ArcRwLockWriteGuard<R, T> {
+    unsafe fn write_guard_arc(self: &Arc<Self>) -> ArcRwLockWriteGuard<R, T> {
         ArcRwLockWriteGuard {
-            rwlock: this.clone(),
+            rwlock: self.clone(),
             marker: PhantomData,
         }
     }
@@ -595,10 +595,10 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     /// and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn read_arc(this: &Arc<Self>) -> ArcRwLockReadGuard<R, T> {
-        this.raw.lock_shared();
+    pub fn read_arc(self: &Arc<Self>) -> ArcRwLockReadGuard<R, T> {
+        self.raw.lock_shared();
         // SAFETY: locking guarantee is upheld
-        unsafe { Self::read_guard_arc(this) }
+        unsafe { self.read_guard_arc() }
     }
 
     /// Attempts to lock this `RwLock` with read access, through an `Arc`.
@@ -607,10 +607,10 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     /// `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn try_read_arc(this: &Arc<Self>) -> Option<ArcRwLockReadGuard<R, T>> {
-        if this.raw.try_lock_shared() {
+    pub fn try_read_arc(self: &Arc<Self>) -> Option<ArcRwLockReadGuard<R, T>> {
+        if self.raw.try_lock_shared() {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { Self::read_guard_arc(this) })
+            Some(unsafe { self.read_guard_arc() })
         } else {
             None
         }
@@ -622,10 +622,10 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     /// and the resulting write guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn write_arc(this: &Arc<Self>) -> ArcRwLockWriteGuard<R, T> {
-        this.raw.lock_exclusive();
+    pub fn write_arc(self: &Arc<Self>) -> ArcRwLockWriteGuard<R, T> {
+        self.raw.lock_exclusive();
         // SAFETY: locking guarantee is upheld
-        unsafe { Self::write_guard_arc(this) }
+        unsafe { self.write_guard_arc() }
     }
 
     /// Attempts to lock this `RwLock` with writ access, through an `Arc`.
@@ -634,10 +634,10 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     /// `Arc` and the resulting write guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn try_write_arc(this: &Arc<Self>) -> Option<ArcRwLockWriteGuard<R, T>> {
-        if this.raw.try_lock_exclusive() {
+    pub fn try_write_arc(self: &Arc<Self>) -> Option<ArcRwLockWriteGuard<R, T>> {
+        if self.raw.try_lock_exclusive() {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { Self::write_guard_arc(this) })
+            Some(unsafe { self.write_guard_arc() })
         } else {
             None
         }
@@ -749,10 +749,10 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     /// `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn try_read_arc_for(this: &Arc<Self>, timeout: R::Duration) -> Option<ArcRwLockReadGuard<R, T>> {
-        if this.raw.try_lock_shared_for(timeout) {
+    pub fn try_read_arc_for(self: &Arc<Self>, timeout: R::Duration) -> Option<ArcRwLockReadGuard<R, T>> {
+        if self.raw.try_lock_shared_for(timeout) {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { Self::read_guard_arc(this) })
+            Some(unsafe { self.read_guard_arc() })
         } else {
             None
         }
@@ -764,10 +764,10 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     /// an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn try_read_arc_until(this: &Arc<Self>, timeout: R::Instant) -> Option<ArcRwLockReadGuard<R, T>> {
-        if this.raw.try_lock_shared_until(timeout) {
+    pub fn try_read_arc_until(self: &Arc<Self>, timeout: R::Instant) -> Option<ArcRwLockReadGuard<R, T>> {
+        if self.raw.try_lock_shared_until(timeout) {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { Self::read_guard_arc(this) })
+            Some(unsafe { self.read_guard_arc() })
         } else {
             None
         }
@@ -779,10 +779,10 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     /// an `Arc` and the resulting write guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn try_write_arc_for(this: &Arc<Self>, timeout: R::Duration) -> Option<ArcRwLockWriteGuard<R, T>> {
-        if this.raw.try_lock_exclusive_for(timeout) {
+    pub fn try_write_arc_for(self: &Arc<Self>, timeout: R::Duration) -> Option<ArcRwLockWriteGuard<R, T>> {
+        if self.raw.try_lock_exclusive_for(timeout) {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { Self::write_guard_arc(this) })
+            Some(unsafe { self.write_guard_arc() })
         } else {
             None
         }
@@ -794,10 +794,10 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     /// an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn try_write_arc_until(this: &Arc<Self>, timeout: R::Instant) -> Option<ArcRwLockWriteGuard<R, T>> {
-        if this.raw.try_lock_exclusive_until(timeout) {
+    pub fn try_write_arc_until(self: &Arc<Self>, timeout: R::Instant) -> Option<ArcRwLockWriteGuard<R, T>> {
+        if self.raw.try_lock_exclusive_until(timeout) {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { Self::write_guard_arc(this) })
+            Some(unsafe { self.write_guard_arc() })
         } else {
             None
         }
@@ -853,10 +853,10 @@ impl<R: RawRwLockRecursive, T: ?Sized> RwLock<R, T> {
     /// an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn read_recursive_arc(this: &Arc<Self>) -> ArcRwLockReadGuard<R, T> {
+    pub fn read_arc_recursive(self: &Arc<Self>) -> ArcRwLockReadGuard<R, T> {
         this.raw.lock_shared_recursive();
         // SAFETY: locking guarantee is upheld
-        unsafe { Self::read_guard_arc(this) }
+        unsafe { self.read_guard_arc() }
     }
 
     /// Attempts to lock this `RwLock` with shared read access, through an `Arc`.
@@ -865,10 +865,10 @@ impl<R: RawRwLockRecursive, T: ?Sized> RwLock<R, T> {
     /// of an `Arc` and the resulting read guard has no lifetime requirements.   
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn try_read_recursive_arc(this: &Arc<Self>) -> Option<ArcRwLockReadGuard<R, T>> {
-        if this.raw.try_lock_shared_recursive() {
+    pub fn try_read_recursive_arc(self: &Arc<Self>) -> Option<ArcRwLockReadGuard<R, T>> {
+        if self.raw.try_lock_shared_recursive() {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { Self::read_guard_arc(this) })
+            Some(unsafe { self.read_guard_arc() })
         } else {
             None
         }
@@ -924,10 +924,10 @@ impl<R: RawRwLockRecursiveTimed, T: ?Sized> RwLock<R, T> {
     /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn try_read_recursive_for_arc(this: &Arc<Self>, timeout: R::Duration) -> Option<ArcRwLockReadGuard<R, T>> {
-        if this.raw.try_lock_shared_recursive_for(timeout) {
+    pub fn try_read_arc_recursive_for(self: &Arc<Self>, timeout: R::Duration) -> Option<ArcRwLockReadGuard<R, T>> {
+        if self.raw.try_lock_shared_recursive_for(timeout) {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { Self::read_guard_arc(this) })
+            Some(unsafe { self.read_guard_arc() })
         } else {
             None
         }
@@ -939,10 +939,10 @@ impl<R: RawRwLockRecursiveTimed, T: ?Sized> RwLock<R, T> {
     /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn try_read_recursive_until_arc(this: &Arc<Self>, timeout: R::Instant) -> Option<ArcRwLockReadGuard<R, T>> {
-        if this.raw.try_lock_shared_recursive_until(timeout) {
+    pub fn try_read_arc_recursive_until(self: &Arc<Self>, timeout: R::Instant) -> Option<ArcRwLockReadGuard<R, T>> {
+        if self.raw.try_lock_shared_recursive_until(timeout) {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { Self::read_guard_arc(this) })
+            Some(unsafe { self.read_guard_arc() })
         } else {
             None
         }
@@ -999,9 +999,9 @@ impl<R: RawRwLockUpgrade, T: ?Sized> RwLock<R, T> {
     /// The lock must be held when calling this method.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    unsafe fn upgradable_guard_arc(this: &Arc<Self>) -> ArcRwLockUpgradableReadGuard<R, T> {
+    unsafe fn upgradable_guard_arc(self: &Arc<Self>) -> ArcRwLockUpgradableReadGuard<R, T> {
         ArcRwLockUpgradableReadGuard {
-            rwlock: this.clone(),
+            rwlock: self.clone(),
             marker: PhantomData 
         }
     }
@@ -1012,10 +1012,10 @@ impl<R: RawRwLockUpgrade, T: ?Sized> RwLock<R, T> {
     /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn upgradable_read_arc(this: &Arc<Self>) -> ArcRwLockUpgradableReadGuard<R, T> {
-        this.raw.lock_upgradable();
+    pub fn upgradable_read_arc(self: &Arc<Self>) -> ArcRwLockUpgradableReadGuard<R, T> {
+        self.raw.lock_upgradable();
         // SAFETY: locking guarantee is upheld
-        unsafe { Self::upgradable_guard_arc(this) }
+        unsafe { self.upgradable_guard_arc() }
     }
 
     /// Attempts to lock this `RwLock` with upgradable read access, through an `Arc`.
@@ -1024,10 +1024,10 @@ impl<R: RawRwLockUpgrade, T: ?Sized> RwLock<R, T> {
     /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn try_upgradable_read_arc(this: &Arc<Self>) -> Option<ArcRwLockUpgradableReadGuard<R, T>> {
-        if this.raw.try_lock_upgradable() {
+    pub fn try_upgradable_read_arc(self: &Arc<Self>) -> Option<ArcRwLockUpgradableReadGuard<R, T>> {
+        if self.raw.try_lock_upgradable() {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { Self::upgradable_guard_arc(this) })
+            Some(unsafe { self.upgradable_guard_arc() })
         } else {
             None
         }
@@ -1079,13 +1079,13 @@ impl<R: RawRwLockUpgradeTimed, T: ?Sized> RwLock<R, T> {
     /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn try_upgradable_read_for_arc(
-        this: &Arc<Self>,
+    pub fn try_upgradable_read_arc_for(
+        self: &Arc<Self>,
         timeout: R::Duration,
     ) -> Option<ArcRwLockUpgradableReadGuard<R, T>> {
-        if this.raw.try_lock_upgradable_for(timeout) {
+        if self.raw.try_lock_upgradable_for(timeout) {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { Self::upgradable_guard_arc(this) })
+            Some(unsafe { self.upgradable_guard_arc(this) })
         } else {
             None
         }
@@ -1097,13 +1097,13 @@ impl<R: RawRwLockUpgradeTimed, T: ?Sized> RwLock<R, T> {
     /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn try_upgradable_read_until_arc(
+    pub fn try_upgradable_read_arc_until(
         this: &Arc<Self>,
         timeout: R::Instant,
     ) -> Option<ArcRwLockUpgradableReadGuard<R, T>> {
-        if this.raw.try_lock_upgradable_until(timeout) {
+        if self.raw.try_lock_upgradable_until(timeout) {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { Self::upgradable_guard_arc(this) })
+            Some(unsafe { self.upgradable_guard_arc() })
         } else {
             None
         }
@@ -1363,7 +1363,10 @@ impl<R: RawRwLockFair, T: ?Sized> ArcRwLockReadGuard<R, T> {
         unsafe {
             s.rwlock.raw.unlock_shared_fair();
         }
-        mem::forget(s);
+
+        // SAFETY: ensure the Arc has its refcount decremented
+        let s = ManuallyDrop::new(s);
+        unsafe { ptr::drop_in_place(&s.rwlock) };
     }
 
     /// Temporarily unlocks the `RwLock` to execute the given function.
@@ -1745,7 +1748,7 @@ impl<R: RawRwLockFair, T: ?Sized> ArcRwLockWriteGuard<R, T> {
 
         // SAFETY: prevent the Arc from leaking memory
         let s = ManuallyDrop::new(s);
-        let _ = unsafe { ptr::read(&s.rwlock) };
+        unsafe { ptr::drop_in_place(&s.rwlock) };
     }
 
     /// Temporarily unlocks the `RwLock` to execute the given function.
@@ -2139,7 +2142,7 @@ impl<R: RawRwLockUpgradeFair, T: ?Sized> ArcRwLockUpgradableReadGuard<R, T> {
 
         // SAFETY: make sure we decrement the refcount properly
         let s = ManuallyDrop::new(s);
-        let _ = unsafe { ptr::read(&s.rwlock) };
+        unsafe { ptr::drop_in_place(&s.rwlock) }; 
     }
 
     /// Temporarily unlocks the `RwLock` to execute the given function.


### PR DESCRIPTION
Resolves #273.

This adds guards for `Mutex` and `RwLock` that allow it to be used from inside of an `Arc`, without lifetime hurdles.