### PR TITLE
Switch from llvm_asm!() to new asm!() macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
-#![cfg_attr(feature = "nightly", feature(llvm_asm))]
+#![cfg_attr(feature = "nightly", feature(asm))]
 
 mod condvar;
 mod elision;


### PR DESCRIPTION
To be honest I'm not the most familiar with inline assembly, but afaict the new version is correct. The assembly output is identical, at least, checking `RawRwLock::bump_shared_slow` (which calls both elision impls) using `cargo asm`.

This should be ready for use when `asm!()` is stabilized, cf (well, your own stabilization report I guess) https://github.com/rust-lang/rust/issues/72016#issuecomment-964186287
