### PR TITLE
Update windows-sys to 0.33, petgraph to 0.6

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
 
 env:
+  CARGO_INCREMENTAL: 0
   RUST_TEST_THREADS: 1
 
 jobs:
@@ -18,7 +19,7 @@ jobs:
         os: [ubuntu, macos, windows]
         channel: [1.49.0, stable, beta, nightly]
         feature: [arc_lock, serde, deadlock_detection]
-        exclude: 
+        exclude:
           - feature: deadlock_detection
             channel: '1.49.0'
         include:
@@ -41,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: 
+        target:
           - wasm32-unknown-unknown
           - x86_64-fortanix-unknown-sgx
           #- x86_64-unknown-redox

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 cfg-if = "1.0.0"
 smallvec = "1.6.1"
-petgraph = { version = "0.5.1", optional = true }
+petgraph = { version = "0.6.0", optional = true }
 thread-id = { version = "4.0.0", optional = true }
 backtrace = { version = "0.3.60", optional = true }
 
@@ -23,7 +23,7 @@ libc = "0.2.95"
 redox_syscall = "0.2.8"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.32", features = [
+windows-sys = { version = "0.33.0", features = [
     "Win32_Foundation",
     "Win32_System_LibraryLoader",
     "Win32_System_SystemServices",


### PR DESCRIPTION
This updates two outdated dependencies:

- windows-sys 0.32.0 -> 0.33.0
- petgraph 0.5.1 -> 0.6.0

(The first commit is from #327, and needed to fix CI failure)