### PR TITLE
Disable eventual fairness on wasm32-unknown-unknown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2018"
 [dependencies]
 parking_lot_core = { path = "core", version = "0.8.4" }
 lock_api = { path = "lock_api", version = "0.4.5" }
-instant = "0.1.9"
 
 [dev-dependencies]
 rand = "0.8.3"
@@ -28,8 +27,6 @@ owning_ref = ["lock_api/owning_ref"]
 nightly = ["parking_lot_core/nightly", "lock_api/nightly"]
 deadlock_detection = ["parking_lot_core/deadlock_detection"]
 serde = ["lock_api/serde"]
-stdweb = ["instant/stdweb"]
-wasm-bindgen = ["instant/wasm-bindgen"]
 send_guard = []
 
 [workspace]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,6 @@ smallvec = "1.6.1"
 petgraph = { version = "0.5.1", optional = true }
 thread-id = { version = "4.0.0", optional = true }
 backtrace = { version = "0.3.60", optional = true }
-instant = "0.1.9"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.95"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -46,7 +46,7 @@
 #![cfg_attr(
     all(
         feature = "nightly",
-        target_arch = "wasm32",
+        target_family = "wasm",
         target_feature = "atomics"
     ),
     feature(stdsimd)

--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -18,7 +18,7 @@ use std::time::{Duration, Instant};
 // Don't use Instant on wasm32-unknown-unknown, it just panics.
 cfg_if::cfg_if! {
     if #[cfg(all(
-        target_arch = "wasm32",
+        target_family = "wasm",
         target_os = "unknown",
         target_vendor = "unknown"
     ))] {

--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -12,9 +12,33 @@ use core::{
     ptr,
     sync::atomic::{AtomicPtr, AtomicUsize, Ordering},
 };
-use instant::Instant;
 use smallvec::SmallVec;
-use std::time::Duration;
+use std::time::{Duration, Instant};
+
+// Don't use Instant on wasm32-unknown-unknown, it just panics.
+cfg_if::cfg_if! {
+    if #[cfg(all(
+        target_arch = "wasm32",
+        target_os = "unknown",
+        target_vendor = "unknown"
+    ))] {
+        #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+        struct TimeoutInstant;
+        impl TimeoutInstant {
+            fn now() -> TimeoutInstant {
+                TimeoutInstant
+            }
+        }
+        impl core::ops::Add<Duration> for TimeoutInstant {
+            type Output = Self;
+            fn add(self, _rhs: Duration) -> Self::Output {
+                TimeoutInstant
+            }
+        }
+    } else {
+        use std::time::Instant as TimeoutInstant;
+    }
+}
 
 static NUM_THREADS: AtomicUsize = AtomicUsize::new(0);
 
