### PR TITLE
ci: Update `actions/checkout` from v2 to v3.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
             os: ubuntu
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: rustup default ${{ matrix.channel }}
     - run: cargo build --all
     - run: cargo test --all
@@ -51,20 +51,20 @@ jobs:
           #- x86_64-unknown-redox
           #- x86_64-linux-android
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: rustup default nightly
     - run: rustup target add ${{ matrix.target }}
     - run: cargo build --workspace --target ${{ matrix.target }} --features nightly
   build_docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: rustup default nightly
       - run: cargo doc --workspace --features arc_lock,serde,deadlock_detection --no-deps -p parking_lot -p parking_lot_core -p lock_api
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: rustup default nightly
       - run: |
           cd benchmark


### PR DESCRIPTION
This fixes some warnings about using old versions of node in the GitHub Actions UI:

    The following actions uses node12 which is deprecated and
    will be forced to run on node16: actions/checkout@v2.
    For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/