### PR TITLE
hardware-lock-elision: Remove redundant import.

### DIFF
--- a/src/elision.rs
+++ b/src/elision.rs
@@ -5,11 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-#[cfg(all(
-    feature = "hardware-lock-elision",
-    any(target_arch = "x86", target_arch = "x86_64")
-))]
-use std::arch::asm;
 use std::sync::atomic::AtomicUsize;
 
 // Extension trait to add lock elision primitives to atomic types


### PR DESCRIPTION
Each function which uses `asm!` is already importing `core::arch::asm` on its own.