### PR TITLE
add `MutexGuard::leak`

### DIFF
--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -565,6 +565,17 @@ impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> MutexGuard<'a, R, T> {
         defer!(s.mutex.raw.lock());
         f()
     }
+
+    /// Leaks the mutex guard and returns a mutable reference to the data
+    /// protected by the mutex.
+    ///
+    /// This will leave the `Mutex` in a locked state.
+    #[inline]
+    pub fn leak(s: Self) -> &'a mut T {
+        let r = unsafe { &mut *s.mutex.data.get() };
+        mem::forget(s);
+        r
+    }
 }
 
 impl<'a, R: RawMutexFair + 'a, T: ?Sized + 'a> MutexGuard<'a, R, T> {


### PR DESCRIPTION
This pr adds `MutexGuard::leak`.

This is particularly useful for obtaining a static reference to data protected by a static mutex without having to keep the guard around. 