### PR TITLE
Fix CI on macos

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,9 @@ jobs:
         exclude:
           - feature: deadlock_detection
             channel: '1.49.0'
+            # Versions before 1.54 fail to build on the latest XCode.
+          - os: macos
+            channel: '1.49.0'
         include:
           - channel: nightly
             feature: nightly


### PR DESCRIPTION
Versions before 1.54 fail to build on the latest XCode.