### PR TITLE
Fix `ReentrantMutexGuard::try_map` signature

### DIFF
--- a/core/src/thread_parker/generic.rs
+++ b/core/src/thread_parker/generic.rs
@@ -8,8 +8,8 @@
 //! A simple spin lock based thread parker. Used on platforms without better
 //! parking facilities available.
 
-use core::sync::atomic::{AtomicBool, Ordering};
 use core::hint::spin_loop;
+use core::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::Instant;
 

--- a/core/src/thread_parker/unix.rs
+++ b/core/src/thread_parker/unix.rs
@@ -127,12 +127,22 @@ impl super::ThreadParkerT for ThreadParker {
 
 impl ThreadParker {
     /// Initializes the condvar to use CLOCK_MONOTONIC instead of CLOCK_REALTIME.
-    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "android", target_os = "espidf"))]
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "android",
+        target_os = "espidf"
+    ))]
     #[inline]
     unsafe fn init(&self) {}
 
     /// Initializes the condvar to use CLOCK_MONOTONIC instead of CLOCK_REALTIME.
-    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "android", target_os = "espidf")))]
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "android",
+        target_os = "espidf"
+    )))]
     #[inline]
     unsafe fn init(&self) {
         let mut attr = MaybeUninit::<libc::pthread_condattr_t>::uninit();

--- a/core/src/thread_parker/windows/keyed_event.rs
+++ b/core/src/thread_parker/windows/keyed_event.rs
@@ -55,40 +55,40 @@ impl KeyedEvent {
 
     #[allow(non_snake_case)]
     pub fn create() -> Option<KeyedEvent> {
-            let ntdll = unsafe { GetModuleHandleA(b"ntdll.dll\0".as_ptr()) };
-            if ntdll == 0 {
-                return None;
-            }
+        let ntdll = unsafe { GetModuleHandleA(b"ntdll.dll\0".as_ptr()) };
+        if ntdll == 0 {
+            return None;
+        }
 
-            let NtCreateKeyedEvent =
-                unsafe { GetProcAddress(ntdll, b"NtCreateKeyedEvent\0".as_ptr())? };
-            let NtReleaseKeyedEvent =
-                unsafe { GetProcAddress(ntdll, b"NtReleaseKeyedEvent\0".as_ptr())? };
-            let NtWaitForKeyedEvent =
-                unsafe { GetProcAddress(ntdll, b"NtWaitForKeyedEvent\0".as_ptr())?};
+        let NtCreateKeyedEvent =
+            unsafe { GetProcAddress(ntdll, b"NtCreateKeyedEvent\0".as_ptr())? };
+        let NtReleaseKeyedEvent =
+            unsafe { GetProcAddress(ntdll, b"NtReleaseKeyedEvent\0".as_ptr())? };
+        let NtWaitForKeyedEvent =
+            unsafe { GetProcAddress(ntdll, b"NtWaitForKeyedEvent\0".as_ptr())? };
 
-            let NtCreateKeyedEvent: extern "system" fn(
-                KeyedEventHandle: *mut HANDLE,
-                DesiredAccess: u32,
-                ObjectAttributes: *mut ffi::c_void,
-                Flags: u32,
-            ) -> NTSTATUS = unsafe { mem::transmute(NtCreateKeyedEvent) };
-            let mut handle = MaybeUninit::uninit();
-            let status = NtCreateKeyedEvent(
-                handle.as_mut_ptr(),
-                GENERIC_READ | GENERIC_WRITE,
-                ptr::null_mut(),
-                0,
-            );
-            if status != STATUS_SUCCESS {
-                return None;
-            }
+        let NtCreateKeyedEvent: extern "system" fn(
+            KeyedEventHandle: *mut HANDLE,
+            DesiredAccess: u32,
+            ObjectAttributes: *mut ffi::c_void,
+            Flags: u32,
+        ) -> NTSTATUS = unsafe { mem::transmute(NtCreateKeyedEvent) };
+        let mut handle = MaybeUninit::uninit();
+        let status = NtCreateKeyedEvent(
+            handle.as_mut_ptr(),
+            GENERIC_READ | GENERIC_WRITE,
+            ptr::null_mut(),
+            0,
+        );
+        if status != STATUS_SUCCESS {
+            return None;
+        }
 
-            Some(KeyedEvent {
-                handle: unsafe { handle.assume_init() },
-                NtReleaseKeyedEvent: unsafe { mem::transmute(NtReleaseKeyedEvent) },
-                NtWaitForKeyedEvent: unsafe { mem::transmute(NtWaitForKeyedEvent) },
-            })
+        Some(KeyedEvent {
+            handle: unsafe { handle.assume_init() },
+            NtReleaseKeyedEvent: unsafe { mem::transmute(NtReleaseKeyedEvent) },
+            NtWaitForKeyedEvent: unsafe { mem::transmute(NtWaitForKeyedEvent) },
+        })
     }
 
     #[inline]

--- a/core/src/thread_parker/windows/waitaddress.rs
+++ b/core/src/thread_parker/windows/waitaddress.rs
@@ -32,22 +32,21 @@ pub struct WaitAddress {
 impl WaitAddress {
     #[allow(non_snake_case)]
     pub fn create() -> Option<WaitAddress> {
-            // MSDN claims that that WaitOnAddress and WakeByAddressSingle are
-            // located in kernel32.dll, but they are lying...
-            let synch_dll =
-                unsafe { GetModuleHandleA(b"api-ms-win-core-synch-l1-2-0.dll\0".as_ptr()) };
-            if synch_dll == 0 {
-                return None;
-            }
+        // MSDN claims that that WaitOnAddress and WakeByAddressSingle are
+        // located in kernel32.dll, but they are lying...
+        let synch_dll = unsafe { GetModuleHandleA(b"api-ms-win-core-synch-l1-2-0.dll\0".as_ptr()) };
+        if synch_dll == 0 {
+            return None;
+        }
 
-            let WaitOnAddress = unsafe { GetProcAddress(synch_dll, b"WaitOnAddress\0".as_ptr())? };
-            let WakeByAddressSingle =
-                unsafe { GetProcAddress(synch_dll, b"WakeByAddressSingle\0".as_ptr())? };
+        let WaitOnAddress = unsafe { GetProcAddress(synch_dll, b"WaitOnAddress\0".as_ptr())? };
+        let WakeByAddressSingle =
+            unsafe { GetProcAddress(synch_dll, b"WakeByAddressSingle\0".as_ptr())? };
 
-            Some(WaitAddress {
-                WaitOnAddress: unsafe { mem::transmute(WaitOnAddress) },
-                WakeByAddressSingle: unsafe { mem::transmute(WakeByAddressSingle) },
-            })
+        Some(WaitAddress {
+            WaitOnAddress: unsafe { mem::transmute(WaitOnAddress) },
+            WakeByAddressSingle: unsafe { mem::transmute(WakeByAddressSingle) },
+        })
     }
 
     #[inline]

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -646,7 +646,7 @@ impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> ReentrantMutexGu
     /// in already locked the mutex.
     ///
     /// This is an associated function that needs to be
-    /// used as `ReentrantMutexGuard::map(...)`. A method would interfere with methods of
+    /// used as `ReentrantMutexGuard::try_map(...)`. A method would interfere with methods of
     /// the same name on the contents of the locked data.
     #[inline]
     pub fn try_map<U: ?Sized, F>(
@@ -942,7 +942,7 @@ impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a>
     /// in already locked the mutex.
     ///
     /// This is an associated function that needs to be
-    /// used as `MappedReentrantMutexGuard::map(...)`. A method would interfere with methods of
+    /// used as `MappedReentrantMutexGuard::try_map(...)`. A method would interfere with methods of
     /// the same name on the contents of the locked data.
     #[inline]
     pub fn try_map<U: ?Sized, F>(

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -654,10 +654,10 @@ impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> ReentrantMutexGu
         f: F,
     ) -> Result<MappedReentrantMutexGuard<'a, R, G, U>, Self>
     where
-        F: FnOnce(&mut T) -> Option<&mut U>,
+        F: FnOnce(&T) -> Option<&U>,
     {
         let raw = &s.remutex.raw;
-        let data = match f(unsafe { &mut *s.remutex.data.get() }) {
+        let data = match f(unsafe { &*s.remutex.data.get() }) {
             Some(data) => data,
             None => return Err(s),
         };

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -1512,7 +1512,7 @@ impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> RwLockWriteGuard<'a, R, T> {
     /// in already locked the data.
     ///
     /// This is an associated function that needs to be
-    /// used as `RwLockWriteGuard::map(...)`. A method would interfere with methods of
+    /// used as `RwLockWriteGuard::try_map(...)`. A method would interfere with methods of
     /// the same name on the contents of the locked data.
     #[inline]
     pub fn try_map<U: ?Sized, F>(s: Self, f: F) -> Result<MappedRwLockWriteGuard<'a, R, U>, Self>
@@ -2374,7 +2374,7 @@ impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> MappedRwLockReadGuard<'a, R, T> {
     /// in already locked the data.
     ///
     /// This is an associated function that needs to be
-    /// used as `MappedRwLockReadGuard::map(...)`. A method would interfere with methods of
+    /// used as `MappedRwLockReadGuard::try_map(...)`. A method would interfere with methods of
     /// the same name on the contents of the locked data.
     #[inline]
     pub fn try_map<U: ?Sized, F>(s: Self, f: F) -> Result<MappedRwLockReadGuard<'a, R, U>, Self>
@@ -2512,7 +2512,7 @@ impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> MappedRwLockWriteGuard<'a, R, T> {
     /// in already locked the data.
     ///
     /// This is an associated function that needs to be
-    /// used as `MappedRwLockWriteGuard::map(...)`. A method would interfere with methods of
+    /// used as `MappedRwLockWriteGuard::try_map(...)`. A method would interfere with methods of
     /// the same name on the contents of the locked data.
     #[inline]
     pub fn try_map<U: ?Sized, F>(s: Self, f: F) -> Result<MappedRwLockWriteGuard<'a, R, U>, Self>

--- a/src/condvar.rs
+++ b/src/condvar.rs
@@ -140,38 +140,38 @@ impl Condvar {
         // Unpark one thread and requeue the rest onto the mutex
         let from = self as *const _ as usize;
         let to = mutex as usize;
-            let validate = || {
-                // Make sure that our atomic state still points to the same
-                // mutex. If not then it means that all threads on the current
-                // mutex were woken up and a new waiting thread switched to a
-                // different mutex. In that case we can get away with doing
-                // nothing.
-                if self.state.load(Ordering::Relaxed) != mutex {
-                    return RequeueOp::Abort;
-                }
+        let validate = || {
+            // Make sure that our atomic state still points to the same
+            // mutex. If not then it means that all threads on the current
+            // mutex were woken up and a new waiting thread switched to a
+            // different mutex. In that case we can get away with doing
+            // nothing.
+            if self.state.load(Ordering::Relaxed) != mutex {
+                return RequeueOp::Abort;
+            }
 
-                // Unpark one thread if the mutex is unlocked, otherwise just
-                // requeue everything to the mutex. This is safe to do here
-                // since unlocking the mutex when the parked bit is set requires
-                // locking the queue. There is the possibility of a race if the
-                // mutex gets locked after we check, but that doesn't matter in
-                // this case.
-                if unsafe { (*mutex).mark_parked_if_locked() } {
-                    RequeueOp::RequeueOne
-                } else {
-                    RequeueOp::UnparkOne
-                }
-            };
-            let callback = |_op, result: UnparkResult| {
-                // Clear our state if there are no more waiting threads
-                if !result.have_more_threads {
-                    self.state.store(ptr::null_mut(), Ordering::Relaxed);
-                }
-                TOKEN_NORMAL
-            };
-            let res = unsafe { parking_lot_core::unpark_requeue(from, to, validate, callback) };
+            // Unpark one thread if the mutex is unlocked, otherwise just
+            // requeue everything to the mutex. This is safe to do here
+            // since unlocking the mutex when the parked bit is set requires
+            // locking the queue. There is the possibility of a race if the
+            // mutex gets locked after we check, but that doesn't matter in
+            // this case.
+            if unsafe { (*mutex).mark_parked_if_locked() } {
+                RequeueOp::RequeueOne
+            } else {
+                RequeueOp::UnparkOne
+            }
+        };
+        let callback = |_op, result: UnparkResult| {
+            // Clear our state if there are no more waiting threads
+            if !result.have_more_threads {
+                self.state.store(ptr::null_mut(), Ordering::Relaxed);
+            }
+            TOKEN_NORMAL
+        };
+        let res = unsafe { parking_lot_core::unpark_requeue(from, to, validate, callback) };
 
-            res.unparked_threads + res.requeued_threads != 0
+        res.unparked_threads + res.requeued_threads != 0
     }
 
     /// Wakes up all blocked threads on this condvar.
@@ -196,46 +196,46 @@ impl Condvar {
 
     #[cold]
     fn notify_all_slow(&self, mutex: *mut RawMutex) -> usize {
-            // Unpark one thread and requeue the rest onto the mutex
-            let from = self as *const _ as usize;
-            let to = mutex as usize;
-            let validate = || {
-                // Make sure that our atomic state still points to the same
-                // mutex. If not then it means that all threads on the current
-                // mutex were woken up and a new waiting thread switched to a
-                // different mutex. In that case we can get away with doing
-                // nothing.
-                if self.state.load(Ordering::Relaxed) != mutex {
-                    return RequeueOp::Abort;
-                }
+        // Unpark one thread and requeue the rest onto the mutex
+        let from = self as *const _ as usize;
+        let to = mutex as usize;
+        let validate = || {
+            // Make sure that our atomic state still points to the same
+            // mutex. If not then it means that all threads on the current
+            // mutex were woken up and a new waiting thread switched to a
+            // different mutex. In that case we can get away with doing
+            // nothing.
+            if self.state.load(Ordering::Relaxed) != mutex {
+                return RequeueOp::Abort;
+            }
 
-                // Clear our state since we are going to unpark or requeue all
-                // threads.
-                self.state.store(ptr::null_mut(), Ordering::Relaxed);
+            // Clear our state since we are going to unpark or requeue all
+            // threads.
+            self.state.store(ptr::null_mut(), Ordering::Relaxed);
 
-                // Unpark one thread if the mutex is unlocked, otherwise just
-                // requeue everything to the mutex. This is safe to do here
-                // since unlocking the mutex when the parked bit is set requires
-                // locking the queue. There is the possibility of a race if the
-                // mutex gets locked after we check, but that doesn't matter in
-                // this case.
-                if unsafe { (*mutex).mark_parked_if_locked() } {
-                    RequeueOp::RequeueAll
-                } else {
-                    RequeueOp::UnparkOneRequeueRest
-                }
-            };
-            let callback = |op, result: UnparkResult| {
-                // If we requeued threads to the mutex, mark it as having
-                // parked threads. The RequeueAll case is already handled above.
-                if op == RequeueOp::UnparkOneRequeueRest && result.requeued_threads != 0 {
-                    unsafe { (*mutex).mark_parked() };
-                }
-                TOKEN_NORMAL
-            };
-            let res = unsafe { parking_lot_core::unpark_requeue(from, to, validate, callback) };
+            // Unpark one thread if the mutex is unlocked, otherwise just
+            // requeue everything to the mutex. This is safe to do here
+            // since unlocking the mutex when the parked bit is set requires
+            // locking the queue. There is the possibility of a race if the
+            // mutex gets locked after we check, but that doesn't matter in
+            // this case.
+            if unsafe { (*mutex).mark_parked_if_locked() } {
+                RequeueOp::RequeueAll
+            } else {
+                RequeueOp::UnparkOneRequeueRest
+            }
+        };
+        let callback = |op, result: UnparkResult| {
+            // If we requeued threads to the mutex, mark it as having
+            // parked threads. The RequeueAll case is already handled above.
+            if op == RequeueOp::UnparkOneRequeueRest && result.requeued_threads != 0 {
+                unsafe { (*mutex).mark_parked() };
+            }
+            TOKEN_NORMAL
+        };
+        let res = unsafe { parking_lot_core::unpark_requeue(from, to, validate, callback) };
 
-            res.unparked_threads + res.requeued_threads
+        res.unparked_threads + res.requeued_threads
     }
 
     /// Blocks the current thread until this condition variable receives a
@@ -294,67 +294,69 @@ impl Condvar {
     // This is a non-generic function to reduce the monomorphization cost of
     // using `wait_until`.
     fn wait_until_internal(&self, mutex: &RawMutex, timeout: Option<Instant>) -> WaitTimeoutResult {
-            let result;
-            let mut bad_mutex = false;
-            let mut requeued = false;
-            {
-                let addr = self as *const _ as usize;
-                let lock_addr = mutex as *const _ as *mut _;
-                let validate = || {
-                    // Ensure we don't use two different mutexes with the same
-                    // Condvar at the same time. This is done while locked to
-                    // avoid races with notify_one
-                    let state = self.state.load(Ordering::Relaxed);
-                    if state.is_null() {
-                        self.state.store(lock_addr, Ordering::Relaxed);
-                    } else if state != lock_addr {
-                        bad_mutex = true;
-                        return false;
-                    }
-                    true
-                };
-                let before_sleep = || {
-                    // Unlock the mutex before sleeping...
-                    unsafe { mutex.unlock() };
-                };
-                let timed_out = |k, was_last_thread| {
-                    // If we were requeued to a mutex, then we did not time out.
-                    // We'll just park ourselves on the mutex again when we try
-                    // to lock it later.
-                    requeued = k != addr;
+        let result;
+        let mut bad_mutex = false;
+        let mut requeued = false;
+        {
+            let addr = self as *const _ as usize;
+            let lock_addr = mutex as *const _ as *mut _;
+            let validate = || {
+                // Ensure we don't use two different mutexes with the same
+                // Condvar at the same time. This is done while locked to
+                // avoid races with notify_one
+                let state = self.state.load(Ordering::Relaxed);
+                if state.is_null() {
+                    self.state.store(lock_addr, Ordering::Relaxed);
+                } else if state != lock_addr {
+                    bad_mutex = true;
+                    return false;
+                }
+                true
+            };
+            let before_sleep = || {
+                // Unlock the mutex before sleeping...
+                unsafe { mutex.unlock() };
+            };
+            let timed_out = |k, was_last_thread| {
+                // If we were requeued to a mutex, then we did not time out.
+                // We'll just park ourselves on the mutex again when we try
+                // to lock it later.
+                requeued = k != addr;
 
-                    // If we were the last thread on the queue then we need to
-                    // clear our state. This is normally done by the
-                    // notify_{one,all} functions when not timing out.
-                    if !requeued && was_last_thread {
-                        self.state.store(ptr::null_mut(), Ordering::Relaxed);
-                    }
-                };
-                result = unsafe { parking_lot_core::park(
+                // If we were the last thread on the queue then we need to
+                // clear our state. This is normally done by the
+                // notify_{one,all} functions when not timing out.
+                if !requeued && was_last_thread {
+                    self.state.store(ptr::null_mut(), Ordering::Relaxed);
+                }
+            };
+            result = unsafe {
+                parking_lot_core::park(
                     addr,
                     validate,
                     before_sleep,
                     timed_out,
                     DEFAULT_PARK_TOKEN,
                     timeout,
-                ) };
-            }
+                )
+            };
+        }
 
-            // Panic if we tried to use multiple mutexes with a Condvar. Note
-            // that at this point the MutexGuard is still locked. It will be
-            // unlocked by the unwinding logic.
-            if bad_mutex {
-                panic!("attempted to use a condition variable with more than one mutex");
-            }
+        // Panic if we tried to use multiple mutexes with a Condvar. Note
+        // that at this point the MutexGuard is still locked. It will be
+        // unlocked by the unwinding logic.
+        if bad_mutex {
+            panic!("attempted to use a condition variable with more than one mutex");
+        }
 
-            // ... and re-lock it once we are done sleeping
-            if result == ParkResult::Unparked(TOKEN_HANDOFF) {
-                unsafe { deadlock::acquire_resource(mutex as *const _ as usize) };
-            } else {
-                mutex.lock();
-            }
+        // ... and re-lock it once we are done sleeping
+        if result == ParkResult::Unparked(TOKEN_HANDOFF) {
+            unsafe { deadlock::acquire_resource(mutex as *const _ as usize) };
+        } else {
+            mutex.lock();
+        }
 
-            WaitTimeoutResult(!(result.is_unparked() || requeued))
+        WaitTimeoutResult(!(result.is_unparked() || requeued))
     }
 
     /// Waits on this condition variable for a notification, timing out after a
@@ -745,8 +747,7 @@ mod tests {
         };
 
         let mut mutex_guard = mutex.lock();
-        let timeout_result = cv
-            .wait_while_until_internal(&mut mutex_guard, condition, None);
+        let timeout_result = cv.wait_while_until_internal(&mut mutex_guard, condition, None);
 
         assert!(!timeout_result.timed_out());
         assert!(*mutex_guard == 1);
@@ -767,8 +768,7 @@ mod tests {
         let timeout = Some(Instant::now() + Duration::from_millis(500));
         let handle = spawn_wait_while_notifier(mutex.clone(), cv.clone(), num_iters, timeout);
 
-        let timeout_result =
-            cv.wait_while_until_internal(&mut mutex_guard, condition, timeout);
+        let timeout_result = cv.wait_while_until_internal(&mut mutex_guard, condition, timeout);
 
         assert!(timeout_result.timed_out());
         assert!(*mutex_guard == num_iters + 1);
@@ -793,8 +793,7 @@ mod tests {
         let mut mutex_guard = mutex.lock();
         let handle = spawn_wait_while_notifier(mutex.clone(), cv.clone(), num_iters, None);
 
-        let timeout_result =
-            cv.wait_while_until_internal(&mut mutex_guard, condition, None);
+        let timeout_result = cv.wait_while_until_internal(&mut mutex_guard, condition, None);
 
         assert!(!timeout_result.timed_out());
         assert!(*mutex_guard == num_iters + 1);

--- a/src/elision.rs
+++ b/src/elision.rs
@@ -5,7 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-#[cfg(all(feature = "hardware-lock-elision", any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(all(
+    feature = "hardware-lock-elision",
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 use std::arch::asm;
 use std::sync::atomic::AtomicUsize;
 
@@ -35,7 +38,10 @@ pub fn have_elision() -> bool {
 
 // This implementation is never actually called because it is guarded by
 // have_elision().
-#[cfg(not(all(feature = "hardware-lock-elision", any(target_arch = "x86", target_arch = "x86_64"))))]
+#[cfg(not(all(
+    feature = "hardware-lock-elision",
+    any(target_arch = "x86", target_arch = "x86_64")
+)))]
 impl AtomicElisionExt for AtomicUsize {
     type IntType = usize;
 
@@ -50,7 +56,10 @@ impl AtomicElisionExt for AtomicUsize {
     }
 }
 
-#[cfg(all(feature = "hardware-lock-elision", any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(all(
+    feature = "hardware-lock-elision",
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 impl AtomicElisionExt for AtomicUsize {
     type IntType = usize;
 


### PR DESCRIPTION
This previously incorrectly used `&mut T` instead of `&T`.

Fixes #354

This is a breaking change but will be released in a minor version since it fixes a soundness issue.