### PR TITLE
Disable incremental compilation to fix CI failure

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
 
 env:
+  CARGO_INCREMENTAL: 0
   RUST_TEST_THREADS: 1
 
 jobs:
@@ -18,7 +19,7 @@ jobs:
         os: [ubuntu, macos, windows]
         channel: [1.49.0, stable, beta, nightly]
         feature: [arc_lock, serde, deadlock_detection]
-        exclude: 
+        exclude:
           - feature: deadlock_detection
             channel: '1.49.0'
         include:
@@ -41,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: 
+        target:
           - wasm32-unknown-unknown
           - x86_64-fortanix-unknown-sgx
           #- x86_64-unknown-redox


### PR DESCRIPTION
Both #325 and #326's CI failed with a linker error.
This seems to be a bug of incremental compilation and is fixed by disabling incremental compilation.

- https://github.com/Amanieu/parking_lot/runs/5495996459?check_suite_focus=true
- https://github.com/Amanieu/parking_lot/runs/5496070565?check_suite_focus=true