### PR TITLE
Fix linker issues and target support

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,6 +22,9 @@ libc = "0.2.95"
 [target.'cfg(target_os = "redox")'.dependencies]
 redox_syscall = "0.3"
 
+[target.'cfg(windows)'.dependencies]
+windows-targets = "0.48.0"
+
 [features]
 nightly = []
 deadlock_detection = ["petgraph", "thread-id", "backtrace"]

--- a/core/src/thread_parker/windows/bindings.rs
+++ b/core/src/thread_parker/windows/bindings.rs
@@ -24,13 +24,8 @@ pub type WaitOnAddress = unsafe extern "system" fn(
 ) -> BOOL;
 pub type WakeByAddressSingle = unsafe extern "system" fn(Address: *const std::ffi::c_void);
 
-#[link(name = "kernel32")]
-extern "system" {
-    pub fn GetLastError() -> u32;
-    pub fn CloseHandle(hObject: HANDLE) -> BOOL;
-
-    pub fn GetModuleHandleA(lpModuleName: *const u8) -> HINSTANCE;
-    pub fn GetProcAddress(hModule: HINSTANCE, lpProcName: *const u8) -> FARPROC;
-
-    pub fn Sleep(dwMilliseconds: u32);
-}
+windows_targets::link!("kernel32.dll" "system" fn GetLastError() -> u32);
+windows_targets::link!("kernel32.dll" "system" fn CloseHandle(hObject: HANDLE) -> BOOL);
+windows_targets::link!("kernel32.dll" "system" fn GetModuleHandleA(lpModuleName: *const u8) -> HINSTANCE);
+windows_targets::link!("kernel32.dll" "system" fn GetProcAddress(hModule: HINSTANCE, lpProcName: *const u8) -> FARPROC);
+windows_targets::link!("kernel32.dll" "system" fn Sleep(dwMilliseconds: u32) -> ());


### PR DESCRIPTION
While I don’t think the [3-6 month](https://crates.io/crates/windows-sys/versions) update cadence of the [windows-sys](https://crates.io/crates/windows-sys) crate was a substantial issue, dropping that dependency (#374) is certainly your choice. However, by doing so you gave up some functionality and target support which will prevent `parking_lot_core` from linking in many cases. 

The [windows](https://crates.io/crates/windows) and [windows-sys](https://crates.io/crates/windows-sys) crates depend on the [windows-targets](https://crates.io/crates/windows-targets) crate for linker support. The `windows-targets` crate includes only import libs, supports semantic versioning of libs, and optional support for [raw-dylib](https://github.com/rust-lang/rust/issues/58713). It provides explicit import libs for the following targets:

* i686_msvc
* x86_64_msvc
* aarch64_msvc
* i686_gnu
* x86_64_gnu
* x86_64_gnullvm
* aarch64_gnullvm

By contrast, the older `winapi` crate only provided import libs for i686_gnu and x86_64_gnu and lacked support for `raw-dylib`, link-level semantic versioning, or ARM64. #374 further yanked all of this and means that dependents must now rely on some other implicit dependency to ensure that this crate’s imports will continue to link. 

I think restoring `windows-sys` would be simpler in the long run, but as an alternative you can accept this PR which simply adds a dependency on the `windows-targets` crate directly to restore the target support described above. 

Hope that helps.