### PR TITLE
lock_api: Add default "atomic_usize" feature

### DIFF
--- a/lock_api/Cargo.toml
+++ b/lock_api/Cargo.toml
@@ -26,5 +26,7 @@ serde = { version = "1.0.126", default-features = false, optional = true }
 autocfg = "1.1.0"
 
 [features]
+default = ["atomic_usize"]
 nightly = []
 arc_lock = []
+atomic_usize = []

--- a/lock_api/src/lib.rs
+++ b/lock_api/src/lib.rs
@@ -107,7 +107,9 @@ unsafe impl Sync for GuardNoSend {}
 mod mutex;
 pub use crate::mutex::*;
 
+#[cfg(feature = "atomic_usize")]
 mod remutex;
+#[cfg(feature = "atomic_usize")]
 pub use crate::remutex::*;
 
 mod rwlock;


### PR DESCRIPTION
Adds a default "atomic_usize" feature as a feature gate for library components that rely on `AtomicUsize`. Some platforms, such as AVR, do not support atomics with large widths.

Current library users will experience no changes, but users on constrained platforms can opt-out by using `default_features = false`.