### PR TITLE
Allow unsafe creation of new lock guards

### DIFF
--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -309,7 +309,7 @@ impl<R: RawMutex, T: ?Sized> Mutex<R, T> {
     /// the guard was forgotten with `mem::forget`.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    unsafe fn make_guard_arc_unchecked(self: &Arc<Self>) -> ArcMutexGuard<R, T> {
+    unsafe fn make_arc_guard_unchecked(self: &Arc<Self>) -> ArcMutexGuard<R, T> {
         ArcMutexGuard {
             mutex: self.clone(),
             marker: PhantomData,
@@ -325,7 +325,7 @@ impl<R: RawMutex, T: ?Sized> Mutex<R, T> {
     pub fn lock_arc(self: &Arc<Self>) -> ArcMutexGuard<R, T> {
         self.raw.lock();
         // SAFETY: the locking guarantee is upheld
-        unsafe { self.make_guard_arc_unchecked() }
+        unsafe { self.make_arc_guard_unchecked() }
     }
 
     /// Attempts to acquire a lock through an `Arc`.
@@ -337,7 +337,7 @@ impl<R: RawMutex, T: ?Sized> Mutex<R, T> {
     pub fn try_lock_arc(self: &Arc<Self>) -> Option<ArcMutexGuard<R, T>> {
         if self.raw.try_lock() {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { self.make_guard_arc_unchecked() })
+            Some(unsafe { self.make_arc_guard_unchecked() })
         } else {
             None
         }
@@ -402,7 +402,7 @@ impl<R: RawMutexTimed, T: ?Sized> Mutex<R, T> {
     pub fn try_lock_arc_for(self: &Arc<Self>, timeout: R::Duration) -> Option<ArcMutexGuard<R, T>> {
         if self.raw.try_lock_for(timeout) {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { self.make_guard_arc_unchecked() })
+            Some(unsafe { self.make_arc_guard_unchecked() })
         } else {
             None
         }
@@ -420,7 +420,7 @@ impl<R: RawMutexTimed, T: ?Sized> Mutex<R, T> {
     ) -> Option<ArcMutexGuard<R, T>> {
         if self.raw.try_lock_until(timeout) {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { self.make_guard_arc_unchecked() })
+            Some(unsafe { self.make_arc_guard_unchecked() })
         } else {
             None
         }

--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -192,7 +192,7 @@ impl<R: RawMutex, T: ?Sized> Mutex<R, T> {
     /// # Safety
     ///
     /// The lock must be held when calling this method. This method must only
-    /// be called if this thread holds the lock and no other `MutexGaurd` exists
+    /// be called if this thread holds the lock and no `MutexGaurd` exists
     /// for this lock
     #[inline]
     pub unsafe fn guard(&self) -> MutexGuard<'_, R, T> {

--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -191,9 +191,11 @@ impl<R, T> Mutex<R, T> {
 impl<R: RawMutex, T: ?Sized> Mutex<R, T> {
     /// # Safety
     ///
-    /// The lock must be held when calling this method.
+    /// The lock must be held when calling this method. This method must only
+    /// be called if this thread holds the lock and no other `MutexGaurd` exists
+    /// for this lock
     #[inline]
-    unsafe fn guard(&self) -> MutexGuard<'_, R, T> {
+    pub unsafe fn guard(&self) -> MutexGuard<'_, R, T> {
         MutexGuard {
             mutex: self,
             marker: PhantomData,

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -292,7 +292,7 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     /// # Safety
     ///
     /// The lock must be held when calling this method.This method must only
-    /// be called if this thread holds the lock and no other `MutexGaurd` exists
+    /// be called if this thread holds the lock and no `ReentrantMutexGuard` exists
     /// for this lock
     #[inline]
     pub unsafe fn guard(&self) -> ReentrantMutexGuard<'_, R, G, T> {

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -417,7 +417,7 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     /// the guard was forgotten with `mem::forget`.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub unsafe fn make_guard_arc_unchecked(self: &Arc<Self>) -> ArcReentrantMutexGuard<R, G, T> {
+    pub unsafe fn make_arc_guard_unchecked(self: &Arc<Self>) -> ArcReentrantMutexGuard<R, G, T> {
         ArcReentrantMutexGuard {
             remutex: self.clone(),
             marker: PhantomData,
@@ -433,7 +433,7 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     pub fn lock_arc(self: &Arc<Self>) -> ArcReentrantMutexGuard<R, G, T> {
         self.raw.lock();
         // SAFETY: locking guarantee is upheld
-        unsafe { self.make_guard_arc_unchecked() }
+        unsafe { self.make_arc_guard_unchecked() }
     }
 
     /// Attempts to acquire a reentrant mutex through an `Arc`.
@@ -445,7 +445,7 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     pub fn try_lock_arc(self: &Arc<Self>) -> Option<ArcReentrantMutexGuard<R, G, T>> {
         if self.raw.try_lock() {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { self.make_guard_arc_unchecked() })
+            Some(unsafe { self.make_arc_guard_unchecked() })
         } else {
             None
         }
@@ -513,7 +513,7 @@ impl<R: RawMutexTimed, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     ) -> Option<ArcReentrantMutexGuard<R, G, T>> {
         if self.raw.try_lock_for(timeout) {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { self.make_guard_arc_unchecked() })
+            Some(unsafe { self.make_arc_guard_unchecked() })
         } else {
             None
         }
@@ -531,7 +531,7 @@ impl<R: RawMutexTimed, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     ) -> Option<ArcReentrantMutexGuard<R, G, T>> {
         if self.raw.try_lock_until(timeout) {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { self.make_guard_arc_unchecked() })
+            Some(unsafe { self.make_arc_guard_unchecked() })
         } else {
             None
         }

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -291,9 +291,11 @@ impl<R, G, T> ReentrantMutex<R, G, T> {
 impl<R: RawMutex, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     /// # Safety
     ///
-    /// The lock must be held when calling this method.
+    /// The lock must be held when calling this method.This method must only
+    /// be called if this thread holds the lock and no other `MutexGaurd` exists
+    /// for this lock
     #[inline]
-    unsafe fn guard(&self) -> ReentrantMutexGuard<'_, R, G, T> {
+    pub unsafe fn guard(&self) -> ReentrantMutexGuard<'_, R, G, T> {
         ReentrantMutexGuard {
             remutex: &self,
             marker: PhantomData,

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -412,7 +412,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     /// # Safety
     ///
     /// The lock must be held when calling this method. This method must only
-    /// be called if this thread holds the lock and no other `MutexGaurd` exists
+    /// be called if this thread holds the read lock and no `RwLockReadGuard` exists
     /// for this lock
     #[inline]
     pub unsafe fn read_guard(&self) -> RwLockReadGuard<'_, R, T> {
@@ -424,7 +424,9 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
 
     /// # Safety
     ///
-    /// The lock must be held when calling this method.
+    /// The lock must be held when calling this method. This method must only
+    /// be called if this thread holds the write lock and no `RwLockWriteGuard` exists
+    /// for this lock
     #[inline]
     pub unsafe fn write_guard(&self) -> RwLockWriteGuard<'_, R, T> {
         RwLockWriteGuard {
@@ -992,7 +994,7 @@ impl<R: RawRwLockUpgrade, T: ?Sized> RwLock<R, T> {
     ///
     /// The lock must be held when calling this method.
     #[inline]
-    pub unsafe fn upgradable_guard(&self) -> RwLockUpgradableReadGuard<'_, R, T> {
+    unsafe fn upgradable_guard(&self) -> RwLockUpgradableReadGuard<'_, R, T> {
         RwLockUpgradableReadGuard {
             rwlock: self,
             marker: PhantomData,

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -416,8 +416,8 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     /// This method must only be called if the thread logically holds a read lock.
     ///
     /// This function does not increment the read count of the lock. Calling this function when a
-    /// guard has already been produced for the thread is undefined behaviour unless the
-    /// guard was forgotten with `mem::forget`.`
+    /// guard has already been produced is undefined behaviour unless the guard was forgotten
+    /// with `mem::forget`.`
     #[inline]
     pub unsafe fn make_read_guard_unchecked(&self) -> RwLockReadGuard<'_, R, T> {
         RwLockReadGuard {
@@ -601,8 +601,8 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     /// This method must only be called if the thread logically holds a read lock.
     ///
     /// This function does not increment the read count of the lock. Calling this function when a
-    /// guard has already been produced for the thread is undefined behaviour unless the
-    /// guard was forgotten with `mem::forget`.`
+    /// guard has already been produced is undefined behaviour unless the guard was forgotten
+    /// with `mem::forget`.`
     #[cfg(feature = "arc_lock")]
     #[inline]
     pub unsafe fn make_read_guard_arc_unchecked(self: &Arc<Self>) -> ArcRwLockReadGuard<R, T> {
@@ -1015,8 +1015,8 @@ impl<R: RawRwLockUpgrade, T: ?Sized> RwLock<R, T> {
     /// This method must only be called if the thread logically holds an upgradable read lock.
     ///
     /// This function does not increment the read count of the lock. Calling this function when a
-    /// guard has already been produced for the thread is undefined behaviour unless the
-    /// guard was forgotten with `mem::forget`.`
+    /// guard has already been produced is undefined behaviour unless the guard was forgotten
+    /// with `mem::forget`.`
     #[inline]
     pub unsafe fn make_upgradable_guard_unchecked(&self) -> RwLockUpgradableReadGuard<'_, R, T> {
         RwLockUpgradableReadGuard {

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -411,9 +411,11 @@ impl<R, T> RwLock<R, T> {
 impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     /// # Safety
     ///
-    /// The lock must be held when calling this method.
+    /// The lock must be held when calling this method. This method must only
+    /// be called if this thread holds the lock and no other `MutexGaurd` exists
+    /// for this lock
     #[inline]
-    unsafe fn read_guard(&self) -> RwLockReadGuard<'_, R, T> {
+    pub unsafe fn read_guard(&self) -> RwLockReadGuard<'_, R, T> {
         RwLockReadGuard {
             rwlock: self,
             marker: PhantomData,
@@ -424,7 +426,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     ///
     /// The lock must be held when calling this method.
     #[inline]
-    unsafe fn write_guard(&self) -> RwLockWriteGuard<'_, R, T> {
+    pub unsafe fn write_guard(&self) -> RwLockWriteGuard<'_, R, T> {
         RwLockWriteGuard {
             rwlock: self,
             marker: PhantomData,
@@ -990,7 +992,7 @@ impl<R: RawRwLockUpgrade, T: ?Sized> RwLock<R, T> {
     ///
     /// The lock must be held when calling this method.
     #[inline]
-    unsafe fn upgradable_guard(&self) -> RwLockUpgradableReadGuard<'_, R, T> {
+    pub unsafe fn upgradable_guard(&self) -> RwLockUpgradableReadGuard<'_, R, T> {
         RwLockUpgradableReadGuard {
             rwlock: self,
             marker: PhantomData,

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -605,7 +605,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     /// with `mem::forget`.`
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub unsafe fn make_read_guard_arc_unchecked(self: &Arc<Self>) -> ArcRwLockReadGuard<R, T> {
+    pub unsafe fn make_arc_read_guard_unchecked(self: &Arc<Self>) -> ArcRwLockReadGuard<R, T> {
         ArcRwLockReadGuard {
             rwlock: self.clone(),
             marker: PhantomData,
@@ -622,7 +622,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     /// the guard was forgotten with `mem::forget`.
     #[cfg(feature = "arc_lock")]
     #[inline]
-    pub unsafe fn make_write_guard_arc_unchecked(self: &Arc<Self>) -> ArcRwLockWriteGuard<R, T> {
+    pub unsafe fn make_arc_write_guard_unchecked(self: &Arc<Self>) -> ArcRwLockWriteGuard<R, T> {
         ArcRwLockWriteGuard {
             rwlock: self.clone(),
             marker: PhantomData,
@@ -638,7 +638,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     pub fn read_arc(self: &Arc<Self>) -> ArcRwLockReadGuard<R, T> {
         self.raw.lock_shared();
         // SAFETY: locking guarantee is upheld
-        unsafe { self.make_read_guard_arc_unchecked() }
+        unsafe { self.make_arc_read_guard_unchecked() }
     }
 
     /// Attempts to lock this `RwLock` with read access, through an `Arc`.
@@ -650,7 +650,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     pub fn try_read_arc(self: &Arc<Self>) -> Option<ArcRwLockReadGuard<R, T>> {
         if self.raw.try_lock_shared() {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { self.make_read_guard_arc_unchecked() })
+            Some(unsafe { self.make_arc_read_guard_unchecked() })
         } else {
             None
         }
@@ -665,7 +665,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     pub fn write_arc(self: &Arc<Self>) -> ArcRwLockWriteGuard<R, T> {
         self.raw.lock_exclusive();
         // SAFETY: locking guarantee is upheld
-        unsafe { self.make_write_guard_arc_unchecked() }
+        unsafe { self.make_arc_write_guard_unchecked() }
     }
 
     /// Attempts to lock this `RwLock` with writ access, through an `Arc`.
@@ -677,7 +677,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     pub fn try_write_arc(self: &Arc<Self>) -> Option<ArcRwLockWriteGuard<R, T>> {
         if self.raw.try_lock_exclusive() {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { self.make_write_guard_arc_unchecked() })
+            Some(unsafe { self.make_arc_write_guard_unchecked() })
         } else {
             None
         }
@@ -795,7 +795,7 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     ) -> Option<ArcRwLockReadGuard<R, T>> {
         if self.raw.try_lock_shared_for(timeout) {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { self.make_read_guard_arc_unchecked() })
+            Some(unsafe { self.make_arc_read_guard_unchecked() })
         } else {
             None
         }
@@ -813,7 +813,7 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     ) -> Option<ArcRwLockReadGuard<R, T>> {
         if self.raw.try_lock_shared_until(timeout) {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { self.make_read_guard_arc_unchecked() })
+            Some(unsafe { self.make_arc_read_guard_unchecked() })
         } else {
             None
         }
@@ -831,7 +831,7 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     ) -> Option<ArcRwLockWriteGuard<R, T>> {
         if self.raw.try_lock_exclusive_for(timeout) {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { self.make_write_guard_arc_unchecked() })
+            Some(unsafe { self.make_arc_write_guard_unchecked() })
         } else {
             None
         }
@@ -849,7 +849,7 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     ) -> Option<ArcRwLockWriteGuard<R, T>> {
         if self.raw.try_lock_exclusive_until(timeout) {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { self.make_write_guard_arc_unchecked() })
+            Some(unsafe { self.make_arc_write_guard_unchecked() })
         } else {
             None
         }
@@ -908,7 +908,7 @@ impl<R: RawRwLockRecursive, T: ?Sized> RwLock<R, T> {
     pub fn read_arc_recursive(self: &Arc<Self>) -> ArcRwLockReadGuard<R, T> {
         self.raw.lock_shared_recursive();
         // SAFETY: locking guarantee is upheld
-        unsafe { self.make_read_guard_arc_unchecked() }
+        unsafe { self.make_arc_read_guard_unchecked() }
     }
 
     /// Attempts to lock this `RwLock` with shared read access, through an `Arc`.
@@ -920,7 +920,7 @@ impl<R: RawRwLockRecursive, T: ?Sized> RwLock<R, T> {
     pub fn try_read_recursive_arc(self: &Arc<Self>) -> Option<ArcRwLockReadGuard<R, T>> {
         if self.raw.try_lock_shared_recursive() {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { self.make_read_guard_arc_unchecked() })
+            Some(unsafe { self.make_arc_read_guard_unchecked() })
         } else {
             None
         }
@@ -982,7 +982,7 @@ impl<R: RawRwLockRecursiveTimed, T: ?Sized> RwLock<R, T> {
     ) -> Option<ArcRwLockReadGuard<R, T>> {
         if self.raw.try_lock_shared_recursive_for(timeout) {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { self.make_read_guard_arc_unchecked() })
+            Some(unsafe { self.make_arc_read_guard_unchecked() })
         } else {
             None
         }
@@ -1000,7 +1000,7 @@ impl<R: RawRwLockRecursiveTimed, T: ?Sized> RwLock<R, T> {
     ) -> Option<ArcRwLockReadGuard<R, T>> {
         if self.raw.try_lock_shared_recursive_until(timeout) {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { self.make_read_guard_arc_unchecked() })
+            Some(unsafe { self.make_arc_read_guard_unchecked() })
         } else {
             None
         }
@@ -1058,12 +1058,20 @@ impl<R: RawRwLockUpgrade, T: ?Sized> RwLock<R, T> {
         }
     }
 
+    /// Creates a new `ArcRwLockUpgradableReadGuard` without checking if the lock is held.
+    ///
     /// # Safety
     ///
-    /// The lock must be held when calling this method.
+    /// This method must only be called if the thread logically holds an upgradable read lock.
+    ///
+    /// This function does not increment the read count of the lock. Calling this function when a
+    /// guard has already been produced is undefined behaviour unless the guard was forgotten
+    /// with `mem::forget`.`
     #[cfg(feature = "arc_lock")]
     #[inline]
-    unsafe fn upgradable_guard_arc(self: &Arc<Self>) -> ArcRwLockUpgradableReadGuard<R, T> {
+    pub unsafe fn make_upgradable_arc_guard_unchecked(
+        self: &Arc<Self>,
+    ) -> ArcRwLockUpgradableReadGuard<R, T> {
         ArcRwLockUpgradableReadGuard {
             rwlock: self.clone(),
             marker: PhantomData,
@@ -1079,7 +1087,7 @@ impl<R: RawRwLockUpgrade, T: ?Sized> RwLock<R, T> {
     pub fn upgradable_read_arc(self: &Arc<Self>) -> ArcRwLockUpgradableReadGuard<R, T> {
         self.raw.lock_upgradable();
         // SAFETY: locking guarantee is upheld
-        unsafe { self.upgradable_guard_arc() }
+        unsafe { self.make_upgradable_arc_guard_unchecked() }
     }
 
     /// Attempts to lock this `RwLock` with upgradable read access, through an `Arc`.
@@ -1091,7 +1099,7 @@ impl<R: RawRwLockUpgrade, T: ?Sized> RwLock<R, T> {
     pub fn try_upgradable_read_arc(self: &Arc<Self>) -> Option<ArcRwLockUpgradableReadGuard<R, T>> {
         if self.raw.try_lock_upgradable() {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { self.upgradable_guard_arc() })
+            Some(unsafe { self.make_upgradable_arc_guard_unchecked() })
         } else {
             None
         }
@@ -1149,7 +1157,7 @@ impl<R: RawRwLockUpgradeTimed, T: ?Sized> RwLock<R, T> {
     ) -> Option<ArcRwLockUpgradableReadGuard<R, T>> {
         if self.raw.try_lock_upgradable_for(timeout) {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { self.upgradable_guard_arc() })
+            Some(unsafe { self.make_upgradable_arc_guard_unchecked() })
         } else {
             None
         }
@@ -1167,7 +1175,7 @@ impl<R: RawRwLockUpgradeTimed, T: ?Sized> RwLock<R, T> {
     ) -> Option<ArcRwLockUpgradableReadGuard<R, T>> {
         if self.raw.try_lock_upgradable_until(timeout) {
             // SAFETY: locking guarantee is upheld
-            Some(unsafe { self.upgradable_guard_arc() })
+            Some(unsafe { self.make_upgradable_arc_guard_unchecked() })
         } else {
             None
         }


### PR DESCRIPTION
This PR changes the visibility of the functions that produce the lock guards to public. 
The inspiration for this comes from my desire to extend the mutex with new locking functions (async locking for example).

I was initially concerned that exposing this might be a bad idea even if it is useful. However, I decided that exposing these functions was no worse than the already public `force_unlock` functions. 