### PR TITLE
Add MSRV to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["mutex", "condvar", "rwlock", "once", "thread"]
 categories = ["concurrency"]
 edition = "2018"
+rust-version = "1.49"
 
 [dependencies]
 parking_lot_core = { path = "core", version = "0.9.0" }


### PR DESCRIPTION
Add a `rust_version` entry to `Cargo.toml` in order to codify the MSRV for `cargo` to pick it up.  
This leads to a more helpful and more actionable error message, for example:

> error: package `parking_lot v0.12.1 ([…])` cannot be built because
> it requires rustc 1.59 or newer, while the currently active rustc
> version is 1.58.1

Supersedes #347.
