### PR TITLE
Markdown fixes / improvements.

### DIFF
--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -1103,7 +1103,7 @@ pub mod deadlock {
     pub(super) use super::deadlock_impl::DeadlockData;
 
     /// Acquire a resource identified by key in the deadlock detector
-    /// Noop if deadlock_detection feature isn't enabled.
+    /// Noop if `deadlock_detection` feature isn't enabled.
     ///
     /// # Safety
     ///
@@ -1115,7 +1115,7 @@ pub mod deadlock {
     }
 
     /// Release a resource identified by key in the deadlock detector.
-    /// Noop if deadlock_detection feature isn't enabled.
+    /// Noop if `deadlock_detection` feature isn't enabled.
     ///
     /// # Panics
     ///

--- a/core/src/thread_parker/mod.rs
+++ b/core/src/thread_parker/mod.rs
@@ -20,7 +20,7 @@ pub trait ThreadParkerT {
     unsafe fn prepare_park(&self);
 
     /// Checks if the park timed out. This should be called while holding the
-    /// queue lock after park_until has returned false.
+    /// queue lock after `park_until` has returned false.
     unsafe fn timed_out(&self) -> bool;
 
     /// Parks the thread until it is unparked. This should be called after it has
@@ -33,7 +33,7 @@ pub trait ThreadParkerT {
     unsafe fn park_until(&self, timeout: Instant) -> bool;
 
     /// Locks the parker to prevent the target thread from exiting. This is
-    /// necessary to ensure that thread-local ThreadData objects remain valid.
+    /// necessary to ensure that thread-local `ThreadData` objects remain valid.
     /// This should be called while holding the queue lock.
     unsafe fn unpark_lock(&self) -> Self::UnparkHandle;
 }

--- a/core/src/thread_parker/windows/bindings.rs
+++ b/core/src/thread_parker/windows/bindings.rs
@@ -1,5 +1,5 @@
 //! Manual bindings to the win32 API to avoid dependencies on windows-sys or winapi
-//! as these bindings will **never** change and parking_lot_core is a foundational
+//! as these bindings will **never** change and `parking_lot_core` is a foundational
 //! dependency for the Rust ecosystem, so the dependencies used by it have an
 //! outsize affect
 

--- a/core/src/word_lock.rs
+++ b/core/src/word_lock.rs
@@ -78,7 +78,7 @@ pub struct WordLock {
 }
 
 impl WordLock {
-    /// Returns a new, unlocked, WordLock.
+    /// Returns a new, unlocked, `WordLock`.
     pub const fn new() -> Self {
         WordLock {
             state: AtomicUsize::new(0),

--- a/lock_api/src/lib.rs
+++ b/lock_api/src/lib.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-//! This library provides type-safe and fully-featured `Mutex` and `RwLock`
+//! This library provides type-safe and fully-featured [`Mutex`] and [`RwLock`]
 //! types which wrap a simple raw mutex or rwlock type. This has several
 //! benefits: not only does it eliminate a large portion of the work in
 //! implementing custom lock types, it also allows users to write code which is
@@ -20,7 +20,7 @@
 //!    your mutex guard as a type alias for `lock_api::MutexGuard`.
 //!    See the [example](#example) below for details.
 //!
-//! This process is similar for RwLocks, except that two guards need to be
+//! This process is similar for [`RwLock`]s, except that two guards need to be
 //! exported instead of one. (Or 3 guards if your type supports upgradable read
 //! locks, see [extension traits](#extension-traits) below for details)
 //!

--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -58,10 +58,10 @@ pub unsafe trait RawMutex {
     /// This method may only be called if the mutex is held in the current context, i.e. it must
     /// be paired with a successful call to [`lock`], [`try_lock`], [`try_lock_for`] or [`try_lock_until`].
     ///
-    /// [`lock`]: #tymethod.lock
-    /// [`try_lock`]: #tymethod.try_lock
-    /// [`try_lock_for`]: trait.RawMutexTimed.html#tymethod.try_lock_for
-    /// [`try_lock_until`]: trait.RawMutexTimed.html#tymethod.try_lock_until
+    /// [`lock`]: RawMutex::lock
+    /// [`try_lock`]: RawMutex::try_lock
+    /// [`try_lock_for`]: RawMutexTimed::try_lock_for
+    /// [`try_lock_until`]: RawMutexTimed::try_lock_until
     unsafe fn unlock(&self);
 
     /// Checks whether the mutex is currently locked.
@@ -90,9 +90,7 @@ pub unsafe trait RawMutexFair: RawMutex {
     /// # Safety
     ///
     /// This method may only be called if the mutex is held in the current context, see
-    /// the documentation of [`unlock`].
-    ///
-    /// [`unlock`]: trait.RawMutex.html#tymethod.unlock
+    /// the documentation of [`unlock`](RawMutex::unlock).
     unsafe fn unlock_fair(&self);
 
     /// Temporarily yields the mutex to a waiting thread if there is one.
@@ -104,9 +102,7 @@ pub unsafe trait RawMutexFair: RawMutex {
     /// # Safety
     ///
     /// This method may only be called if the mutex is held in the current context, see
-    /// the documentation of [`unlock`].
-    ///
-    /// [`unlock`]: trait.RawMutex.html#tymethod.unlock
+    /// the documentation of [`unlock`](RawMutex::unlock).
     unsafe fn bump(&self) {
         self.unlock_fair();
         self.lock();

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -61,9 +61,6 @@ pub unsafe trait GetThreadId {
 /// mutex can successfully acquire a lock multiple times in the same thread.
 /// Only use this when you know you want a raw mutex that can be locked
 /// reentrantly; you probably want [`ReentrantMutex`] instead.
-///
-/// [`RawMutex`]: trait.RawMutex.html
-/// [`ReentrantMutex`]: struct.ReentrantMutex.html
 pub struct RawReentrantMutex<R, G> {
     owner: AtomicUsize,
     lock_count: Cell<usize>,
@@ -214,7 +211,7 @@ impl<R: RawMutexTimed, G: GetThreadId> RawReentrantMutex<R, G> {
 /// - `ReentrantMutexGuard` does not give mutable references to the locked data.
 ///   Use a `RefCell` if you need this.
 ///
-/// See [`Mutex`](struct.Mutex.html) for more details about the underlying mutex
+/// See [`Mutex`](crate::Mutex) for more details about the underlying mutex
 /// primitive.
 pub struct ReentrantMutex<R, G, T: ?Sized> {
     raw: RawReentrantMutex<R, G>,

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -98,7 +98,7 @@ pub unsafe trait RawRwLock {
     }
 }
 
-/// Additional methods for RwLocks which support fair unlocking.
+/// Additional methods for `RwLock`s which support fair unlocking.
 ///
 /// Fair unlocking means that a lock is handed directly over to the next waiting
 /// thread if there is one, without giving other threads the opportunity to
@@ -148,7 +148,7 @@ pub unsafe trait RawRwLockFair: RawRwLock {
     }
 }
 
-/// Additional methods for RwLocks which support atomically downgrading an
+/// Additional methods for `RwLock`s which support atomically downgrading an
 /// exclusive lock to a shared lock.
 pub unsafe trait RawRwLockDowngrade: RawRwLock {
     /// Atomically downgrades an exclusive lock into a shared lock without
@@ -160,7 +160,7 @@ pub unsafe trait RawRwLockDowngrade: RawRwLock {
     unsafe fn downgrade(&self);
 }
 
-/// Additional methods for RwLocks which support locking with timeouts.
+/// Additional methods for `RwLock`s which support locking with timeouts.
 ///
 /// The `Duration` and `Instant` types are specified as associated types so that
 /// this trait is usable even in `no_std` environments.
@@ -184,7 +184,7 @@ pub unsafe trait RawRwLockTimed: RawRwLock {
     fn try_lock_exclusive_until(&self, timeout: Self::Instant) -> bool;
 }
 
-/// Additional methods for RwLocks which support recursive read locks.
+/// Additional methods for `RwLock`s which support recursive read locks.
 ///
 /// These are guaranteed to succeed without blocking if
 /// another read lock is held at the time of the call. This allows a thread
@@ -199,7 +199,7 @@ pub unsafe trait RawRwLockRecursive: RawRwLock {
     fn try_lock_shared_recursive(&self) -> bool;
 }
 
-/// Additional methods for RwLocks which support recursive read locks and timeouts.
+/// Additional methods for `RwLock`s which support recursive read locks and timeouts.
 pub unsafe trait RawRwLockRecursiveTimed: RawRwLockRecursive + RawRwLockTimed {
     /// Attempts to acquire a shared lock until a timeout is reached, without
     /// deadlocking in case of a recursive lock.
@@ -210,7 +210,7 @@ pub unsafe trait RawRwLockRecursiveTimed: RawRwLockRecursive + RawRwLockTimed {
     fn try_lock_shared_recursive_until(&self, timeout: Self::Instant) -> bool;
 }
 
-/// Additional methods for RwLocks which support atomically upgrading a shared
+/// Additional methods for `RwLock`s which support atomically upgrading a shared
 /// lock to an exclusive lock.
 ///
 /// This requires acquiring a special "upgradable read lock" instead of a
@@ -246,7 +246,7 @@ pub unsafe trait RawRwLockUpgrade: RawRwLock {
     unsafe fn try_upgrade(&self) -> bool;
 }
 
-/// Additional methods for RwLocks which support upgradable locks and fair
+/// Additional methods for `RwLock`s which support upgradable locks and fair
 /// unlocking.
 pub unsafe trait RawRwLockUpgradeFair: RawRwLockUpgrade + RawRwLockFair {
     /// Releases an upgradable lock using a fair unlock protocol.
@@ -271,7 +271,7 @@ pub unsafe trait RawRwLockUpgradeFair: RawRwLockUpgrade + RawRwLockFair {
     }
 }
 
-/// Additional methods for RwLocks which support upgradable locks and lock
+/// Additional methods for `RwLock`s which support upgradable locks and lock
 /// downgrading.
 pub unsafe trait RawRwLockUpgradeDowngrade: RawRwLockUpgrade + RawRwLockDowngrade {
     /// Downgrades an upgradable lock to a shared lock.
@@ -289,7 +289,7 @@ pub unsafe trait RawRwLockUpgradeDowngrade: RawRwLockUpgrade + RawRwLockDowngrad
     unsafe fn downgrade_to_upgradable(&self);
 }
 
-/// Additional methods for RwLocks which support upgradable locks and locking
+/// Additional methods for `RwLock`s which support upgradable locks and locking
 /// with timeouts.
 pub unsafe trait RawRwLockUpgradeTimed: RawRwLockUpgrade + RawRwLockTimed {
     /// Attempts to acquire an upgradable lock until a timeout is reached.
@@ -417,7 +417,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     ///
     /// This function does not increment the read count of the lock. Calling this function when a
     /// guard has already been produced is undefined behaviour unless the guard was forgotten
-    /// with `mem::forget`.`
+    /// with `mem::forget`.
     #[inline]
     pub unsafe fn make_read_guard_unchecked(&self) -> RwLockReadGuard<'_, R, T> {
         RwLockReadGuard {
@@ -1016,7 +1016,7 @@ impl<R: RawRwLockUpgrade, T: ?Sized> RwLock<R, T> {
     ///
     /// This function does not increment the read count of the lock. Calling this function when a
     /// guard has already been produced is undefined behaviour unless the guard was forgotten
-    /// with `mem::forget`.`
+    /// with `mem::forget`.
     #[inline]
     pub unsafe fn make_upgradable_guard_unchecked(&self) -> RwLockUpgradableReadGuard<'_, R, T> {
         RwLockUpgradableReadGuard {

--- a/src/raw_rwlock.rs
+++ b/src/raw_rwlock.rs
@@ -923,8 +923,8 @@ impl RawRwLock {
         self.lock_upgradable();
     }
 
-    /// Common code for waking up parked threads after releasing WRITER_BIT or
-    /// UPGRADABLE_BIT.
+    /// Common code for waking up parked threads after releasing `WRITER_BIT` or
+    /// `UPGRADABLE_BIT`.
     ///
     /// # Safety
     ///

--- a/src/remutex.rs
+++ b/src/remutex.rs
@@ -36,7 +36,7 @@ unsafe impl GetThreadId for RawThreadId {
 /// - `ReentrantMutexGuard` does not give mutable references to the locked data.
 ///   Use a `RefCell` if you need this.
 ///
-/// See [`Mutex`](type.Mutex.html) for more details about the underlying mutex
+/// See [`Mutex`](crate::Mutex) for more details about the underlying mutex
 /// primitive.
 pub type ReentrantMutex<T> = lock_api::ReentrantMutex<RawMutex, RawThreadId, T>;
 


### PR DESCRIPTION
This fixes missing backticks, imbalanced backticks, old HTML intradoc links, and adds a couple of links.