### PR TITLE
windows: impl `ThreadParkerT` / `UnparkHandleT`.

### DIFF
--- a/core/src/thread_parker/windows/mod.rs
+++ b/core/src/thread_parker/windows/mod.rs
@@ -75,11 +75,13 @@ pub struct ThreadParker {
     backend: &'static Backend,
 }
 
-impl ThreadParker {
-    pub const IS_CHEAP_TO_CONSTRUCT: bool = true;
+impl super::ThreadParkerT for ThreadParker {
+    type UnparkHandle = UnparkHandle;
+
+    const IS_CHEAP_TO_CONSTRUCT: bool = true;
 
     #[inline]
-    pub fn new() -> ThreadParker {
+    fn new() -> ThreadParker {
         // Initialize the backend here to ensure we don't get any panics
         // later on, which could leave synchronization primitives in a broken
         // state.
@@ -91,7 +93,7 @@ impl ThreadParker {
 
     // Prepares the parker. This should be called before adding it to the queue.
     #[inline]
-    pub fn prepare_park(&self) {
+    unsafe fn prepare_park(&self) {
         match *self.backend {
             Backend::KeyedEvent(ref x) => x.prepare_park(&self.key),
             Backend::WaitAddress(ref x) => x.prepare_park(&self.key),
@@ -101,7 +103,7 @@ impl ThreadParker {
     // Checks if the park timed out. This should be called while holding the
     // queue lock after park_until has returned false.
     #[inline]
-    pub fn timed_out(&self) -> bool {
+    unsafe fn timed_out(&self) -> bool {
         match *self.backend {
             Backend::KeyedEvent(ref x) => x.timed_out(&self.key),
             Backend::WaitAddress(ref x) => x.timed_out(&self.key),
@@ -111,7 +113,7 @@ impl ThreadParker {
     // Parks the thread until it is unparked. This should be called after it has
     // been added to the queue, after unlocking the queue.
     #[inline]
-    pub unsafe fn park(&self) {
+    unsafe fn park(&self) {
         match *self.backend {
             Backend::KeyedEvent(ref x) => x.park(&self.key),
             Backend::WaitAddress(ref x) => x.park(&self.key),
@@ -122,7 +124,7 @@ impl ThreadParker {
     // should be called after it has been added to the queue, after unlocking
     // the queue. Returns true if we were unparked and false if we timed out.
     #[inline]
-    pub unsafe fn park_until(&self, timeout: Instant) -> bool {
+    unsafe fn park_until(&self, timeout: Instant) -> bool {
         match *self.backend {
             Backend::KeyedEvent(ref x) => x.park_until(&self.key, timeout),
             Backend::WaitAddress(ref x) => x.park_until(&self.key, timeout),
@@ -133,7 +135,7 @@ impl ThreadParker {
     // necessary to ensure that thread-local ThreadData objects remain valid.
     // This should be called while holding the queue lock.
     #[inline]
-    pub unsafe fn unpark_lock(&self) -> UnparkHandle {
+    unsafe fn unpark_lock(&self) -> UnparkHandle {
         match *self.backend {
             Backend::KeyedEvent(ref x) => UnparkHandle::KeyedEvent(x.unpark_lock(&self.key)),
             Backend::WaitAddress(ref x) => UnparkHandle::WaitAddress(x.unpark_lock(&self.key)),
@@ -149,11 +151,11 @@ pub enum UnparkHandle {
     WaitAddress(waitaddress::UnparkHandle),
 }
 
-impl UnparkHandle {
+impl super::UnparkHandleT for UnparkHandle {
     // Wakes up the parked thread. This should be called after the queue lock is
     // released to avoid blocking the queue for too long.
     #[inline]
-    pub unsafe fn unpark(self) {
+    unsafe fn unpark(self) {
         match self {
             UnparkHandle::KeyedEvent(x) => x.unpark(),
             UnparkHandle::WaitAddress(x) => x.unpark(),


### PR DESCRIPTION
These imports were introduced in 2fb27d35 and were unused at the time and remain so.