### PR TITLE
Update `windows-targets` 0.52

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,7 +27,7 @@ libc = "0.2.95"
 redox_syscall = "0.4"
 
 [target.'cfg(windows)'.dependencies]
-windows-targets = "0.48.0"
+windows-targets = "0.52.0"
 
 [features]
 nightly = []


### PR DESCRIPTION
This just brings expanded lib support to include coverage for the first update to the `windows-sys` crate in 8 months. https://github.com/microsoft/windows-rs/releases/tag/0.52.0