### PR TITLE
Add support for watchOS.

### DIFF
--- a/core/src/thread_parker/unix.rs
+++ b/core/src/thread_parker/unix.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "watchos"))]
 use core::ptr;
 use core::{
     cell::{Cell, UnsafeCell},
@@ -130,6 +130,7 @@ impl ThreadParker {
     #[cfg(any(
         target_os = "macos",
         target_os = "ios",
+        target_os = "watchos",
         target_os = "android",
         target_os = "espidf"
     ))]
@@ -140,6 +141,7 @@ impl ThreadParker {
     #[cfg(not(any(
         target_os = "macos",
         target_os = "ios",
+        target_os = "watchos",
         target_os = "android",
         target_os = "espidf"
     )))]
@@ -193,7 +195,7 @@ impl super::UnparkHandleT for UnparkHandle {
 }
 
 // Returns the current time on the clock used by pthread_cond_t as a timespec.
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "watchos"))]
 #[inline]
 fn timespec_now() -> libc::timespec {
     let mut now = MaybeUninit::<libc::timeval>::uninit();
@@ -206,7 +208,7 @@ fn timespec_now() -> libc::timespec {
         tv_nsec: now.tv_usec as tv_nsec_t * 1000,
     }
 }
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "watchos")))]
 #[inline]
 fn timespec_now() -> libc::timespec {
     let mut now = MaybeUninit::<libc::timespec>::uninit();


### PR DESCRIPTION
This PR adds support to parking_lot for watchOS. This can be tested by building on a mac with the following command when the watchOS SDK is installed through Xcode:
```
cargo build -Zbuild-std --target=arm64_32-apple-watchos
```
The support simply mirrors macOS and iOS support.

Note: I've also got a `watchos-0.8` branch with the changes cherry picked onto `backport-core-0.8`, I'm not exactly sure how backports are handled.