### PR TITLE
Initial (optional) `triomphe::Arc` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ features = ["arc_lock", "serde", "deadlock_detection"]
 [dependencies]
 parking_lot_core = { path = "core", version = "0.9.0" }
 lock_api = { path = "lock_api", version = "0.4.6" }
+triomphe = { version = "0.1.14", optional = true }
 
 [dev-dependencies]
 rand = "0.8.3"
@@ -37,6 +38,7 @@ deadlock_detection = ["parking_lot_core/deadlock_detection"]
 serde = ["lock_api/serde"]
 send_guard = []
 hardware-lock-elision = []
+triomphe = ["dep:triomphe", "lock_api/triomphe"]
 
 [workspace]
 exclude = ["benchmark"]

--- a/lock_api/Cargo.toml
+++ b/lock_api/Cargo.toml
@@ -17,6 +17,7 @@ rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 [dependencies]
 scopeguard = { version = "1.1.0", default-features = false }
 owning_ref = { version = "0.4.1", optional = true }
+triomphe = { version = "0.1.14", optional = true }
 
 # Optional dependency for supporting serde.  Optional crates automatically
 # create a feature with the same name as the crate, so if you need serde
@@ -31,3 +32,4 @@ default = ["atomic_usize"]
 nightly = []
 arc_lock = []
 atomic_usize = []
+triomphe = ["dep:triomphe"]

--- a/lock_api/src/lib.rs
+++ b/lock_api/src/lib.rs
@@ -89,12 +89,18 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
+#![cfg_attr(
+    all(feature = "arc_lock", feature = "triomphe"),
+    feature(arbitrary_self_types)
+)]
 
 #[macro_use]
 extern crate scopeguard;
 
-#[cfg(feature = "arc_lock")]
+#[cfg(all(feature = "arc_lock", not(feature = "triomphe")))]
 extern crate alloc;
+#[cfg(all(feature = "arc_lock", feature = "triomphe"))]
+extern crate triomphe;
 
 /// Marker type which indicates that the Guard type for a lock is `Send`.
 pub struct GuardSend(());

--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -11,12 +11,14 @@ use core::marker::PhantomData;
 use core::mem;
 use core::ops::{Deref, DerefMut};
 
-#[cfg(feature = "arc_lock")]
+#[cfg(all(feature = "arc_lock", not(feature = "triomphe")))]
 use alloc::sync::Arc;
 #[cfg(feature = "arc_lock")]
 use core::mem::ManuallyDrop;
 #[cfg(feature = "arc_lock")]
 use core::ptr;
+#[cfg(all(feature = "arc_lock", feature = "triomphe"))]
+use triomphe::Arc;
 
 #[cfg(feature = "owning_ref")]
 use owning_ref::StableAddress;

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -19,12 +19,14 @@ use core::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
-#[cfg(feature = "arc_lock")]
+#[cfg(all(feature = "arc_lock", not(feature = "triomphe")))]
 use alloc::sync::Arc;
 #[cfg(feature = "arc_lock")]
 use core::mem::ManuallyDrop;
 #[cfg(feature = "arc_lock")]
 use core::ptr;
+#[cfg(all(feature = "arc_lock", feature = "triomphe"))]
+use triomphe::Arc;
 
 #[cfg(feature = "owning_ref")]
 use owning_ref::StableAddress;

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -11,12 +11,14 @@ use core::marker::PhantomData;
 use core::mem;
 use core::ops::{Deref, DerefMut};
 
-#[cfg(feature = "arc_lock")]
+#[cfg(all(feature = "arc_lock", not(feature = "triomphe")))]
 use alloc::sync::Arc;
 #[cfg(feature = "arc_lock")]
 use core::mem::ManuallyDrop;
 #[cfg(feature = "arc_lock")]
 use core::ptr;
+#[cfg(all(feature = "arc_lock", feature = "triomphe"))]
+use triomphe::Arc;
 
 #[cfg(feature = "owning_ref")]
 use owning_ref::StableAddress;

