### PR TITLE
Make `RwLock` guards `Sync` again

### DIFF
--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -1188,6 +1188,8 @@ pub struct RwLockReadGuard<'a, R: RawRwLock, T: ?Sized> {
     marker: PhantomData<(&'a T, R::GuardMarker)>,
 }
 
+unsafe impl<R: RawRwLock + Sync, T: Sync + ?Sized> Sync for RwLockReadGuard<'_, R, T> {}
+
 impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> RwLockReadGuard<'a, R, T> {
     /// Returns a reference to the original reader-writer lock object.
     pub fn rwlock(s: &Self) -> &'a RwLock<R, T> {
@@ -1475,6 +1477,8 @@ pub struct RwLockWriteGuard<'a, R: RawRwLock, T: ?Sized> {
     rwlock: &'a RwLock<R, T>,
     marker: PhantomData<(&'a mut T, R::GuardMarker)>,
 }
+
+unsafe impl<R: RawRwLock + Sync, T: Sync + ?Sized> Sync for RwLockWriteGuard<'_, R, T> {}
 
 impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> RwLockWriteGuard<'a, R, T> {
     /// Returns a reference to the original reader-writer lock object.


### PR DESCRIPTION
This was removed in #262 because there was a soundness issue when `R: !Sync`, but the fix was a bit too radical.