### PR TITLE
lock_api: Enable doc_auto_cfg on docs.rs

### DIFF
--- a/lock_api/Cargo.toml
+++ b/lock_api/Cargo.toml
@@ -9,6 +9,10 @@ keywords = ["mutex", "rwlock", "lock", "no_std"]
 categories = ["concurrency", "no-std"]
 edition = "2018"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 scopeguard = { version = "1.1.0", default-features = false }
 owning_ref = { version = "0.4.1", optional = true }

--- a/lock_api/src/lib.rs
+++ b/lock_api/src/lib.rs
@@ -86,6 +86,7 @@
 //!   requires the `alloc` crate to be present.
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
 


### PR DESCRIPTION
This enables all features to be activated for docs.rs with automated annotations if types or functions are feature-gated.

You can preview this locally by running
```
RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc --all-features --open
```