--- a/src/condvar.rs
+++ b/src/condvar.rs
@@ -526,12 +526,15 @@ impl fmt::Debug for Condvar {
 mod tests {
     use crate::{Condvar, Mutex, MutexGuard};
     use std::sync::mpsc::channel;
+    #[cfg(not(feature = "triomphe"))]
     use std::sync::Arc;
     use std::thread;
     use std::thread::sleep;
     use std::thread::JoinHandle;
     use std::time::Duration;
     use std::time::Instant;
+    #[cfg(feature = "triomphe")]
+    use triomphe::Arc;
 
     #[test]
     fn smoke() {
@@ -916,7 +919,11 @@ mod tests {
 #[cfg(test)]
 mod webkit_queue_test {
     use crate::{Condvar, Mutex, MutexGuard};
-    use std::{collections::VecDeque, sync::Arc, thread, time::Duration};
+    #[cfg(not(feature = "triomphe"))]
+    use std::sync::Arc;
+    use std::{collections::VecDeque, thread, time::Duration};
+    #[cfg(feature = "triomphe")]
+    use triomphe::Arc;
 
     #[derive(Clone, Copy)]
     enum Timeout {

--- a/src/fair_mutex.rs
+++ b/src/fair_mutex.rs
@@ -104,8 +104,11 @@ mod tests {
     use crate::FairMutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::mpsc::channel;
+    #[cfg(not(feature = "triomphe"))]
     use std::sync::Arc;
     use std::thread;
+    #[cfg(feature = "triomphe")]
+    use triomphe::Arc;
 
     #[cfg(feature = "serde")]
     use bincode::{deserialize, serialize};

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -113,8 +113,11 @@ mod tests {
     use crate::{Condvar, Mutex};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::mpsc::channel;
+    #[cfg(not(feature = "triomphe"))]
     use std::sync::Arc;
     use std::thread;
+    #[cfg(feature = "triomphe")]
+    use triomphe::Arc;
 
     #[cfg(feature = "serde")]
     use bincode::{deserialize, serialize};

--- a/src/remutex.rs
+++ b/src/remutex.rs
@@ -74,8 +74,11 @@ mod tests {
     use crate::ReentrantMutexGuard;
     use std::cell::RefCell;
     use std::sync::mpsc::channel;
+    #[cfg(not(feature = "triomphe"))]
     use std::sync::Arc;
     use std::thread;
+    #[cfg(feature = "triomphe")]
+    use triomphe::Arc;
 
     #[cfg(feature = "serde")]
     use bincode::{deserialize, serialize};

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -130,9 +130,12 @@ mod tests {
     use rand::Rng;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::mpsc::channel;
+    #[cfg(not(feature = "triomphe"))]
     use std::sync::Arc;
     use std::thread;
     use std::time::Duration;
+    #[cfg(feature = "triomphe")]
+    use triomphe::Arc;
 
     #[cfg(feature = "serde")]
     use bincode::{deserialize, serialize};
@@ -642,7 +645,12 @@ mod tests {
     #[test]
     #[cfg(feature = "arc_lock")]
     fn test_issue_430() {
-        let lock = std::sync::Arc::new(RwLock::new(0));
+        #[cfg(not(feature = "triomphe"))]
+        use std::sync::Arc;
+        #[cfg(feature = "triomphe")]
+        use triomphe::Arc;
+
+        let lock = Arc::new(RwLock::new(0));
 
         let mut rl = lock.upgradable_read_arc();
 


### PR DESCRIPTION
See subject.

This adds support for swapping out `std::sync::Arc` (`parking_lot`) resp. `alloc::sync::Arc` (`lock_api`) for [`triomphe`](https://docs.rs/triomphe/latest/triomphe/)`::`[`Arc`](https://docs.rs/triomphe/latest/triomphe/struct.Arc.html).

Both crates had a `triomphe` feature added but alternatively I could put this behind a `triomphe_arc_lock` feature instead.
Or even `arc_de_triomphe_lock`, to fully express the presumed naming intent of that crate. :wink:

I need this for a project I'm working on so I thought I may as well open a PR, in case this is useful. If not, just close the PR and ignore.
