### PR TITLE
Revert #379

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,14 +13,8 @@ edition = "2018"
 cfg-if = "1.0.0"
 smallvec = "1.6.1"
 petgraph = { version = "0.6.0", optional = true }
-backtrace = { version = "0.3.60", optional = true }
-
-[target.'cfg(not(target = "wasm32-unknown-unknown"))'.dependencies]
 thread-id = { version = "4.0.0", optional = true }
-
-[target.'cfg(target = "wasm32-unknown-unknown")'.dependencies]
-js-sys = { version = "0.3.50", optional = true }
-web-sys = { version = "0.3.50", optional = true, features = ["console"] }
+backtrace = { version = "0.3.60", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.95"
@@ -33,4 +27,4 @@ windows-targets = "0.48.0"
 
 [features]
 nightly = []
-deadlock_detection = ["petgraph", "thread-id", "web-sys", "js-sys", "backtrace"]
+deadlock_detection = ["petgraph", "thread-id", "backtrace"]


### PR DESCRIPTION
This reverts https://github.com/Amanieu/parking_lot/pull/379 for two reasons:
- This doesn't actually work, because `cfg(target = "...")` is an unstable feature ([RFC](https://rust-lang.github.io/rfcs/3239-cfg-target.html)) and was not enabled.
- Using the worker name as a thread ID is quite unreliable, as they are simply an empty string if not set during their creation, which is commonly not done. Certainly there is nothing in place to make them unique.

In the meantime, `thread-id` now supports `wasm32-unknown-unknown` (https://github.com/ruuda/thread-id/pull/12) in v4.1, so `parking_lot_core` now inherited that support without any changes required.