### PR TITLE
Mark `MutexGuard` with `#[clippy::has_significant_drop]`

### DIFF
--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -485,7 +485,7 @@ where
 ///
 /// The data protected by the mutex can be accessed through this guard via its
 /// `Deref` and `DerefMut` implementations.
-#[clippy::has_significant_drop]`
+#[clippy::has_significant_drop]
 #[must_use = "if unused the Mutex will immediately unlock"]
 pub struct MutexGuard<'a, R: RawMutex, T: ?Sized> {
     mutex: &'a Mutex<R, T>,

--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -485,6 +485,7 @@ where
 ///
 /// The data protected by the mutex can be accessed through this guard via its
 /// `Deref` and `DerefMut` implementations.
+#[clippy::has_significant_drop]`
 #[must_use = "if unused the Mutex will immediately unlock"]
 pub struct MutexGuard<'a, R: RawMutex, T: ?Sized> {
     mutex: &'a Mutex<R, T>,


### PR DESCRIPTION
`#[clippy::has_significant_drop]` tells that a structure should be considered when evaluating some lints. Examples of such behavior are the existent `clippy::significant_drop_in_scrutinee` and the soon-to-be-finished https://github.com/rust-lang/rust-clippy/issues/9399.