### PR TITLE
Add `--generate-link-to-definition` option when building on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["mutex", "condvar", "rwlock", "once", "thread"]
 categories = ["concurrency"]
 edition = "2018"
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]
+
 [dependencies]
 parking_lot_core = { path = "core", version = "0.9.0" }
 lock_api = { path = "lock_api", version = "0.4.6" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,6 +10,9 @@ categories = ["concurrency"]
 edition = "2018"
 rust-version = "1.49.0"
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]
+
 [dependencies]
 cfg-if = "1.0.0"
 smallvec = "1.6.1"

--- a/lock_api/Cargo.toml
+++ b/lock_api/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [dependencies]
 scopeguard = { version = "1.1.0", default-features = false }


### PR DESCRIPTION
This option generates links in source code pages, allowing to jump to definition and to jump back to doc. It makes browsing the source code pages much nicer. You can see it in action [here](https://doc.rust-lang.org/stable/nightly-rustc/src/rustc_middle/lib.rs.html#90).