### PR TITLE
Add `lock_api::{Mutex, ReentrantMutex, RwLock}::from_raw` methods

### DIFF
--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -173,14 +173,22 @@ impl<R: RawMutex, T> Mutex<R, T> {
 
 impl<R, T> Mutex<R, T> {
     /// Creates a new mutex based on a pre-existing raw mutex.
-    ///
-    /// This allows creating a mutex in a constant context on stable Rust.
     #[inline]
-    pub const fn const_new(raw_mutex: R, val: T) -> Mutex<R, T> {
+    pub const fn from_raw(raw_mutex: R, val: T) -> Mutex<R, T> {
         Mutex {
             raw: raw_mutex,
             data: UnsafeCell::new(val),
         }
+    }
+
+    /// Creates a new mutex based on a pre-existing raw mutex.
+    ///
+    /// This allows creating a mutex in a constant context on stable Rust.
+    ///
+    /// This method is a legacy alias for [`from_raw`](Self::from_raw).
+    #[inline]
+    pub const fn const_new(raw_mutex: R, val: T) -> Mutex<R, T> {
+        Self::from_raw(raw_mutex, val)
     }
 }
 

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -268,11 +268,8 @@ impl<R: RawMutex, G: GetThreadId, T> ReentrantMutex<R, G, T> {
 impl<R, G, T> ReentrantMutex<R, G, T> {
     /// Creates a new reentrant mutex based on a pre-existing raw mutex and a
     /// helper to get the thread ID.
-    ///
-    /// This allows creating a reentrant mutex in a constant context on stable
-    /// Rust.
     #[inline]
-    pub const fn const_new(raw_mutex: R, get_thread_id: G, val: T) -> ReentrantMutex<R, G, T> {
+    pub const fn from_raw(raw_mutex: R, get_thread_id: G, val: T) -> ReentrantMutex<R, G, T> {
         ReentrantMutex {
             data: UnsafeCell::new(val),
             raw: RawReentrantMutex {
@@ -282,6 +279,18 @@ impl<R, G, T> ReentrantMutex<R, G, T> {
                 get_thread_id,
             },
         }
+    }
+
+    /// Creates a new reentrant mutex based on a pre-existing raw mutex and a
+    /// helper to get the thread ID.
+    ///
+    /// This allows creating a reentrant mutex in a constant context on stable
+    /// Rust.
+    ///
+    /// This method is a legacy alias for [`from_raw`](Self::from_raw).
+    #[inline]
+    pub const fn const_new(raw_mutex: R, get_thread_id: G, val: T) -> ReentrantMutex<R, G, T> {
+        Self::from_raw(raw_mutex, get_thread_id, val)
     }
 }
 

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -396,15 +396,24 @@ impl<R: RawRwLock, T> RwLock<R, T> {
 impl<R, T> RwLock<R, T> {
     /// Creates a new new instance of an `RwLock<T>` based on a pre-existing
     /// `RawRwLock<T>`.
-    ///
-    /// This allows creating a `RwLock<T>` in a constant context on stable
-    /// Rust.
     #[inline]
-    pub const fn const_new(raw_rwlock: R, val: T) -> RwLock<R, T> {
+    pub const fn from_raw(raw_rwlock: R, val: T) -> RwLock<R, T> {
         RwLock {
             data: UnsafeCell::new(val),
             raw: raw_rwlock,
         }
+    }
+
+    /// Creates a new new instance of an `RwLock<T>` based on a pre-existing
+    /// `RawRwLock<T>`.
+    ///
+    /// This allows creating a `RwLock<T>` in a constant context on stable
+    /// Rust.
+    ///
+    /// This method is a legacy alias for [`from_raw`](Self::from_raw).
+    #[inline]
+    pub const fn const_new(raw_rwlock: R, val: T) -> RwLock<R, T> {
+        Self::from_raw(raw_rwlock, val)
     }
 }
 


### PR DESCRIPTION
Addresses https://github.com/Amanieu/parking_lot/issues/400 by implementing https://github.com/Amanieu/parking_lot/issues/400#issuecomment-1888695827.

This PR adds `from_raw` methods for `lock_api::{Mutex, ReentrantMutex, RwLock}`. These have the same behavior as the existing legacy `const_new` methods.

These methods are useful with `RawMutex`, etc. implementations which don't support `const` initialization.