### PR TITLE
Reduce repeats in unpark_all_one_fast test

### DIFF
--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -1476,7 +1476,7 @@ mod tests {
 
     test! {
         unpark_all_one_fast(
-            repeats: 10000, latches: 1, delay: 0, threads: 1, single_unparks: 0
+            repeats: 1000, latches: 1, delay: 0, threads: 1, single_unparks: 0
         );
         unpark_all_hundred_fast(
             repeats: 100, latches: 1, delay: 0, threads: 100, single_unparks: 0


### PR DESCRIPTION
This test is causing failures in Android CI because it is too slow. I suggest reducing the number of repeats.

From our CI:
```
stdout: 
running 12 tests
test parking_lot::tests::unpark_one_one ... ok <0.499s>
test parking_lot::tests::hundred_unpark_all_one ... ok <0.568s>
test parking_lot::tests::unpark_one_fifty ... ok <0.706s>
test parking_lot::tests::unpark_one_fifty_then_fifty_all ... ok <1.489s>
test parking_lot::tests::unpark_one_hundred_fast ... ok <3.500s>
test parking_lot::tests::unpark_all_one ... ok <6.221s>
test parking_lot::tests::unpark_one_fifty_then_fifty_all_fast ... ok <10.103s>
test parking_lot::tests::unpark_all_hundred_fast ... ok <15.896s>
test parking_lot::tests::unpark_all_hundred ... ok <15.980s>
test parking_lot::tests::hundred_unpark_all_one_fast ... ok <20.817s>
test parking_lot::tests::unpark_one_one_fast ... ok <27.496s>
test parking_lot::tests::unpark_all_one_fast has been running for over 60 seconds

stderr: 
  Test run incomplete. Started 12 tests, finished 11
```