### PR TITLE
stdarch_wasm_atomic_wait instead of stdsimd

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -49,7 +49,7 @@
         target_family = "wasm",
         target_feature = "atomics"
     ),
-    feature(stdsimd)
+    feature(stdarch_wasm_atomic_wait)
 )]
 
 mod parking_lot;


### PR DESCRIPTION
Should fix #434 

I don't know the context of the change so I might be missing something important. I only know that I tested on nightly and it works.