@@ -47,7 +71,7 @@ impl HashTable {
         let new_size = (num_threads * LOAD_FACTOR).next_power_of_two();
         let hash_bits = 0usize.leading_zeros() - new_size.leading_zeros() - 1;
 
-        let now = Instant::now();
+        let now = TimeoutInstant::now();
         let mut entries = Vec::with_capacity(new_size);
         for i in 0..new_size {
             // We must ensure the seed is not zero
@@ -77,7 +101,7 @@ struct Bucket {
 
 impl Bucket {
     #[inline]
-    pub fn new(timeout: Instant, seed: u32) -> Self {
+    pub fn new(timeout: TimeoutInstant, seed: u32) -> Self {
         Self {
             mutex: WordLock::new(),
             queue_head: Cell::new(ptr::null()),
@@ -89,7 +113,7 @@ impl Bucket {
 
 struct FairTimeout {
     // Next time at which point be_fair should be set
-    timeout: Instant,
+    timeout: TimeoutInstant,
 
     // the PRNG state for calculating the next timeout
     seed: u32,
@@ -97,14 +121,14 @@ struct FairTimeout {
 
 impl FairTimeout {
     #[inline]
-    fn new(timeout: Instant, seed: u32) -> FairTimeout {
+    fn new(timeout: TimeoutInstant, seed: u32) -> FairTimeout {
         FairTimeout { timeout, seed }
     }
 
     // Determine whether we should force a fair unlock, and update the timeout
     #[inline]
     fn should_timeout(&mut self) -> bool {
-        let now = Instant::now();
+        let now = TimeoutInstant::now();
         if now > self.timeout {
             // Time between 0 and 1ms.
             let nanos = self.gen_u32() % 1_000_000;

--- a/core/src/thread_parker/generic.rs
+++ b/core/src/thread_parker/generic.rs
@@ -9,8 +9,8 @@
 //! parking facilities available.
 
 use core::sync::atomic::{spin_loop_hint, AtomicBool, Ordering};
-use instant::Instant;
 use std::thread;
+use std::time::Instant;
 
 // Helper type for putting a thread to sleep until some other thread wakes it up
 pub struct ThreadParker {

--- a/core/src/thread_parker/linux.rs
+++ b/core/src/thread_parker/linux.rs
@@ -9,9 +9,9 @@ use core::{
     ptr,
     sync::atomic::{AtomicI32, Ordering},
 };
-use instant::Instant;
 use libc;
 use std::thread;
+use std::time::Instant;
 
 // x32 Linux uses a non-standard type for tv_nsec in timespec.
 // See https://sourceware.org/bugzilla/show_bug.cgi?id=16437

--- a/core/src/thread_parker/mod.rs
+++ b/core/src/thread_parker/mod.rs
@@ -68,12 +68,12 @@ cfg_if! {
         mod imp;
     } else if #[cfg(all(
         feature = "nightly",
-        target_arch = "wasm32",
+        target_family = "wasm",
         target_feature = "atomics"
     ))] {
         #[path = "wasm_atomic.rs"]
         mod imp;
-    } else if #[cfg(target_arch = "wasm32")] {
+    } else if #[cfg(target_family = "wasm")] {
         #[path = "wasm.rs"]
         mod imp;
     } else {

--- a/core/src/thread_parker/mod.rs
+++ b/core/src/thread_parker/mod.rs
@@ -1,5 +1,5 @@
 use cfg_if::cfg_if;
-use instant::Instant;
+use std::time::Instant;
 
 /// Trait for the platform thread parker implementation.
 ///

--- a/core/src/thread_parker/redox.rs
+++ b/core/src/thread_parker/redox.rs
@@ -9,8 +9,8 @@ use core::{
     ptr,
     sync::atomic::{AtomicI32, Ordering},
 };
-use instant::Instant;
 use std::thread;
+use std::time::Instant;
 use syscall::{
     call::futex,
     data::TimeSpec,

--- a/core/src/thread_parker/sgx.rs
+++ b/core/src/thread_parker/sgx.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use core::sync::atomic::{AtomicBool, Ordering};
-use instant::Instant;
+use std::time::Instant;
 use std::{
     io,
     os::fortanix_sgx::{

--- a/core/src/thread_parker/unix.rs
+++ b/core/src/thread_parker/unix.rs
@@ -11,8 +11,8 @@ use core::{
     cell::{Cell, UnsafeCell},
     mem::MaybeUninit,
 };
-use instant::Instant;
 use libc;
+use std::time::Instant;
 use std::{thread, time::Duration};
 
 // x32 Linux uses a non-standard type for tv_nsec in timespec.

--- a/core/src/thread_parker/wasm.rs
+++ b/core/src/thread_parker/wasm.rs
@@ -8,8 +8,8 @@
 //! The wasm platform can't park when atomic support is not available.
 //! So this ThreadParker just panics on any attempt to park.
 
-use instant::Instant;
 use std::thread;
+use std::time::Instant;
 
 pub struct ThreadParker(());
 

--- a/core/src/thread_parker/windows/keyed_event.rs
+++ b/core/src/thread_parker/windows/keyed_event.rs
@@ -9,8 +9,8 @@ use core::{
     mem::{self, MaybeUninit},
     ptr,
 };
-use instant::Instant;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
 use winapi::{
     shared::{
         minwindef::{TRUE, ULONG},

--- a/core/src/thread_parker/windows/mod.rs
+++ b/core/src/thread_parker/windows/mod.rs
@@ -9,7 +9,7 @@ use core::{
     ptr,
     sync::atomic::{AtomicPtr, AtomicUsize, Ordering},
 };
-use instant::Instant;
+use std::time::Instant;
 
 mod keyed_event;
 mod waitaddress;

--- a/core/src/thread_parker/windows/waitaddress.rs
+++ b/core/src/thread_parker/windows/waitaddress.rs
@@ -9,7 +9,7 @@ use core::{
     mem,
     sync::atomic::{AtomicUsize, Ordering},
 };
-use instant::Instant;
+use std::time::Instant;
 use winapi::{
     shared::{
         basetsd::SIZE_T,

--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -663,8 +663,8 @@ impl<'a, R: RawMutex + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display for Mutex
 unsafe impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> StableAddress for MutexGuard<'a, R, T> {}
 
 /// An RAII mutex guard returned by the `Arc` locking operations on `Mutex`.
-/// 
-/// This is similar to the `MutexGuard` struct, except instead of using a reference to unlock the `Mutex` it 
+///
+/// This is similar to the `MutexGuard` struct, except instead of using a reference to unlock the `Mutex` it
 /// uses an `Arc<Mutex>`. This has several advantages, most notably that it has an `'static` lifetime.
 #[cfg(feature = "arc_lock")]
 #[must_use = "if unused the Mutex will immediately unlock"]
@@ -713,7 +713,7 @@ impl<R: RawMutexFair, T: ?Sized> ArcMutexGuard<R, T> {
 
         // SAFETY: make sure the Arc gets it reference decremented
         let mut s = ManuallyDrop::new(s);
-        unsafe { ptr::drop_in_place(&mut s.mutex) }; 
+        unsafe { ptr::drop_in_place(&mut s.mutex) };
     }
 
     /// Temporarily unlocks the mutex to execute the given function.

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -401,7 +401,7 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     }
 
     /// # Safety
-    /// 
+    ///
     /// The lock must be held before calling this method.
     #[cfg(feature = "arc_lock")]
     #[inline]
@@ -413,7 +413,7 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     }
 
     /// Acquires a reentrant mutex through an `Arc`.
-    /// 
+    ///
     /// This method is similar to the `lock` method; however, it requires the `ReentrantMutex` to be inside of an
     /// `Arc` and the resulting mutex guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
@@ -425,7 +425,7 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     }
 
     /// Attempts to acquire a reentrant mutex through an `Arc`.
-    /// 
+    ///
     /// This method is similar to the `try_lock` method; however, it requires the `ReentrantMutex` to be inside
     /// of an `Arc` and the resulting mutex guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
@@ -490,12 +490,15 @@ impl<R: RawMutexTimed, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     }
 
     /// Attempts to acquire this lock until a timeout is reached, through an `Arc`.
-    /// 
+    ///
     /// This method is similar to the `try_lock_for` method; however, it requires the `ReentrantMutex` to be
     /// inside of an `Arc` and the resulting mutex guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn try_lock_arc_for(self: &Arc<Self>, timeout: R::Duration) -> Option<ArcReentrantMutexGuard<R, G, T>> {
+    pub fn try_lock_arc_for(
+        self: &Arc<Self>,
+        timeout: R::Duration,
+    ) -> Option<ArcReentrantMutexGuard<R, G, T>> {
         if self.raw.try_lock_for(timeout) {
             // SAFETY: locking guarantee is upheld
             Some(unsafe { self.guard_arc() })
@@ -505,12 +508,15 @@ impl<R: RawMutexTimed, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     }
 
     /// Attempts to acquire this lock until a timeout is reached, through an `Arc`.
-    /// 
+    ///
     /// This method is similar to the `try_lock_until` method; however, it requires the `ReentrantMutex` to be
     /// inside of an `Arc` and the resulting mutex guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn try_lock_arc_until(self: &Arc<Self>, timeout: R::Instant) -> Option<ArcReentrantMutexGuard<R, G, T>> {
+    pub fn try_lock_arc_until(
+        self: &Arc<Self>,
+        timeout: R::Instant,
+    ) -> Option<ArcReentrantMutexGuard<R, G, T>> {
         if self.raw.try_lock_until(timeout) {
             // SAFETY: locking guarantee is upheld
             Some(unsafe { self.guard_arc() })
@@ -736,7 +742,6 @@ impl<'a, R: RawMutexFair + 'a, G: GetThreadId + 'a, T: ?Sized + 'a>
             s.remutex.raw.bump();
         }
     }
-
 }
 
 impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> Deref
@@ -783,9 +788,9 @@ unsafe impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> StableAdd
 {
 }
 
-/// An RAII mutex guard returned by the `Arc` locking operations on `ReentrantMutex`. 
-/// 
-/// This is similar to the `ReentrantMutexGuard` struct, except instead of using a reference to unlock the 
+/// An RAII mutex guard returned by the `Arc` locking operations on `ReentrantMutex`.
+///
+/// This is similar to the `ReentrantMutexGuard` struct, except instead of using a reference to unlock the
 /// `Mutex` it uses an `Arc<ReentrantMutex>`. This has several advantages, most notably that it has an `'static`
 /// lifetime.
 #[cfg(feature = "arc_lock")]
@@ -821,9 +826,7 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> ArcReentrantMutexGuard<R, G, T> {
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawMutexFair, G: GetThreadId, T: ?Sized>
-    ArcReentrantMutexGuard<R, G, T>
-{
+impl<R: RawMutexFair, G: GetThreadId, T: ?Sized> ArcReentrantMutexGuard<R, G, T> {
     /// Unlocks the mutex using a fair unlock protocol.
     ///
     /// This is functionally identical to the `unlock_fair` method on [`ReentrantMutexGuard`].
@@ -868,9 +871,7 @@ impl<R: RawMutexFair, G: GetThreadId, T: ?Sized>
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawMutex, G: GetThreadId, T: ?Sized> Deref
-    for ArcReentrantMutexGuard<R, G, T>
-{
+impl<R: RawMutex, G: GetThreadId, T: ?Sized> Deref for ArcReentrantMutexGuard<R, G, T> {
     type Target = T;
     #[inline]
     fn deref(&self) -> &T {
@@ -879,9 +880,7 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> Deref
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawMutex, G: GetThreadId, T: ?Sized> Drop
-    for ArcReentrantMutexGuard<R, G, T>
-{
+impl<R: RawMutex, G: GetThreadId, T: ?Sized> Drop for ArcReentrantMutexGuard<R, G, T> {
     #[inline]
     fn drop(&mut self) {
         // Safety: A ReentrantMutexGuard always holds the lock.

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -590,7 +590,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     }
 
     /// Locks this `RwLock` with read access, through an `Arc`.
-    /// 
+    ///
     /// This method is similar to the `read` method; however, it requires the `RwLock` to be inside of an `Arc`
     /// and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
@@ -602,8 +602,8 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     }
 
     /// Attempts to lock this `RwLock` with read access, through an `Arc`.
-    /// 
-    /// This method is similar to the `try_read` method; however, it requires the `RwLock` to be inside of an 
+    ///
+    /// This method is similar to the `try_read` method; however, it requires the `RwLock` to be inside of an
     /// `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
@@ -617,7 +617,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     }
 
     /// Locks this `RwLock` with write access, through an `Arc`.
-    /// 
+    ///
     /// This method is similar to the `write` method; however, it requires the `RwLock` to be inside of an `Arc`
     /// and the resulting write guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
@@ -629,8 +629,8 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     }
 
     /// Attempts to lock this `RwLock` with writ access, through an `Arc`.
-    /// 
-    /// This method is similar to the `try_write` method; however, it requires the `RwLock` to be inside of an 
+    ///
+    /// This method is similar to the `try_write` method; however, it requires the `RwLock` to be inside of an
     /// `Arc` and the resulting write guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
@@ -744,12 +744,15 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     }
 
     /// Attempts to acquire this `RwLock` with read access until a timeout is reached, through an `Arc`.
-    /// 
+    ///
     /// This method is similar to the `try_read_for` method; however, it requires the `RwLock` to be inside of an
     /// `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn try_read_arc_for(self: &Arc<Self>, timeout: R::Duration) -> Option<ArcRwLockReadGuard<R, T>> {
+    pub fn try_read_arc_for(
+        self: &Arc<Self>,
+        timeout: R::Duration,
+    ) -> Option<ArcRwLockReadGuard<R, T>> {
         if self.raw.try_lock_shared_for(timeout) {
             // SAFETY: locking guarantee is upheld
             Some(unsafe { self.read_guard_arc() })
@@ -759,12 +762,15 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     }
 
     /// Attempts to acquire this `RwLock` with read access until a timeout is reached, through an `Arc`.
-    /// 
+    ///
     /// This method is similar to the `try_read_until` method; however, it requires the `RwLock` to be inside of
     /// an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn try_read_arc_until(self: &Arc<Self>, timeout: R::Instant) -> Option<ArcRwLockReadGuard<R, T>> {
+    pub fn try_read_arc_until(
+        self: &Arc<Self>,
+        timeout: R::Instant,
+    ) -> Option<ArcRwLockReadGuard<R, T>> {
         if self.raw.try_lock_shared_until(timeout) {
             // SAFETY: locking guarantee is upheld
             Some(unsafe { self.read_guard_arc() })
@@ -774,12 +780,15 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     }
 
     /// Attempts to acquire this `RwLock` with write access until a timeout is reached, through an `Arc`.
-    /// 
+    ///
     /// This method is similar to the `try_write_for` method; however, it requires the `RwLock` to be inside of
     /// an `Arc` and the resulting write guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn try_write_arc_for(self: &Arc<Self>, timeout: R::Duration) -> Option<ArcRwLockWriteGuard<R, T>> {
+    pub fn try_write_arc_for(
+        self: &Arc<Self>,
+        timeout: R::Duration,
+    ) -> Option<ArcRwLockWriteGuard<R, T>> {
         if self.raw.try_lock_exclusive_for(timeout) {
             // SAFETY: locking guarantee is upheld
             Some(unsafe { self.write_guard_arc() })
@@ -789,12 +798,15 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     }
 
     /// Attempts to acquire this `RwLock` with read access until a timeout is reached, through an `Arc`.
-    /// 
+    ///
     /// This method is similar to the `try_write_until` method; however, it requires the `RwLock` to be inside of
     /// an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn try_write_arc_until(self: &Arc<Self>, timeout: R::Instant) -> Option<ArcRwLockWriteGuard<R, T>> {
+    pub fn try_write_arc_until(
+        self: &Arc<Self>,
+        timeout: R::Instant,
+    ) -> Option<ArcRwLockWriteGuard<R, T>> {
         if self.raw.try_lock_exclusive_until(timeout) {
             // SAFETY: locking guarantee is upheld
             Some(unsafe { self.write_guard_arc() })
@@ -848,7 +860,7 @@ impl<R: RawRwLockRecursive, T: ?Sized> RwLock<R, T> {
     }
 
     /// Locks this `RwLock` with shared read access, through an `Arc`.
-    /// 
+    ///
     /// This method is similar to the `read_recursive` method; however, it requires the `RwLock` to be inside of
     /// an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
@@ -860,7 +872,7 @@ impl<R: RawRwLockRecursive, T: ?Sized> RwLock<R, T> {
     }
 
     /// Attempts to lock this `RwLock` with shared read access, through an `Arc`.
-    /// 
+    ///
     /// This method is similar to the `try_read_recursive` method; however, it requires the `RwLock` to be inside
     /// of an `Arc` and the resulting read guard has no lifetime requirements.   
     #[cfg(feature = "arc_lock")]
@@ -924,7 +936,10 @@ impl<R: RawRwLockRecursiveTimed, T: ?Sized> RwLock<R, T> {
     /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn try_read_arc_recursive_for(self: &Arc<Self>, timeout: R::Duration) -> Option<ArcRwLockReadGuard<R, T>> {
+    pub fn try_read_arc_recursive_for(
+        self: &Arc<Self>,
+        timeout: R::Duration,
+    ) -> Option<ArcRwLockReadGuard<R, T>> {
         if self.raw.try_lock_shared_recursive_for(timeout) {
             // SAFETY: locking guarantee is upheld
             Some(unsafe { self.read_guard_arc() })
@@ -939,7 +954,10 @@ impl<R: RawRwLockRecursiveTimed, T: ?Sized> RwLock<R, T> {
     /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub fn try_read_arc_recursive_until(self: &Arc<Self>, timeout: R::Instant) -> Option<ArcRwLockReadGuard<R, T>> {
+    pub fn try_read_arc_recursive_until(
+        self: &Arc<Self>,
+        timeout: R::Instant,
+    ) -> Option<ArcRwLockReadGuard<R, T>> {
         if self.raw.try_lock_shared_recursive_until(timeout) {
             // SAFETY: locking guarantee is upheld
             Some(unsafe { self.read_guard_arc() })
@@ -995,19 +1013,19 @@ impl<R: RawRwLockUpgrade, T: ?Sized> RwLock<R, T> {
     }
 
     /// # Safety
-    /// 
+    ///
     /// The lock must be held when calling this method.
     #[cfg(feature = "arc_lock")]
     #[inline]
     unsafe fn upgradable_guard_arc(self: &Arc<Self>) -> ArcRwLockUpgradableReadGuard<R, T> {
         ArcRwLockUpgradableReadGuard {
             rwlock: self.clone(),
-            marker: PhantomData 
+            marker: PhantomData,
         }
     }
 
     /// Locks this `RwLock` with upgradable read access, through an `Arc`.
-    /// 
+    ///
     /// This method is similar to the `upgradable_read` method; however, it requires the `RwLock` to be
     /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
@@ -1019,7 +1037,7 @@ impl<R: RawRwLockUpgrade, T: ?Sized> RwLock<R, T> {
     }
 
     /// Attempts to lock this `RwLock` with upgradable read access, through an `Arc`.
-    /// 
+    ///
     /// This method is similar to the `try_upgradable_read` method; however, it requires the `RwLock` to be
     /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
@@ -1074,7 +1092,7 @@ impl<R: RawRwLockUpgradeTimed, T: ?Sized> RwLock<R, T> {
     }
 
     /// Attempts to lock this `RwLock` with upgradable access until a timeout is reached, through an `Arc`.
-    /// 
+    ///
     /// This method is similar to the `try_upgradable_read_for` method; however, it requires the `RwLock` to be
     /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
@@ -1092,7 +1110,7 @@ impl<R: RawRwLockUpgradeTimed, T: ?Sized> RwLock<R, T> {
     }
 
     /// Attempts to lock this `RwLock` with upgradable access until a timeout is reached, through an `Arc`.
-    /// 
+    ///
     /// This method is similar to the `try_upgradable_read_until` method; however, it requires the `RwLock` to be
     /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
@@ -1318,9 +1336,9 @@ impl<'a, R: RawRwLock + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
 #[cfg(feature = "owning_ref")]
 unsafe impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> StableAddress for RwLockReadGuard<'a, R, T> {}
 
-/// An RAII rwlock guard returned by the `Arc` locking operations on `RwLock`. 
-/// 
-/// This is similar to the `RwLockReadGuard` struct, except instead of using a reference to unlock the `RwLock` 
+/// An RAII rwlock guard returned by the `Arc` locking operations on `RwLock`.
+///
+/// This is similar to the `RwLockReadGuard` struct, except instead of using a reference to unlock the `RwLock`
 /// it uses an `Arc<RwLock>`. This has several advantages, most notably that it has an `'static` lifetime.
 #[cfg(feature = "arc_lock")]
 #[must_use = "if unused the RwLock will immediately unlock"]
@@ -1426,9 +1444,7 @@ impl<R: RawRwLock, T: fmt::Debug + ?Sized> fmt::Debug for ArcRwLockReadGuard<R, 
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawRwLock, T: fmt::Display + ?Sized> fmt::Display
-    for ArcRwLockReadGuard<R, T>
-{
+impl<R: RawRwLock, T: fmt::Display + ?Sized> fmt::Display for ArcRwLockReadGuard<R, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (**self).fmt(f)
     }
@@ -1655,8 +1671,8 @@ impl<'a, R: RawRwLock + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
 #[cfg(feature = "owning_ref")]
 unsafe impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> StableAddress for RwLockWriteGuard<'a, R, T> {}
 
-/// An RAII rwlock guard returned by the `Arc` locking operations on `RwLock`. 
-/// This is similar to the `RwLockWriteGuard` struct, except instead of using a reference to unlock the `RwLock` 
+/// An RAII rwlock guard returned by the `Arc` locking operations on `RwLock`.
+/// This is similar to the `RwLockWriteGuard` struct, except instead of using a reference to unlock the `RwLock`
 /// it uses an `Arc<RwLock>`. This has several advantages, most notably that it has an `'static` lifetime.
 #[cfg(feature = "arc_lock")]
 #[must_use = "if unused the RwLock will immediately unlock"]
@@ -1770,7 +1786,7 @@ impl<R: RawRwLockFair, T: ?Sized> ArcRwLockWriteGuard<R, T> {
 
     /// Temporarily yields the `RwLock` to a waiting thread if there is one.
     ///
-    /// This method is functionally equivalent to the `bump` method on [`RwLockWriteGuard`]. 
+    /// This method is functionally equivalent to the `bump` method on [`RwLockWriteGuard`].
     #[inline]
     pub fn bump(s: &mut Self) {
         // Safety: An RwLockWriteGuard always holds an exclusive lock.
@@ -1816,9 +1832,7 @@ impl<R: RawRwLock, T: fmt::Debug + ?Sized> fmt::Debug for ArcRwLockWriteGuard<R,
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawRwLock, T: fmt::Display + ?Sized> fmt::Display
-    for ArcRwLockWriteGuard<R, T>
-{
+impl<R: RawRwLock, T: fmt::Display + ?Sized> fmt::Display for ArcRwLockWriteGuard<R, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (**self).fmt(f)
     }
@@ -2059,7 +2073,7 @@ unsafe impl<'a, R: RawRwLockUpgrade + 'a, T: ?Sized + 'a> StableAddress
 
 /// An RAII rwlock guard returned by the `Arc` locking operations on `RwLock`.
 /// This is similar to the `RwLockUpgradableReadGuard` struct, except instead of using a reference to unlock the
-/// `RwLock` it uses an `Arc<RwLock>`. This has several advantages, most notably that it has an `'static` 
+/// `RwLock` it uses an `Arc<RwLock>`. This has several advantages, most notably that it has an `'static`
 /// lifetime.
 #[cfg(feature = "arc_lock")]
 #[must_use = "if unused the RwLock will immediately unlock"]
@@ -2069,7 +2083,7 @@ pub struct ArcRwLockUpgradableReadGuard<R: RawRwLockUpgrade, T: ?Sized> {
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawRwLockUpgrade , T: ?Sized> ArcRwLockUpgradableReadGuard<R, T> {
+impl<R: RawRwLockUpgrade, T: ?Sized> ArcRwLockUpgradableReadGuard<R, T> {
     /// Returns a reference to the rwlock, contained in its original `Arc`.
     pub fn rwlock(s: &Self) -> &Arc<RwLock<R, T>> {
         &s.rwlock
@@ -2144,7 +2158,7 @@ impl<R: RawRwLockUpgradeFair, T: ?Sized> ArcRwLockUpgradableReadGuard<R, T> {
 
         // SAFETY: make sure we decrement the refcount properly
         let mut s = ManuallyDrop::new(s);
-        unsafe { ptr::drop_in_place(&mut s.rwlock) }; 
+        unsafe { ptr::drop_in_place(&mut s.rwlock) };
     }
 
     /// Temporarily unlocks the `RwLock` to execute the given function.
@@ -2290,7 +2304,6 @@ impl<R: RawRwLockUpgrade, T: fmt::Display + ?Sized> fmt::Display
         (**self).fmt(f)
     }
 }
-
 
 /// An RAII read lock guard returned by `RwLockReadGuard::map`, which can point to a
 /// subfield of the protected data.

--- a/src/condvar.rs
+++ b/src/condvar.rs
@@ -12,10 +12,9 @@ use core::{
     fmt, ptr,
     sync::atomic::{AtomicPtr, Ordering},
 };
-use instant::Instant;
 use lock_api::RawMutex as RawMutex_;
 use parking_lot_core::{self, ParkResult, RequeueOp, UnparkResult, DEFAULT_PARK_TOKEN};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// A type indicating whether a timed wait on a condition variable returned
 /// due to a time out or not.
@@ -414,11 +413,11 @@ impl fmt::Debug for Condvar {
 #[cfg(test)]
 mod tests {
     use crate::{Condvar, Mutex, MutexGuard};
-    use instant::Instant;
     use std::sync::mpsc::channel;
     use std::sync::Arc;
     use std::thread;
     use std::time::Duration;
+    use std::time::Instant;
 
     #[test]
     fn smoke() {

--- a/src/raw_mutex.rs
+++ b/src/raw_mutex.rs
@@ -10,9 +10,9 @@ use core::{
     sync::atomic::{AtomicU8, Ordering},
     time::Duration,
 };
-use instant::Instant;
 use lock_api::RawMutex as RawMutex_;
 use parking_lot_core::{self, ParkResult, SpinWait, UnparkResult, UnparkToken, DEFAULT_PARK_TOKEN};
+use std::time::Instant;
 
 // UnparkToken used to indicate that that the target thread should attempt to
 // lock the mutex again as soon as it is unparked.

--- a/src/raw_rwlock.rs
+++ b/src/raw_rwlock.rs
@@ -12,12 +12,11 @@ use core::{
     cell::Cell,
     sync::atomic::{AtomicUsize, Ordering},
 };
-use instant::Instant;
 use lock_api::{RawRwLock as RawRwLock_, RawRwLockUpgrade};
 use parking_lot_core::{
     self, deadlock, FilterOp, ParkResult, ParkToken, SpinWait, UnparkResult, UnparkToken,
 };
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 // This reader-writer lock implementation is based on Boost's upgrade_mutex:
 // https://github.com/boostorg/thread/blob/fc08c1fe2840baeeee143440fba31ef9e9a813c8/include/boost/thread/v2/shared_mutex.hpp#L432

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,8 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use instant::Instant;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 // Option::unchecked_unwrap
 pub trait UncheckedOptionExt<T> {


### PR DESCRIPTION
std::time::Instant panics on this target and the external instant crate
adds undesirable external dependencies to the wasm module.

Fixes #269