### PR TITLE
feat(wasm-bindgen): deadlock detector support

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,8 +13,14 @@ edition = "2018"
 cfg-if = "1.0.0"
 smallvec = "1.6.1"
 petgraph = { version = "0.6.0", optional = true }
-thread-id = { version = "4.0.0", optional = true }
 backtrace = { version = "0.3.60", optional = true }
+
+[target.'cfg(not(target = "wasm32-unknown-unknown"))'.dependencies]
+thread-id = { version = "4.0.0", optional = true }
+
+[target.'cfg(target = "wasm32-unknown-unknown")'.dependencies]
+js-sys = { version = "0.3.50", optional = true }
+web-sys = { version = "0.3.50", optional = true, features = ["console"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.95"
@@ -24,4 +30,4 @@ redox_syscall = "0.3"
 
 [features]
 nightly = []
-deadlock_detection = ["petgraph", "thread-id", "backtrace"]
+deadlock_detection = ["petgraph", "thread-id", "web-sys", "js-sys", "backtrace"]

--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -1150,30 +1150,54 @@ mod deadlock_impl {
     use super::{get_hashtable, lock_bucket, with_thread_data, ThreadData, NUM_THREADS};
     use crate::thread_parker::{ThreadParkerT, UnparkHandleT};
     use crate::word_lock::WordLock;
+    #[cfg(not(target = "wasm32-unknown-unknown"))]
     use backtrace::Backtrace;
+    #[cfg(target = "wasm32-unknown-unknown")]
+    use js_sys::{global, Error, Reflect};
     use petgraph;
     use petgraph::graphmap::DiGraphMap;
     use std::cell::{Cell, UnsafeCell};
     use std::collections::HashSet;
     use std::sync::atomic::Ordering;
     use std::sync::mpsc;
+    #[cfg(not(target = "wasm32-unknown-unknown"))]
     use thread_id;
 
     /// Representation of a deadlocked thread
     pub struct DeadlockedThread {
+        #[cfg(not(target = "wasm32-unknown-unknown"))]
         thread_id: usize,
+        #[cfg(target = "wasm32-unknown-unknown")]
+        worker_name: String,
+        #[cfg(not(target = "wasm32-unknown-unknown"))]
         backtrace: Backtrace,
+        #[cfg(target = "wasm32-unknown-unknown")]
+        stacktrace: String,
     }
 
     impl DeadlockedThread {
+        #[cfg(not(target = "wasm32-unknown-unknown"))]
         /// The system thread id
         pub fn thread_id(&self) -> usize {
             self.thread_id
         }
 
+        #[cfg(target = "wasm32-unknown-unknown")]
+        /// The system thread id
+        pub fn worker_name(&self) -> &str {
+            &self.worker_name
+        }
+
+        #[cfg(not(target = "wasm32-unknown-unknown"))]
         /// The thread backtrace
         pub fn backtrace(&self) -> &Backtrace {
             &self.backtrace
+        }
+
+        #[cfg(target = "wasm32-unknown-unknown")]
+        /// The thread error stacktrace
+        pub fn stacktrace(&self) -> &str {
+            &self.stacktrace
         }
     }
 
@@ -1187,8 +1211,13 @@ mod deadlock_impl {
         // Sender used to report the backtrace
         backtrace_sender: UnsafeCell<Option<mpsc::Sender<DeadlockedThread>>>,
 
+        #[cfg(not(target = "wasm32-unknown-unknown"))]
         // System thread id
         thread_id: usize,
+
+        #[cfg(target = "wasm32-unknown-unknown")]
+        /// The web worker's name
+        worker_name: String,
     }
 
     impl DeadlockData {
@@ -1197,7 +1226,13 @@ mod deadlock_impl {
                 resources: UnsafeCell::new(Vec::new()),
                 deadlocked: Cell::new(false),
                 backtrace_sender: UnsafeCell::new(None),
+                #[cfg(not(target = "wasm32-unknown-unknown"))]
                 thread_id: thread_id::get(),
+                #[cfg(target = "wasm32-unknown-unknown")]
+                worker_name: Reflect::get(&global().into(), &"name".into())
+                    .unwrap()
+                    .as_string()
+                    .unwrap(),
             }
         }
     }
@@ -1207,8 +1242,17 @@ mod deadlock_impl {
             let sender = (*td.deadlock_data.backtrace_sender.get()).take().unwrap();
             sender
                 .send(DeadlockedThread {
+                    #[cfg(not(target = "wasm32-unknown-unknown"))]
                     thread_id: td.deadlock_data.thread_id,
+                    #[cfg(target = "wasm32-unknown-unknown")]
+                    worker_name: td.deadlock_data.worker_name.clone(),
+                    #[cfg(not(target = "wasm32-unknown-unknown"))]
                     backtrace: Backtrace::new(),
+                    #[cfg(target = "wasm32-unknown-unknown")]
+                    stacktrace: Reflect::get(&Error::new("deadlock").into(), &"stack".into())
+                        .unwrap()
+                        .as_string()
+                        .unwrap(),
                 })
                 .unwrap();
             // make sure to close this sender


### PR DESCRIPTION
This adds deadlock_detector support for the WASM target.

Instead of `thread_id` I added a conditional `worker_name` field