### PR TITLE
Use core::hint::spin_loop instead of the deprecated spin_loop_hint.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,11 +16,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos, windows]
-        channel: [1.41.0, stable, beta, nightly]
+        channel: [1.49.0, stable, beta, nightly]
         feature: [arc_lock, serde, deadlock_detection]
         exclude: 
           - feature: deadlock_detection
-            channel: '1.41.0'
+            channel: '1.49.0'
         include:
           - channel: nightly
             feature: nightly

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,11 +2,11 @@ name: Rust
 
 on:
   push:
-    branches-ignore:
-      - trying.tmp
-      - staging.tmp
+    branches:
+      - trying
+      - staging
   pull_request:
-    
+
 env:
   RUST_TEST_THREADS: 1
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ changes to the core API do not cause breaking changes for users of `parking_lot`
 
 ## Minimum Rust version
 
-The current minimum required Rust version is 1.41. Any change to this is
+The current minimum required Rust version is 1.49. Any change to this is
 considered a breaking change and will require a major version bump.
 
 ## License

--- a/core/src/spinwait.rs
+++ b/core/src/spinwait.rs
@@ -6,14 +6,14 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::thread_parker;
-use std::sync::atomic::spin_loop_hint;
+use core::hint::spin_loop;
 
 // Wastes some CPU time for the given number of iterations,
 // using a hint to indicate to the CPU that we are spinning.
 #[inline]
 fn cpu_relax(iterations: u32) {
     for _ in 0..iterations {
-        spin_loop_hint()
+        spin_loop()
     }
 }
 

--- a/core/src/thread_parker/generic.rs
+++ b/core/src/thread_parker/generic.rs
@@ -8,7 +8,8 @@
 //! A simple spin lock based thread parker. Used on platforms without better
 //! parking facilities available.
 
-use core::sync::atomic::{spin_loop_hint, AtomicBool, Ordering};
+use core::sync::atomic::{AtomicBool, Ordering};
+use core::hint::spin_loop;
 use std::thread;
 use std::time::Instant;
 
@@ -42,7 +43,7 @@ impl super::ThreadParkerT for ThreadParker {
     #[inline]
     unsafe fn park(&self) {
         while self.parked.load(Ordering::Acquire) != false {
-            spin_loop_hint();
+            spin_loop();
         }
     }
 
@@ -52,7 +53,7 @@ impl super::ThreadParkerT for ThreadParker {
             if Instant::now() >= timeout {
                 return false;
             }
-            spin_loop_hint();
+            spin_loop();
         }
         true
     }


### PR DESCRIPTION
Bumps MSRV to 1.49.0

Fixes #295