### PR TITLE
Optionally support parking_lot within global allocators.

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,3 +29,8 @@ winapi = { version = "0.3.9", features = ["winnt", "ntstatus", "minwindef",
 [features]
 nightly = []
 deadlock_detection = ["petgraph", "thread-id", "backtrace"]
+
+# Enable this to enable support for `#[global_allocator]` implementations using
+# parking_lot locks. Users must ensure that `parking_lot_core::init()` is called
+# before any synchronization functions are called.
+global_allocator_compat = []

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -59,6 +59,8 @@ mod util;
 mod word_lock;
 
 pub use self::parking_lot::deadlock;
+#[cfg(feature = "global_allocator_compat")]
+pub use self::parking_lot::init;
 pub use self::parking_lot::{park, unpark_all, unpark_filter, unpark_one, unpark_requeue};
 pub use self::parking_lot::{
     FilterOp, ParkResult, ParkToken, RequeueOp, UnparkResult, UnparkToken,

--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -188,10 +188,8 @@ impl ThreadData {
         // letting the outer call perform the grow.
         #[cfg(feature = "global_allocator_compat")]
         let grow = {
-            thread_local!(static ACTIVE: AtomicBool = AtomicBool::new(false));
-            !ACTIVE
-                .try_with(|active| active.swap(true, Ordering::Relaxed))
-                .unwrap_or(true)
+            thread_local!(static ACTIVE: Cell<bool> = Cell::new(false));
+            !ACTIVE.try_with(|active| active.swap(true)).unwrap_or(true)
         };
 
         #[cfg(not(feature = "global_allocator_compat"))]

--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -241,7 +241,7 @@ impl Drop for ThreadData {
 /// be called before any synchronization functions are called.
 #[cfg(feature = "global_allocator_compat")]
 pub fn init() {
-    let _ = get_hashtable();
+    create_hashtable();
 }
 
 /// Returns a reference to the latest hash table, creating one if it doesn't exist yet.


### PR DESCRIPTION
This adds a feature to support using parking_lot locks in
`#[global_allocator]` implementations. The main hazard is parking_lot calling
into the global allocator, and then the global allocator calling back into
parking_lot, at a point where parking_lot is not prepared to be re-entered on
the same thread.

There are currently two places where this comes up:

 - When a new thread is created, parking_lot needs to allocate space in its
   hashtable for the new thread. It uses the global allocator to allocate this
   space, and if the global allocator uses parking lot, it doesn't work because
   the hashtable is not ready for the new thread yet.

 - If the new hashtable is allocated while bucket locks are held, and the
   global allocator attempts to acquire a parking lot lock, it deadlocks
   because all the buckets are locked.

For the first, this adds a new `reserve` function, defined when the "reserve"
feature is enabled. This allocates space in the hashtable, and if users call
it before each thread creation in the program, parking_lot won't ever need to
call `grow_hashtable` on new threads. This is admittedly awkward to guarantee
in general, however it's not a problem in my own use case. And this function
might also be useful in cases where users want to create a pool of threads all
at once, to reduce temporary allocations, leakage, and rehashing. However, I'm
open to other ideas here.

For the second, when "reserve" is enabled, `create_hashtable` will allocate the
new `HashTable` before locking all the bucket locks, to avoid deadlock if
allocating the `HashTable` attempts to take a lock.