### PR TITLE
Adjust the `wasm32-unknown-unknown` atomic docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ lock.
 There are a few restrictions when using this library on stable Rust:
 
 - The `wasm32-unknown-unknown` target is only fully supported on nightly with
-  `-C target-feature=+atomics` in `RUSTFLAGS` and `-Z build-std` passed to cargo.
-  parking_lot will work mostly fine on stable, the only difference is it will
-  panic instead of block forever if you hit a deadlock.
+  `-C target-feature=+atomics` in `RUSTFLAGS` and `-Zbuild-std=panic_abort,std`
+  passed to cargo. parking_lot will work mostly fine on stable, the only
+  difference is it will panic instead of block forever if you hit a deadlock.
   Just make sure not to enable `-C target-feature=+atomics` on stable as that
   will allow wasm to run with multiple threads which will completely break
   parking_lot's concurrency guarantees.


### PR DESCRIPTION
Currently the documentation on how to target `wasm32-unknown-unknown` with `-C target-feature=+atomics` is incorrect and will yield compile errors.

This is because `wasm32-unknown-unknown` doesn't support unwinding, but `-Zbuild-std` doesn't support automatic selection of the correct panic strategy, so this has to be set manually with `-Zbuild-std=panic_abort,std`.

This PR corrects the documentation to reflect this.

See https://github.com/rust-lang/wg-cargo-std-aware/issues/29.

Fixes #267.