### PR TITLE
Update use of `libc::timespec` to prepare for future libc version

### DIFF
--- a/core/src/thread_parker/linux.rs
+++ b/core/src/thread_parker/linux.rs
@@ -80,10 +80,10 @@ impl super::ThreadParkerT for ThreadParker {
                 self.park();
                 return true;
             }
-            let ts = libc::timespec {
-                tv_sec: diff.as_secs() as libc::time_t,
-                tv_nsec: diff.subsec_nanos() as tv_nsec_t,
-            };
+            // SAFETY: libc::timespec is zero initializable.
+            let mut ts: libc::timespec = std::mem::zeroed();
+            ts.tv_sec = diff.as_secs() as libc::time_t;
+            ts.tv_nsec = diff.subsec_nanos() as tv_nsec_t;
             self.futex_wait(Some(ts));
         }
         true


### PR DESCRIPTION
In a future release of the `libc` crate, `libc::timespec` will contain private padding fields on 32-bit `*-linux-musl` targets and so the struct will no longer be able to be created using the literal initialization syntax.

Update the use of `libc::timespec` to create a value by calling `std::mem::zeroed()` first and then setting the `tv_sec` and `tv_nsec` fields manually which works with both current versions of `libc` as well as the future version which contains that change.

See also https://github.com/rust-lang/libc/pull/2088