### PR TITLE
Document async signal safety of unpark methods

### DIFF
--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -724,6 +724,10 @@ pub unsafe fn park(
 ///
 /// The `callback` function is called while the queue is locked and must not
 /// panic or call into any function in `parking_lot`.
+///
+/// The `parking_lot` functions are not re-entrant and calling this method
+/// from the context of an asynchronous signal handler may result in undefined
+/// behavior, including corruption of internal state and/or deadlocks.
 #[inline]
 pub unsafe fn unpark_one(
     key: usize,
@@ -801,6 +805,10 @@ pub unsafe fn unpark_one(
 /// You should only call this function with an address that you control, since
 /// you could otherwise interfere with the operation of other synchronization
 /// primitives.
+///
+/// The `parking_lot` functions are not re-entrant and calling this method
+/// from the context of an asynchronous signal handler may result in undefined
+/// behavior, including corruption of internal state and/or deadlocks.
 #[inline]
 pub unsafe fn unpark_all(key: usize, unpark_token: UnparkToken) -> usize {
     // Lock the bucket for the given key


### PR DESCRIPTION
...without mentioning the word "async" since for majority of rust developers, it
has an entirely different meaning (so does "safety" but I think this is good
enough).

Safety disclaimer is only added to the unpark methods, as those are the only
ones that one might sanely wish to call from an async context.

Happy to tweak the wording if someone has a better suggestion.