### PR TITLE
Fix `ReentrantMutex::bump()` lock count

### DIFF
--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -183,8 +183,10 @@ impl<R: RawMutexFair, G: GetThreadId> RawReentrantMutex<R, G> {
         if self.lock_count.get() == 1 {
             let id = self.owner.load(Ordering::Relaxed);
             self.owner.store(0, Ordering::Relaxed);
+            self.lock_count.set(0);
             self.mutex.bump();
             self.owner.store(id, Ordering::Relaxed);
+            self.lock_count.set(1);
         }
     }
 }

--- a/src/remutex.rs
+++ b/src/remutex.rs
@@ -71,9 +71,11 @@ pub type MappedReentrantMutexGuard<'a, T> =
 #[cfg(test)]
 mod tests {
     use crate::ReentrantMutex;
+    use crate::ReentrantMutexGuard;
     use std::cell::RefCell;
     use std::sync::Arc;
     use std::thread;
+    use std::sync::mpsc::channel;
 
     #[cfg(feature = "serde")]
     use bincode::{deserialize, serialize};
@@ -132,6 +134,26 @@ mod tests {
         let mutex = ReentrantMutex::new(vec![0u8, 10]);
 
         assert_eq!(format!("{:?}", mutex), "ReentrantMutex { data: [0, 10] }");
+    }
+
+    #[test]
+    fn test_reentrant_mutex_bump() {
+        let mutex = Arc::new(ReentrantMutex::new(()));
+        let mutex2 = mutex.clone();
+
+        let mut guard = mutex.lock();
+
+        let (tx, rx) = channel();
+
+        thread::spawn(move || {
+            let _guard = mutex2.lock();
+            tx.send(()).unwrap();
+        });
+
+        // `bump()` repeatedly until the thread starts up and requests the lock
+        while rx.try_recv().is_err() {
+            ReentrantMutexGuard::bump(&mut guard);
+        }
     }
 
     #[cfg(feature = "serde")]


### PR DESCRIPTION
Closes https://github.com/Amanieu/parking_lot/issues/389

Hopefully the test seems reasonable. I ended up using a channel to try and avoid the `bump()` running before before the thread tries to acquire the lock.