### PR TITLE
Fix incorrect memory ordering in RwLock

### DIFF
--- a/src/raw_rwlock.rs
+++ b/src/raw_rwlock.rs
@@ -988,8 +988,8 @@ impl RawRwLock {
                 if let Err(x) = self.state.compare_exchange_weak(
                     state,
                     state | WRITER_PARKED_BIT,
-                    Ordering::Relaxed,
-                    Ordering::Relaxed,
+                    Ordering::Acquire,
+                    Ordering::Acquire,
                 ) {
                     state = x;
                     continue;


### PR DESCRIPTION
Fixes #323