### PR TITLE
Enable some features for the playground

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ rust-version = "1.49"
 features = ["arc_lock", "serde", "deadlock_detection"]
 rustdoc-args = ["--generate-link-to-definition"]
 
+[package.metadata.playground]
+features = ["arc_lock", "serde", "deadlock_detection"]
+
 [dependencies]
 parking_lot_core = { path = "core", version = "0.9.0" }
 lock_api = { path = "lock_api", version = "0.4.6" }


### PR DESCRIPTION
This will enable some features (`arc_lock`, `serde`, and `deadlock_detection`) on the playground (https://play.rust-lang.org). Feature list was copied from `package.metadata.docs.rs`, feel free to change if it isn't right.

See https://github.com/rust-lang/rust-playground/issues/192 for more info.

Many other popular crates have done a similar thing ([serde](https://github.com/serde-rs/serde/blob/44613c7d0190dbb5ecd2d5ec19c636f45b7488cc/serde/Cargo.toml#L26-L27), [tokio](https://github.com/tokio-rs/tokio/blob/7a30504fd423aa782239ead92f3afa3474f8037c/tokio/Cargo.toml#L165-L166), etc).