### PR TITLE
Use Ordering::Acquire for is_locked predicates

### DIFF
--- a/src/raw_rwlock.rs
+++ b/src/raw_rwlock.rs
@@ -140,13 +140,13 @@ unsafe impl lock_api::RawRwLock for RawRwLock {
 
     #[inline]
     fn is_locked(&self) -> bool {
-        let state = self.state.load(Ordering::Relaxed);
+        let state = self.state.load(Ordering::Acquire);
         state & (WRITER_BIT | READERS_MASK) != 0
     }
 
     #[inline]
     fn is_locked_exclusive(&self) -> bool {
-        let state = self.state.load(Ordering::Relaxed);
+        let state = self.state.load(Ordering::Acquire);
         state & (WRITER_BIT) != 0
     }
 }


### PR DESCRIPTION
In algorithms such as optimistic latch coupling, reordering instructions before and after is_locked() or is_locked_exclusive() could cause a problem.

In the current implementation, we use the relaxed memory ordering for reading the state value. This allows instructions after is_locked()/is_locked_exclusive() to be reordered before them. This will break the aforementioned optimistic latch coupling.