### PR TITLE
Remove `windows-sys` dependency

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,14 +22,6 @@ libc = "0.2.95"
 [target.'cfg(target_os = "redox")'.dependencies]
 redox_syscall = "0.2.8"
 
-[target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.45.0", features = [
-    "Win32_Foundation",
-    "Win32_System_LibraryLoader",
-    "Win32_System_SystemServices",
-    "Win32_System_WindowsProgramming",
-] }
-
 [features]
 nightly = []
 deadlock_detection = ["petgraph", "thread-id", "backtrace"]

--- a/core/src/thread_parker/windows/bindings.rs
+++ b/core/src/thread_parker/windows/bindings.rs
@@ -1,0 +1,32 @@
+pub const INFINITE: u32 = 4294967295;
+pub const ERROR_TIMEOUT: u32 = 1460;
+pub const GENERIC_READ: u32 = 2147483648;
+pub const GENERIC_WRITE: u32 = 1073741824;
+pub const STATUS_SUCCESS: i32 = 0 as _;
+pub const STATUS_TIMEOUT: i32 = 258 as _;
+
+pub type HANDLE = isize;
+pub type HINSTANCE = isize;
+pub type BOOL = i32;
+pub type BOOLEAN = u8;
+pub type NTSTATUS = i32;
+pub type FARPROC = Option<unsafe extern "system" fn() -> isize>;
+pub type WaitOnAddress = unsafe extern "system" fn(
+    Address: *const std::ffi::c_void,
+    CompareAddress: *const std::ffi::c_void,
+    AddressSize: usize,
+    dwMilliseconds: u32,
+) -> BOOL;
+pub type WakeByAddressSingle = unsafe extern "system" fn(Address: *const std::ffi::c_void);
+
+#[link(name = "kernel32")]
+extern "system" {
+    pub fn GetLastError() -> u32;
+    pub fn CloseHandle(hObject: HANDLE) -> BOOL;
+
+    pub fn GetModuleHandleA(lpModuleName: *const u8) -> HINSTANCE;
+    pub fn GetProcAddress(hModule: HINSTANCE, lpProcName: *const u8) -> FARPROC;
+
+    pub fn Sleep(dwMilliseconds: u32);
+}
+

--- a/core/src/thread_parker/windows/keyed_event.rs
+++ b/core/src/thread_parker/windows/keyed_event.rs
@@ -13,17 +13,11 @@ use core::{
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
-use windows_sys::Win32::{
-    Foundation::{CloseHandle, BOOLEAN, HANDLE, NTSTATUS, STATUS_SUCCESS, STATUS_TIMEOUT},
-    System::{
-        LibraryLoader::{GetModuleHandleA, GetProcAddress},
-        SystemServices::{GENERIC_READ, GENERIC_WRITE},
-    },
-};
-
 const STATE_UNPARKED: usize = 0;
 const STATE_PARKED: usize = 1;
 const STATE_TIMED_OUT: usize = 2;
+
+use super::bindings::*;
 
 #[allow(non_snake_case)]
 pub struct KeyedEvent {

--- a/core/src/thread_parker/windows/mod.rs
+++ b/core/src/thread_parker/windows/mod.rs
@@ -11,6 +11,7 @@ use core::{
 };
 use std::time::Instant;
 
+mod bindings;
 mod keyed_event;
 mod waitaddress;
 
@@ -60,7 +61,7 @@ impl Backend {
             Err(global_backend_ptr) => {
                 unsafe {
                     // We lost the race, free our object and return the global one
-                    Box::from_raw(backend_ptr);
+                    let _ = Box::from_raw(backend_ptr);
                     &*global_backend_ptr
                 }
             }
@@ -163,26 +164,10 @@ impl UnparkHandle {
 // Yields the rest of the current timeslice to the OS
 #[inline]
 pub fn thread_yield() {
-    // Note that this is manually defined here rather than using the definition
-    // through `winapi`. The `winapi` definition comes from the `synchapi`
-    // header which enables the "synchronization.lib" library. It turns out,
-    // however that `Sleep` comes from `kernel32.dll` so this activation isn't
-    // necessary.
-    //
-    // This was originally identified in rust-lang/rust where on MinGW the
-    // libsynchronization.a library pulls in a dependency on a newer DLL not
-    // present in older versions of Windows. (see rust-lang/rust#49438)
-    //
-    // This is a bit of a hack for now and ideally we'd fix MinGW's own import
-    // libraries, but that'll probably take a lot longer than patching this here
-    // and avoiding the `synchapi` feature entirely.
-    extern "system" {
-        fn Sleep(a: u32);
-    }
     unsafe {
         // We don't use SwitchToThread here because it doesn't consider all
         // threads in the system and the thread we are waiting for may not get
         // selected.
-        Sleep(0);
+        bindings::Sleep(0);
     }
 }


### PR DESCRIPTION
This replaces the `windows-sys` dependency with manual bindings to only the functions, types, and constants needed by `parking_lot`.

## Rationale

`parking_lot` is a foundational dependency, and thus its choice of dependencies has a fairly wide effect on the ecosystem since it's almost inevitable that even a moderately sized dependency graph will pull it in. This is particularly true due the problematic issue I pointed out in https://github.com/microsoft/windows-rs/issues/1720, in which I actually used parking_lot as an example due to its foundational nature. Using bindings in the few places they are needed means we can completely get rid of the `windows-sys` dependency, positively impacting a huge part of the crates ecosystem with no negatives.

1. Win32 functions/types/constants **will never change**, there is no reason to use an external crate of bindings
2. `parking_lot_core` already has manual bindings to `Nt*` functions since they are not officially supported by Microsoft and thus not part of the Win32 metadata used to generate the windows-sys bindings.