### PR TITLE
Fix Ordering on WordLock (tsan detected)

### DIFF
--- a/core/build.rs
+++ b/core/build.rs
@@ -1,0 +1,10 @@
+// Automatically detect tsan in a way that's compatible with both stable (which
+// doesn't support sanitizers) and nightly (which does). Works because build
+// scripts gets `cfg` info, even if the cfg is unstable.
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    let santizer_list = std::env::var("CARGO_CFG_SANITIZE").unwrap_or_default();
+    if santizer_list.contains("thread") {
+        println!("cargo:rustc-cfg=tsan_enabled");
+    }
+}

--- a/core/src/word_lock.rs
+++ b/core/src/word_lock.rs
@@ -154,7 +154,7 @@ impl WordLock {
                 if let Err(x) = self.state.compare_exchange_weak(
                     state,
                     state.with_queue_head(thread_data),
-                    Ordering::Release,
+                    Ordering::AcqRel,
                     Ordering::Relaxed,
                 ) {
                     return x;
@@ -189,7 +189,7 @@ impl WordLock {
             match self.state.compare_exchange_weak(
                 state,
                 state | QUEUE_LOCKED_BIT,
-                Ordering::Acquire,
+                Ordering::AcqRel,
                 Ordering::Relaxed,
             ) {
                 Ok(_) => break,
@@ -230,7 +230,7 @@ impl WordLock {
                 match self.state.compare_exchange_weak(
                     state,
                     state & !QUEUE_LOCKED_BIT,
-                    Ordering::Release,
+                    Ordering::AcqRel,
                     Ordering::Relaxed,
                 ) {
                     Ok(_) => return,
@@ -249,7 +249,7 @@ impl WordLock {
                     match self.state.compare_exchange_weak(
                         state,
                         state & LOCKED_BIT,
-                        Ordering::Release,
+                        Ordering::AcqRel,
                         Ordering::Relaxed,
                     ) {
                         Ok(_) => break,


### PR DESCRIPTION
I was writing some hand-rolled locks for a tutorial, and did some lightweight fuzzing of the locks under thread-sanitizer to check correctness. I used parking_lot::RawMutex as my "control group" to sanity-check my test suite, but it ended up detecting data races in WordLock.

Taking a look, the Orderings seem a bit too loose — lock_slow used Release in the cmpxchg_weak but needs at least Acquire semantics to acquire the lock (although just using Acquire did not appease TSan), and unlock_slow had a similar problem but reversed (although that code more obviously needs at least Acquire, and so makes sense that it needs AcqRel).

That said, I'm *definitely* not sure these are actually minimal orderings, but I wasn't able to reduce any individual ordering further without upsetting TSan. That said, there may also be a cleverer approach to this.

---

This is the code that detected the issue. I haven't minimized it, although its still pretty small. It uses `cobb` to perform the thread fuzzing, but `cobb` is all safe code (aside from a single function that isn't called in this test, and just does volatile reads/writes that are clearly sound) https://gist.github.com/thomcc/6ca2bef4b7526caeda06f4cceaabfe70