### PR TITLE
Bump MSRV to 1.59

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,11 +17,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos, windows]
-        channel: [1.49.0, stable, beta, nightly]
+        channel: [1.59.0, stable, beta, nightly]
         feature: [arc_lock, serde, deadlock_detection]
         exclude:
           - feature: deadlock_detection
-            channel: '1.49.0'
+            channel: '1.59.0'
         include:
           - channel: nightly
             feature: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["mutex", "condvar", "rwlock", "once", "thread"]
 categories = ["concurrency"]
 edition = "2018"
+rust-version = "1.59"
 
 [dependencies]
 parking_lot_core = { path = "core", version = "0.9.0" }

--- a/README.md
+++ b/README.md
@@ -128,8 +128,7 @@ Note that the `deadlock_detection` and `send_guard` features are incompatible
 and cannot be used together.
 
 Hardware lock elision support for x86 can be enabled with the
-`hardware-lock-elision` feature. This requires Rust 1.59 due to the use of
-inline assembly.
+`hardware-lock-elision` feature, which uses inline assembly.
 
 The core parking lot API is provided by the `parking_lot_core` crate. It is
 separate from the synchronization primitives in the `parking_lot` crate so that
@@ -137,7 +136,7 @@ changes to the core API do not cause breaking changes for users of `parking_lot`
 
 ## Minimum Rust version
 
-The current minimum required Rust version is 1.49. Any change to this is
+The current minimum required Rust version is 1.59. Any change to this is
 considered a breaking change and will require a major version bump.
 
 ## License


### PR DESCRIPTION
In #309, usage of the `asm` feature was promoted because it is now part of the stable Rust channel.

This, however, causes build failures when using any Rust version between 1.49 (the documented minimum version) up to 1.58, because the `asm` feature [has only become stable in Rust 1.59](https://github.com/rust-lang/rust/releases/tag/1.59.0).

This PR:

- bumps the documented minimum supported Rust version (MSRV) to 1.59; and

- adds a `rust_version` entry to `Cargo.toml` in order to codify the MSRV for `cargo` to pick it up.  
  This leads to a more helpful and more actionable error message, for example:

  > error: package `parking_lot v0.12.1 ([…])` cannot be built because it requires rustc 1.59 or newer, while the currently active rustc version is 1.58.1
