### PR TITLE
Add a rwlock method to report if lock is held exclusively

### DIFF
--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -86,7 +86,16 @@ pub unsafe trait RawRwLock {
     }
 
     /// Check if this `RwLock` is currently exclusively locked.
-    fn is_locked_exclusive(&self) -> bool;
+    fn is_locked_exclusive(&self) -> bool {
+        let acquired_lock = self.try_lock_shared();
+        if acquired_lock {
+            // Safety: A shared lock was successfully acquired above.
+            unsafe {
+                self.unlock_shared();
+            }
+        }
+        !acquired_lock
+    }
 }
 
 /// Additional methods for RwLocks which support fair unlocking.

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -84,6 +84,9 @@ pub unsafe trait RawRwLock {
         }
         !acquired_lock
     }
+
+    /// Check if this `RwLock` is currently exclusively locked.
+    fn is_locked_exclusive(&self) -> bool;
 }
 
 /// Additional methods for RwLocks which support fair unlocking.
@@ -500,6 +503,12 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     #[inline]
     pub fn is_locked(&self) -> bool {
         self.raw.is_locked()
+    }
+
+    /// Check if this `RwLock` is currently exclusively locked.
+    #[inline]
+    pub fn is_locked_exclusive(&self) -> bool {
+        self.raw.is_locked_exclusive()
     }
 
     /// Forcibly unlocks a read lock.

--- a/src/raw_rwlock.rs
+++ b/src/raw_rwlock.rs
@@ -143,6 +143,12 @@ unsafe impl lock_api::RawRwLock for RawRwLock {
         let state = self.state.load(Ordering::Relaxed);
         state & (WRITER_BIT | READERS_MASK) != 0
     }
+
+    #[inline]
+    fn is_locked_exclusive(&self) -> bool {
+        let state = self.state.load(Ordering::Relaxed);
+        state & (WRITER_BIT) != 0
+    }
 }
 
 unsafe impl lock_api::RawRwLockFair for RawRwLock {

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -408,6 +408,8 @@ mod tests {
                 write_result.is_none(),
                 "try_write should fail while read_guard is in scope"
             );
+            assert!(lock.is_locked());
+            assert!(!lock.is_locked_exclusive());
 
             drop(read_guard);
         }
@@ -419,6 +421,8 @@ mod tests {
                 write_result.is_none(),
                 "try_write should fail while upgrade_guard is in scope"
             );
+            assert!(lock.is_locked());
+            assert!(!lock.is_locked_exclusive());
 
             drop(upgrade_guard);
         }
@@ -430,6 +434,8 @@ mod tests {
                 write_result.is_none(),
                 "try_write should fail while write_guard is in scope"
             );
+            assert!(lock.is_locked());
+            assert!(lock.is_locked_exclusive());
 
             drop(write_guard);
         }
@@ -614,5 +620,23 @@ mod tests {
         })
         .join()
         .unwrap();
+    }
+
+    #[test]
+    fn test_rw_write_is_locked() {
+        let lock = RwLock::new(0isize);
+        {
+            let _read_guard = lock.read();
+
+            assert!(lock.is_locked());
+            assert!(!lock.is_locked_exclusive());
+        }
+
+        {
+            let _write_guard = lock.write();
+
+            assert!(lock.is_locked());
+            assert!(lock.is_locked_exclusive());
+        }
     }
 }


### PR DESCRIPTION
Closes issue #293.

I also ran into the same issue posed in issue #293. Specifically, it was
for implementing an optimistic hybrid lock as described in [this paper][scalable-latches]
in section 2.3, listing #2. 

[scalable-latches]: https://db.in.tum.de/~giceva/papers/damon_latches.pdf?lang=de
