### PR TITLE
Improve readme wasm32-unknown-unknown nightly section

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,12 @@ There are a few restrictions when using this library on stable Rust:
   statically initialize the locking primitives. Using e.g. `Mutex::new(val)`
   does not work on stable Rust yet.
 - The `wasm32-unknown-unknown` target is only fully supported on nightly with
-  `-C target-feature=+atomics` in `RUSTFLAGS`.
-  parking_lot will work mostly fine on stable, the only problem is it will
+  `-C target-feature=+atomics` in `RUSTFLAGS` and `-Z build-std` passed to cargo.
+  parking_lot will work mostly fine on stable, the only difference is it will
   panic instead of block forever if you hit a deadlock.
+  Just make sure not to enable `-C target-feature=+atomics` on stable as that
+  will allow wasm to run with multiple threads which will completely break
+  parking_lot's concurrency guarantees.
 
 To enable nightly-only functionality, you need to enable the `nightly` feature
 in Cargo (see below).

--- a/README.md
+++ b/README.md
@@ -94,8 +94,10 @@ There are a few restrictions when using this library on stable Rust:
 - You will have to use the `const_*` functions (e.g. `const_mutex(val)`) to
   statically initialize the locking primitives. Using e.g. `Mutex::new(val)`
   does not work on stable Rust yet.
-- The `wasm32-unknown-unknown` target is only supported on nightly and requires
+- The `wasm32-unknown-unknown` target is only fully supported on nightly with
   `-C target-feature=+atomics` in `RUSTFLAGS`.
+  parking_lot will work mostly fine on stable, the only problem is it will
+  panic instead of block forever if you hit a deadlock.
 
 To enable nightly-only functionality, you need to enable the `nightly` feature
 in Cargo (see below).


### PR DESCRIPTION
I made this section of the readme clearer based on your comment here https://github.com/Amanieu/parking_lot/issues/310#issuecomment-1004309603

I figured the primitives having no effect wasnt worth mentioning because wasm32-unknown-unknown is single threaded anyway.

Happy to reword or change anything I wrote.