### PR TITLE
Add `#[track_caller]` for better panic messages for fallible locks using `lock_api`.

### DIFF
--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -219,6 +219,7 @@ impl<R: RawMutex, T: ?Sized> Mutex<R, T> {
     /// Attempts to lock a mutex in the thread which already holds the lock will
     /// result in a deadlock.
     #[inline]
+    #[track_caller]
     pub fn lock(&self) -> MutexGuard<'_, R, T> {
         self.raw.lock();
         // SAFETY: The lock is held, as required.
@@ -326,6 +327,7 @@ impl<R: RawMutex, T: ?Sized> Mutex<R, T> {
     /// and the resulting mutex guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
+    #[track_caller]
     pub fn lock_arc(self: &Arc<Self>) -> ArcMutexGuard<R, T> {
         self.raw.lock();
         // SAFETY: the locking guarantee is upheld

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -337,6 +337,7 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     ///
     /// This function does not block.
     #[inline]
+    #[track_caller]
     pub fn try_lock(&self) -> Option<ReentrantMutexGuard<'_, R, G, T>> {
         if self.raw.try_lock() {
             // SAFETY: The lock is held, as required.
@@ -357,12 +358,14 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
 
     /// Checks whether the mutex is currently locked.
     #[inline]
+    #[track_caller]
     pub fn is_locked(&self) -> bool {
         self.raw.is_locked()
     }
 
     /// Checks whether the mutex is currently held by the current thread.
     #[inline]
+    #[track_caller]
     pub fn is_owned_by_current_thread(&self) -> bool {
         self.raw.is_owned_by_current_thread()
     }
@@ -379,6 +382,7 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     /// `ReentrantMutexGuard` but that guard has be discarded using `mem::forget`.
     /// Behavior is undefined if a mutex is unlocked when not locked.
     #[inline]
+    #[track_caller]
     pub unsafe fn force_unlock(&self) {
         self.raw.unlock();
     }
@@ -450,6 +454,7 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     /// of an `Arc` and the resulting mutex guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
+    #[track_caller]
     pub fn try_lock_arc(self: &Arc<Self>) -> Option<ArcReentrantMutexGuard<R, G, T>> {
         if self.raw.try_lock() {
             // SAFETY: locking guarantee is upheld
@@ -473,6 +478,7 @@ impl<R: RawMutexFair, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     /// `ReentrantMutexGuard` but that guard has be discarded using `mem::forget`.
     /// Behavior is undefined if a mutex is unlocked when not locked.
     #[inline]
+    #[track_caller]
     pub unsafe fn force_unlock_fair(&self) {
         self.raw.unlock_fair();
     }
@@ -485,6 +491,7 @@ impl<R: RawMutexTimed, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     /// `None` is returned. Otherwise, an RAII guard is returned. The lock will
     /// be unlocked when the guard is dropped.
     #[inline]
+    #[track_caller]
     pub fn try_lock_for(&self, timeout: R::Duration) -> Option<ReentrantMutexGuard<'_, R, G, T>> {
         if self.raw.try_lock_for(timeout) {
             // SAFETY: The lock is held, as required.
@@ -500,6 +507,7 @@ impl<R: RawMutexTimed, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     /// `None` is returned. Otherwise, an RAII guard is returned. The lock will
     /// be unlocked when the guard is dropped.
     #[inline]
+    #[track_caller]
     pub fn try_lock_until(&self, timeout: R::Instant) -> Option<ReentrantMutexGuard<'_, R, G, T>> {
         if self.raw.try_lock_until(timeout) {
             // SAFETY: The lock is held, as required.
@@ -515,6 +523,7 @@ impl<R: RawMutexTimed, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     /// inside of an `Arc` and the resulting mutex guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
+    #[track_caller]
     pub fn try_lock_arc_for(
         self: &Arc<Self>,
         timeout: R::Duration,
@@ -533,6 +542,7 @@ impl<R: RawMutexTimed, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     /// inside of an `Arc` and the resulting mutex guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
+    #[track_caller]
     pub fn try_lock_arc_until(
         self: &Arc<Self>,
         timeout: R::Instant,
@@ -695,6 +705,7 @@ impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> ReentrantMutexGu
     /// This is safe because `&mut` guarantees that there exist no other
     /// references to the data protected by the mutex.
     #[inline]
+    #[track_caller]
     pub fn unlocked<F, U>(s: &mut Self, f: F) -> U
     where
         F: FnOnce() -> U,
@@ -724,6 +735,7 @@ impl<'a, R: RawMutexFair + 'a, G: GetThreadId + 'a, T: ?Sized + 'a>
     /// the lock to pass on to a waiting thread if there is one. This is done by
     /// using this method instead of dropping the `ReentrantMutexGuard` normally.
     #[inline]
+    #[track_caller]
     pub fn unlock_fair(s: Self) {
         // Safety: A ReentrantMutexGuard always holds the lock
         unsafe {
@@ -739,6 +751,7 @@ impl<'a, R: RawMutexFair + 'a, G: GetThreadId + 'a, T: ?Sized + 'a>
     /// This is safe because `&mut` guarantees that there exist no other
     /// references to the data protected by the mutex.
     #[inline]
+    #[track_caller]
     pub fn unlocked_fair<F, U>(s: &mut Self, f: F) -> U
     where
         F: FnOnce() -> U,
@@ -757,6 +770,7 @@ impl<'a, R: RawMutexFair + 'a, G: GetThreadId + 'a, T: ?Sized + 'a>
     /// by `lock`, however it can be much more efficient in the case where there
     /// are no waiting threads.
     #[inline]
+    #[track_caller]
     pub fn bump(s: &mut Self) {
         // Safety: A ReentrantMutexGuard always holds the lock
         unsafe {
@@ -834,6 +848,7 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> ArcReentrantMutexGuard<R, G, T> {
     /// This is safe because `&mut` guarantees that there exist no other
     /// references to the data protected by the mutex.
     #[inline]
+    #[track_caller]
     pub fn unlocked<F, U>(s: &mut Self, f: F) -> U
     where
         F: FnOnce() -> U,
@@ -853,6 +868,7 @@ impl<R: RawMutexFair, G: GetThreadId, T: ?Sized> ArcReentrantMutexGuard<R, G, T>
     ///
     /// This is functionally identical to the `unlock_fair` method on [`ReentrantMutexGuard`].
     #[inline]
+    #[track_caller]
     pub fn unlock_fair(s: Self) {
         // Safety: A ReentrantMutexGuard always holds the lock
         unsafe {
@@ -868,6 +884,7 @@ impl<R: RawMutexFair, G: GetThreadId, T: ?Sized> ArcReentrantMutexGuard<R, G, T>
     ///
     /// This is functionally identical to the `unlocked_fair` method on [`ReentrantMutexGuard`].
     #[inline]
+    #[track_caller]
     pub fn unlocked_fair<F, U>(s: &mut Self, f: F) -> U
     where
         F: FnOnce() -> U,
@@ -884,6 +901,7 @@ impl<R: RawMutexFair, G: GetThreadId, T: ?Sized> ArcReentrantMutexGuard<R, G, T>
     ///
     /// This is functionally equivalent to the `bump` method on [`ReentrantMutexGuard`].
     #[inline]
+    #[track_caller]
     pub fn bump(s: &mut Self) {
         // Safety: A ReentrantMutexGuard always holds the lock
         unsafe {
@@ -1005,6 +1023,7 @@ impl<'a, R: RawMutexFair + 'a, G: GetThreadId + 'a, T: ?Sized + 'a>
     /// the lock to pass on to a waiting thread if there is one. This is done by
     /// using this method instead of dropping the `ReentrantMutexGuard` normally.
     #[inline]
+    #[track_caller]
     pub fn unlock_fair(s: Self) {
         // Safety: A MappedReentrantMutexGuard always holds the lock
         unsafe {

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -322,6 +322,7 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     /// returned to allow scoped unlock of the lock. When the guard goes out of
     /// scope, the mutex will be unlocked.
     #[inline]
+    #[track_caller]
     pub fn lock(&self) -> ReentrantMutexGuard<'_, R, G, T> {
         self.raw.lock();
         // SAFETY: The lock is held, as required.
@@ -436,6 +437,7 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     /// `Arc` and the resulting mutex guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
+    #[track_caller]
     pub fn lock_arc(self: &Arc<Self>) -> ArcReentrantMutexGuard<R, G, T> {
         self.raw.lock();
         // SAFETY: locking guarantee is upheld

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -464,6 +464,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     /// Returns an RAII guard which will release this thread's shared access
     /// once it is dropped.
     #[inline]
+    #[track_caller]
     pub fn read(&self) -> RwLockReadGuard<'_, R, T> {
         self.raw.lock_shared();
         // SAFETY: The lock is held, as required.
@@ -478,6 +479,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     ///
     /// This function does not block.
     #[inline]
+    #[track_caller]
     pub fn try_read(&self) -> Option<RwLockReadGuard<'_, R, T>> {
         if self.raw.try_lock_shared() {
             // SAFETY: The lock is held, as required.
@@ -496,6 +498,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     /// Returns an RAII guard which will drop the write access of this `RwLock`
     /// when dropped.
     #[inline]
+    #[track_caller]
     pub fn write(&self) -> RwLockWriteGuard<'_, R, T> {
         self.raw.lock_exclusive();
         // SAFETY: The lock is held, as required.
@@ -510,6 +513,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     ///
     /// This function does not block.
     #[inline]
+    #[track_caller]
     pub fn try_write(&self) -> Option<RwLockWriteGuard<'_, R, T>> {
         if self.raw.try_lock_exclusive() {
             // SAFETY: The lock is held, as required.
@@ -530,12 +534,14 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
 
     /// Checks whether this `RwLock` is currently locked in any way.
     #[inline]
+    #[track_caller]
     pub fn is_locked(&self) -> bool {
         self.raw.is_locked()
     }
 
     /// Check if this `RwLock` is currently exclusively locked.
     #[inline]
+    #[track_caller]
     pub fn is_locked_exclusive(&self) -> bool {
         self.raw.is_locked_exclusive()
     }
@@ -552,6 +558,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     /// `RwLockReadGuard` but that guard has be discarded using `mem::forget`.
     /// Behavior is undefined if a rwlock is read-unlocked when not read-locked.
     #[inline]
+    #[track_caller]
     pub unsafe fn force_unlock_read(&self) {
         self.raw.unlock_shared();
     }
@@ -568,6 +575,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     /// `RwLockWriteGuard` but that guard has be discarded using `mem::forget`.
     /// Behavior is undefined if a rwlock is write-unlocked when not write-locked.
     #[inline]
+    #[track_caller]
     pub unsafe fn force_unlock_write(&self) {
         self.raw.unlock_exclusive();
     }
@@ -644,6 +652,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     /// and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
+    #[track_caller]
     pub fn read_arc(self: &Arc<Self>) -> ArcRwLockReadGuard<R, T> {
         self.raw.lock_shared();
         // SAFETY: locking guarantee is upheld
@@ -656,6 +665,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     /// `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
+    #[track_caller]
     pub fn try_read_arc(self: &Arc<Self>) -> Option<ArcRwLockReadGuard<R, T>> {
         if self.raw.try_lock_shared() {
             // SAFETY: locking guarantee is upheld
@@ -671,6 +681,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     /// and the resulting write guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
+    #[track_caller]
     pub fn write_arc(self: &Arc<Self>) -> ArcRwLockWriteGuard<R, T> {
         self.raw.lock_exclusive();
         // SAFETY: locking guarantee is upheld
@@ -683,6 +694,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     /// `Arc` and the resulting write guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
+    #[track_caller]
     pub fn try_write_arc(self: &Arc<Self>) -> Option<ArcRwLockWriteGuard<R, T>> {
         if self.raw.try_lock_exclusive() {
             // SAFETY: locking guarantee is upheld
@@ -706,6 +718,7 @@ impl<R: RawRwLockFair, T: ?Sized> RwLock<R, T> {
     /// `RwLockReadGuard` but that guard has be discarded using `mem::forget`.
     /// Behavior is undefined if a rwlock is read-unlocked when not read-locked.
     #[inline]
+    #[track_caller]
     pub unsafe fn force_unlock_read_fair(&self) {
         self.raw.unlock_shared_fair();
     }
@@ -722,6 +735,7 @@ impl<R: RawRwLockFair, T: ?Sized> RwLock<R, T> {
     /// `RwLockWriteGuard` but that guard has be discarded using `mem::forget`.
     /// Behavior is undefined if a rwlock is write-unlocked when not write-locked.
     #[inline]
+    #[track_caller]
     pub unsafe fn force_unlock_write_fair(&self) {
         self.raw.unlock_exclusive_fair();
     }
@@ -735,6 +749,7 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     /// `None` is returned. Otherwise, an RAII guard is returned which will
     /// release the shared access when it is dropped.
     #[inline]
+    #[track_caller]
     pub fn try_read_for(&self, timeout: R::Duration) -> Option<RwLockReadGuard<'_, R, T>> {
         if self.raw.try_lock_shared_for(timeout) {
             // SAFETY: The lock is held, as required.
@@ -751,6 +766,7 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     /// `None` is returned. Otherwise, an RAII guard is returned which will
     /// release the shared access when it is dropped.
     #[inline]
+    #[track_caller]
     pub fn try_read_until(&self, timeout: R::Instant) -> Option<RwLockReadGuard<'_, R, T>> {
         if self.raw.try_lock_shared_until(timeout) {
             // SAFETY: The lock is held, as required.
@@ -767,6 +783,7 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     /// `None` is returned. Otherwise, an RAII guard is returned which will
     /// release the exclusive access when it is dropped.
     #[inline]
+    #[track_caller]
     pub fn try_write_for(&self, timeout: R::Duration) -> Option<RwLockWriteGuard<'_, R, T>> {
         if self.raw.try_lock_exclusive_for(timeout) {
             // SAFETY: The lock is held, as required.
@@ -783,6 +800,7 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     /// `None` is returned. Otherwise, an RAII guard is returned which will
     /// release the exclusive access when it is dropped.
     #[inline]
+    #[track_caller]
     pub fn try_write_until(&self, timeout: R::Instant) -> Option<RwLockWriteGuard<'_, R, T>> {
         if self.raw.try_lock_exclusive_until(timeout) {
             // SAFETY: The lock is held, as required.
@@ -798,6 +816,7 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     /// `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
+    #[track_caller]
     pub fn try_read_arc_for(
         self: &Arc<Self>,
         timeout: R::Duration,
@@ -816,6 +835,7 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     /// an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
+    #[track_caller]
     pub fn try_read_arc_until(
         self: &Arc<Self>,
         timeout: R::Instant,
@@ -834,6 +854,7 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     /// an `Arc` and the resulting write guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
+    #[track_caller]
     pub fn try_write_arc_for(
         self: &Arc<Self>,
         timeout: R::Duration,
@@ -852,6 +873,7 @@ impl<R: RawRwLockTimed, T: ?Sized> RwLock<R, T> {
     /// an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
+    #[track_caller]
     pub fn try_write_arc_until(
         self: &Arc<Self>,
         timeout: R::Instant,
@@ -882,6 +904,7 @@ impl<R: RawRwLockRecursive, T: ?Sized> RwLock<R, T> {
     /// Returns an RAII guard which will release this thread's shared access
     /// once it is dropped.
     #[inline]
+    #[track_caller]
     pub fn read_recursive(&self) -> RwLockReadGuard<'_, R, T> {
         self.raw.lock_shared_recursive();
         // SAFETY: The lock is held, as required.
@@ -899,6 +922,7 @@ impl<R: RawRwLockRecursive, T: ?Sized> RwLock<R, T> {
     ///
     /// This function does not block.
     #[inline]
+    #[track_caller]
     pub fn try_read_recursive(&self) -> Option<RwLockReadGuard<'_, R, T>> {
         if self.raw.try_lock_shared_recursive() {
             // SAFETY: The lock is held, as required.
@@ -914,6 +938,7 @@ impl<R: RawRwLockRecursive, T: ?Sized> RwLock<R, T> {
     /// an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
+    #[track_caller]
     pub fn read_arc_recursive(self: &Arc<Self>) -> ArcRwLockReadGuard<R, T> {
         self.raw.lock_shared_recursive();
         // SAFETY: locking guarantee is upheld
@@ -926,6 +951,7 @@ impl<R: RawRwLockRecursive, T: ?Sized> RwLock<R, T> {
     /// of an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
+    #[track_caller]
     pub fn try_read_recursive_arc(self: &Arc<Self>) -> Option<ArcRwLockReadGuard<R, T>> {
         if self.raw.try_lock_shared_recursive() {
             // SAFETY: locking guarantee is upheld
@@ -948,6 +974,7 @@ impl<R: RawRwLockRecursiveTimed, T: ?Sized> RwLock<R, T> {
     /// lock is held at the time of the call. See the documentation for
     /// `read_recursive` for details.
     #[inline]
+    #[track_caller]
     pub fn try_read_recursive_for(
         &self,
         timeout: R::Duration,
@@ -967,6 +994,7 @@ impl<R: RawRwLockRecursiveTimed, T: ?Sized> RwLock<R, T> {
     /// `None` is returned. Otherwise, an RAII guard is returned which will
     /// release the shared access when it is dropped.
     #[inline]
+    #[track_caller]
     pub fn try_read_recursive_until(
         &self,
         timeout: R::Instant,
@@ -985,6 +1013,7 @@ impl<R: RawRwLockRecursiveTimed, T: ?Sized> RwLock<R, T> {
     /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
+    #[track_caller]
     pub fn try_read_arc_recursive_for(
         self: &Arc<Self>,
         timeout: R::Duration,
@@ -1003,6 +1032,7 @@ impl<R: RawRwLockRecursiveTimed, T: ?Sized> RwLock<R, T> {
     /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
+    #[track_caller]
     pub fn try_read_arc_recursive_until(
         self: &Arc<Self>,
         timeout: R::Instant,
@@ -1044,6 +1074,7 @@ impl<R: RawRwLockUpgrade, T: ?Sized> RwLock<R, T> {
     /// Returns an RAII guard which will release this thread's shared access
     /// once it is dropped.
     #[inline]
+    #[track_caller]
     pub fn upgradable_read(&self) -> RwLockUpgradableReadGuard<'_, R, T> {
         self.raw.lock_upgradable();
         // SAFETY: The lock is held, as required.
@@ -1058,6 +1089,7 @@ impl<R: RawRwLockUpgrade, T: ?Sized> RwLock<R, T> {
     ///
     /// This function does not block.
     #[inline]
+    #[track_caller]
     pub fn try_upgradable_read(&self) -> Option<RwLockUpgradableReadGuard<'_, R, T>> {
         if self.raw.try_lock_upgradable() {
             // SAFETY: The lock is held, as required.
@@ -1093,6 +1125,7 @@ impl<R: RawRwLockUpgrade, T: ?Sized> RwLock<R, T> {
     /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
+    #[track_caller]
     pub fn upgradable_read_arc(self: &Arc<Self>) -> ArcRwLockUpgradableReadGuard<R, T> {
         self.raw.lock_upgradable();
         // SAFETY: locking guarantee is upheld
@@ -1105,6 +1138,7 @@ impl<R: RawRwLockUpgrade, T: ?Sized> RwLock<R, T> {
     /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
+    #[track_caller]
     pub fn try_upgradable_read_arc(self: &Arc<Self>) -> Option<ArcRwLockUpgradableReadGuard<R, T>> {
         if self.raw.try_lock_upgradable() {
             // SAFETY: locking guarantee is upheld
@@ -1123,6 +1157,7 @@ impl<R: RawRwLockUpgradeTimed, T: ?Sized> RwLock<R, T> {
     /// `None` is returned. Otherwise, an RAII guard is returned which will
     /// release the shared access when it is dropped.
     #[inline]
+    #[track_caller]
     pub fn try_upgradable_read_for(
         &self,
         timeout: R::Duration,
@@ -1142,6 +1177,7 @@ impl<R: RawRwLockUpgradeTimed, T: ?Sized> RwLock<R, T> {
     /// `None` is returned. Otherwise, an RAII guard is returned which will
     /// release the shared access when it is dropped.
     #[inline]
+    #[track_caller]
     pub fn try_upgradable_read_until(
         &self,
         timeout: R::Instant,
@@ -1160,6 +1196,7 @@ impl<R: RawRwLockUpgradeTimed, T: ?Sized> RwLock<R, T> {
     /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
+    #[track_caller]
     pub fn try_upgradable_read_arc_for(
         self: &Arc<Self>,
         timeout: R::Duration,
@@ -1178,6 +1215,7 @@ impl<R: RawRwLockUpgradeTimed, T: ?Sized> RwLock<R, T> {
     /// inside of an `Arc` and the resulting read guard has no lifetime requirements.
     #[cfg(feature = "arc_lock")]
     #[inline]
+    #[track_caller]
     pub fn try_upgradable_read_arc_until(
         self: &Arc<Self>,
         timeout: R::Instant,
@@ -1291,6 +1329,7 @@ impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> RwLockReadGuard<'a, R, T> {
     /// This is safe because `&mut` guarantees that there exist no other
     /// references to the data protected by the `RwLock`.
     #[inline]
+    #[track_caller]
     pub fn unlocked<F, U>(s: &mut Self, f: F) -> U
     where
         F: FnOnce() -> U,
@@ -1318,6 +1357,7 @@ impl<'a, R: RawRwLockFair + 'a, T: ?Sized + 'a> RwLockReadGuard<'a, R, T> {
     /// the lock to pass on to a waiting thread if there is one. This is done by
     /// using this method instead of dropping the `RwLockReadGuard` normally.
     #[inline]
+    #[track_caller]
     pub fn unlock_fair(s: Self) {
         // Safety: An RwLockReadGuard always holds a shared lock.
         unsafe {
@@ -1333,6 +1373,7 @@ impl<'a, R: RawRwLockFair + 'a, T: ?Sized + 'a> RwLockReadGuard<'a, R, T> {
     /// This is safe because `&mut` guarantees that there exist no other
     /// references to the data protected by the `RwLock`.
     #[inline]
+    #[track_caller]
     pub fn unlocked_fair<F, U>(s: &mut Self, f: F) -> U
     where
         F: FnOnce() -> U,
@@ -1351,6 +1392,7 @@ impl<'a, R: RawRwLockFair + 'a, T: ?Sized + 'a> RwLockReadGuard<'a, R, T> {
     /// by `read`, however it can be much more efficient in the case where there
     /// are no waiting threads.
     #[inline]
+    #[track_caller]
     pub fn bump(s: &mut Self) {
         // Safety: An RwLockReadGuard always holds a shared lock.
         unsafe {
@@ -1417,6 +1459,7 @@ impl<R: RawRwLock, T: ?Sized> ArcRwLockReadGuard<R, T> {
     ///
     /// This is functionally identical to the `unlocked` method on [`RwLockReadGuard`].
     #[inline]
+    #[track_caller]
     pub fn unlocked<F, U>(s: &mut Self, f: F) -> U
     where
         F: FnOnce() -> U,
@@ -1436,6 +1479,7 @@ impl<R: RawRwLockFair, T: ?Sized> ArcRwLockReadGuard<R, T> {
     ///
     /// This is functionally identical to the `unlock_fair` method on [`RwLockReadGuard`].
     #[inline]
+    #[track_caller]
     pub fn unlock_fair(s: Self) {
         // Safety: An RwLockReadGuard always holds a shared lock.
         unsafe {
@@ -1451,6 +1495,7 @@ impl<R: RawRwLockFair, T: ?Sized> ArcRwLockReadGuard<R, T> {
     ///
     /// This is functionally identical to the `unlocked_fair` method on [`RwLockReadGuard`].
     #[inline]
+    #[track_caller]
     pub fn unlocked_fair<F, U>(s: &mut Self, f: F) -> U
     where
         F: FnOnce() -> U,
@@ -1467,6 +1512,7 @@ impl<R: RawRwLockFair, T: ?Sized> ArcRwLockReadGuard<R, T> {
     ///
     /// This is functionally identical to the `bump` method on [`RwLockReadGuard`].
     #[inline]
+    #[track_caller]
     pub fn bump(s: &mut Self) {
         // Safety: An RwLockReadGuard always holds a shared lock.
         unsafe {
@@ -1581,6 +1627,7 @@ impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> RwLockWriteGuard<'a, R, T> {
     /// This is safe because `&mut` guarantees that there exist no other
     /// references to the data protected by the `RwLock`.
     #[inline]
+    #[track_caller]
     pub fn unlocked<F, U>(s: &mut Self, f: F) -> U
     where
         F: FnOnce() -> U,
@@ -1601,6 +1648,7 @@ impl<'a, R: RawRwLockDowngrade + 'a, T: ?Sized + 'a> RwLockWriteGuard<'a, R, T> 
     /// Note that if there are any writers currently waiting to take the lock
     /// then other readers may not be able to acquire the lock even if it was
     /// downgraded.
+    #[track_caller]
     pub fn downgrade(s: Self) -> RwLockReadGuard<'a, R, T> {
         // Safety: An RwLockWriteGuard always holds an exclusive lock.
         unsafe {
@@ -1622,6 +1670,7 @@ impl<'a, R: RawRwLockUpgradeDowngrade + 'a, T: ?Sized + 'a> RwLockWriteGuard<'a,
     /// Note that if there are any writers currently waiting to take the lock
     /// then other readers may not be able to acquire the lock even if it was
     /// downgraded.
+    #[track_caller]
     pub fn downgrade_to_upgradable(s: Self) -> RwLockUpgradableReadGuard<'a, R, T> {
         // Safety: An RwLockWriteGuard always holds an exclusive lock.
         unsafe {
@@ -1650,6 +1699,7 @@ impl<'a, R: RawRwLockFair + 'a, T: ?Sized + 'a> RwLockWriteGuard<'a, R, T> {
     /// the lock to pass on to a waiting thread if there is one. This is done by
     /// using this method instead of dropping the `RwLockWriteGuard` normally.
     #[inline]
+    #[track_caller]
     pub fn unlock_fair(s: Self) {
         // Safety: An RwLockWriteGuard always holds an exclusive lock.
         unsafe {
@@ -1665,6 +1715,7 @@ impl<'a, R: RawRwLockFair + 'a, T: ?Sized + 'a> RwLockWriteGuard<'a, R, T> {
     /// This is safe because `&mut` guarantees that there exist no other
     /// references to the data protected by the `RwLock`.
     #[inline]
+    #[track_caller]
     pub fn unlocked_fair<F, U>(s: &mut Self, f: F) -> U
     where
         F: FnOnce() -> U,
@@ -1683,6 +1734,7 @@ impl<'a, R: RawRwLockFair + 'a, T: ?Sized + 'a> RwLockWriteGuard<'a, R, T> {
     /// by `write`, however it can be much more efficient in the case where there
     /// are no waiting threads.
     #[inline]
+    #[track_caller]
     pub fn bump(s: &mut Self) {
         // Safety: An RwLockWriteGuard always holds an exclusive lock.
         unsafe {
@@ -1755,6 +1807,7 @@ impl<R: RawRwLock, T: ?Sized> ArcRwLockWriteGuard<R, T> {
     ///
     /// This is functionally equivalent to the `unlocked` method on [`RwLockWriteGuard`].
     #[inline]
+    #[track_caller]
     pub fn unlocked<F, U>(s: &mut Self, f: F) -> U
     where
         F: FnOnce() -> U,
@@ -1774,6 +1827,7 @@ impl<R: RawRwLockDowngrade, T: ?Sized> ArcRwLockWriteGuard<R, T> {
     /// writers to take exclusive access of the lock in the meantime.
     ///
     /// This is functionally equivalent to the `downgrade` method on [`RwLockWriteGuard`].
+    #[track_caller]
     pub fn downgrade(s: Self) -> ArcRwLockReadGuard<R, T> {
         // Safety: An RwLockWriteGuard always holds an exclusive lock.
         unsafe {
@@ -1797,6 +1851,7 @@ impl<R: RawRwLockUpgradeDowngrade, T: ?Sized> ArcRwLockWriteGuard<R, T> {
     /// writers to take exclusive access of the lock in the meantime.
     ///
     /// This is functionally identical to the `downgrade_to_upgradable` method on [`RwLockWriteGuard`].
+    #[track_caller]
     pub fn downgrade_to_upgradable(s: Self) -> ArcRwLockUpgradableReadGuard<R, T> {
         // Safety: An RwLockWriteGuard always holds an exclusive lock.
         unsafe {
@@ -1820,6 +1875,7 @@ impl<R: RawRwLockFair, T: ?Sized> ArcRwLockWriteGuard<R, T> {
     ///
     /// This is functionally equivalent to the `unlock_fair` method on [`RwLockWriteGuard`].
     #[inline]
+    #[track_caller]
     pub fn unlock_fair(s: Self) {
         // Safety: An RwLockWriteGuard always holds an exclusive lock.
         unsafe {
@@ -1835,6 +1891,7 @@ impl<R: RawRwLockFair, T: ?Sized> ArcRwLockWriteGuard<R, T> {
     ///
     /// This is functionally equivalent to the `unlocked_fair` method on [`RwLockWriteGuard`].
     #[inline]
+    #[track_caller]
     pub fn unlocked_fair<F, U>(s: &mut Self, f: F) -> U
     where
         F: FnOnce() -> U,
@@ -1851,6 +1908,7 @@ impl<R: RawRwLockFair, T: ?Sized> ArcRwLockWriteGuard<R, T> {
     ///
     /// This method is functionally equivalent to the `bump` method on [`RwLockWriteGuard`].
     #[inline]
+    #[track_caller]
     pub fn bump(s: &mut Self) {
         // Safety: An RwLockWriteGuard always holds an exclusive lock.
         unsafe {
@@ -1926,6 +1984,7 @@ impl<'a, R: RawRwLockUpgrade + 'a, T: ?Sized + 'a> RwLockUpgradableReadGuard<'a,
     /// This is safe because `&mut` guarantees that there exist no other
     /// references to the data protected by the `RwLock`.
     #[inline]
+    #[track_caller]
     pub fn unlocked<F, U>(s: &mut Self, f: F) -> U
     where
         F: FnOnce() -> U,
@@ -1940,6 +1999,7 @@ impl<'a, R: RawRwLockUpgrade + 'a, T: ?Sized + 'a> RwLockUpgradableReadGuard<'a,
 
     /// Atomically upgrades an upgradable read lock lock into an exclusive write lock,
     /// blocking the current thread until it can be acquired.
+    #[track_caller]
     pub fn upgrade(s: Self) -> RwLockWriteGuard<'a, R, T> {
         // Safety: An RwLockUpgradableReadGuard always holds an upgradable lock.
         unsafe {
@@ -1956,6 +2016,7 @@ impl<'a, R: RawRwLockUpgrade + 'a, T: ?Sized + 'a> RwLockUpgradableReadGuard<'a,
     /// Tries to atomically upgrade an upgradable read lock into an exclusive write lock.
     ///
     /// If the access could not be granted at this time, then the current guard is returned.
+    #[track_caller]
     pub fn try_upgrade(s: Self) -> Result<RwLockWriteGuard<'a, R, T>, Self> {
         // Safety: An RwLockUpgradableReadGuard always holds an upgradable lock.
         if unsafe { s.rwlock.raw.try_upgrade() } {
@@ -1985,6 +2046,7 @@ impl<'a, R: RawRwLockUpgradeFair + 'a, T: ?Sized + 'a> RwLockUpgradableReadGuard
     /// the lock to pass on to a waiting thread if there is one. This is done by
     /// using this method instead of dropping the `RwLockUpgradableReadGuard` normally.
     #[inline]
+    #[track_caller]
     pub fn unlock_fair(s: Self) {
         // Safety: An RwLockUpgradableReadGuard always holds an upgradable lock.
         unsafe {
@@ -2000,6 +2062,7 @@ impl<'a, R: RawRwLockUpgradeFair + 'a, T: ?Sized + 'a> RwLockUpgradableReadGuard
     /// This is safe because `&mut` guarantees that there exist no other
     /// references to the data protected by the `RwLock`.
     #[inline]
+    #[track_caller]
     pub fn unlocked_fair<F, U>(s: &mut Self, f: F) -> U
     where
         F: FnOnce() -> U,
@@ -2018,6 +2081,7 @@ impl<'a, R: RawRwLockUpgradeFair + 'a, T: ?Sized + 'a> RwLockUpgradableReadGuard
     /// by `upgradable_read`, however it can be much more efficient in the case where there
     /// are no waiting threads.
     #[inline]
+    #[track_caller]
     pub fn bump(s: &mut Self) {
         // Safety: An RwLockUpgradableReadGuard always holds an upgradable lock.
         unsafe {
@@ -2034,6 +2098,7 @@ impl<'a, R: RawRwLockUpgradeDowngrade + 'a, T: ?Sized + 'a> RwLockUpgradableRead
     /// Note that if there are any writers currently waiting to take the lock
     /// then other readers may not be able to acquire the lock even if it was
     /// downgraded.
+    #[track_caller]
     pub fn downgrade(s: Self) -> RwLockReadGuard<'a, R, T> {
         // Safety: An RwLockUpgradableReadGuard always holds an upgradable lock.
         unsafe {
@@ -2057,6 +2122,7 @@ impl<'a, R: RawRwLockUpgradeDowngrade + 'a, T: ?Sized + 'a> RwLockUpgradableRead
     ///
     /// This function only requires a mutable reference to the guard, unlike
     /// `upgrade` which takes the guard by value.
+    #[track_caller]
     pub fn with_upgraded<Ret, F: FnOnce(&mut T) -> Ret>(&mut self, f: F) -> Ret {
         unsafe {
             self.rwlock.raw.upgrade();
@@ -2082,6 +2148,7 @@ impl<'a, R: RawRwLockUpgradeDowngrade + 'a, T: ?Sized + 'a> RwLockUpgradableRead
     ///
     /// This function only requires a mutable reference to the guard, unlike
     /// `try_upgrade` which takes the guard by value.
+    #[track_caller]
     pub fn try_with_upgraded<Ret, F: FnOnce(&mut T) -> Ret>(&mut self, f: F) -> Option<Ret> {
         if unsafe { self.rwlock.raw.try_upgrade() } {
             // Safety: We just upgraded the lock, so we have mutable access to the data.
@@ -2104,6 +2171,7 @@ impl<'a, R: RawRwLockUpgradeTimed + 'a, T: ?Sized + 'a> RwLockUpgradableReadGuar
     ///
     /// If the access could not be granted before the timeout expires, then
     /// the current guard is returned.
+    #[track_caller]
     pub fn try_upgrade_for(
         s: Self,
         timeout: R::Duration,
@@ -2127,6 +2195,7 @@ impl<'a, R: RawRwLockUpgradeTimed + 'a, T: ?Sized + 'a> RwLockUpgradableReadGuar
     /// If the access could not be granted before the timeout expires, then
     /// the current guard is returned.
     #[inline]
+    #[track_caller]
     pub fn try_upgrade_until(
         s: Self,
         timeout: R::Instant,
@@ -2160,6 +2229,7 @@ impl<'a, R: RawRwLockUpgradeTimed + RawRwLockUpgradeDowngrade + 'a, T: ?Sized + 
     ///
     /// This function only requires a mutable reference to the guard, unlike
     /// `try_upgrade_for` which takes the guard by value.
+    #[track_caller]
     pub fn try_with_upgraded_for<Ret, F: FnOnce(&mut T) -> Ret>(
         &mut self,
         timeout: R::Duration,
@@ -2191,6 +2261,7 @@ impl<'a, R: RawRwLockUpgradeTimed + RawRwLockUpgradeDowngrade + 'a, T: ?Sized + 
     ///
     /// This function only requires a mutable reference to the guard, unlike
     /// `try_upgrade_until` which takes the guard by value.
+    #[track_caller]
     pub fn try_with_upgraded_until<Ret, F: FnOnce(&mut T) -> Ret>(
         &mut self,
         timeout: R::Instant,
@@ -2274,6 +2345,7 @@ impl<R: RawRwLockUpgrade, T: ?Sized> ArcRwLockUpgradableReadGuard<R, T> {
     ///
     /// This is functionally identical to the `unlocked` method on [`RwLockUpgradableReadGuard`].
     #[inline]
+    #[track_caller]
     pub fn unlocked<F, U>(s: &mut Self, f: F) -> U
     where
         F: FnOnce() -> U,
@@ -2288,6 +2360,7 @@ impl<R: RawRwLockUpgrade, T: ?Sized> ArcRwLockUpgradableReadGuard<R, T> {
 
     /// Atomically upgrades an upgradable read lock lock into an exclusive write lock,
     /// blocking the current thread until it can be acquired.
+    #[track_caller]
     pub fn upgrade(s: Self) -> ArcRwLockWriteGuard<R, T> {
         // Safety: An RwLockUpgradableReadGuard always holds an upgradable lock.
         unsafe {
@@ -2308,6 +2381,7 @@ impl<R: RawRwLockUpgrade, T: ?Sized> ArcRwLockUpgradableReadGuard<R, T> {
     /// Tries to atomically upgrade an upgradable read lock into an exclusive write lock.
     ///
     /// If the access could not be granted at this time, then the current guard is returned.
+    #[track_caller]
     pub fn try_upgrade(s: Self) -> Result<ArcRwLockWriteGuard<R, T>, Self> {
         // Safety: An RwLockUpgradableReadGuard always holds an upgradable lock.
         if unsafe { s.rwlock.raw.try_upgrade() } {
@@ -2331,6 +2405,7 @@ impl<R: RawRwLockUpgradeFair, T: ?Sized> ArcRwLockUpgradableReadGuard<R, T> {
     ///
     /// This is functionally identical to the `unlock_fair` method on [`RwLockUpgradableReadGuard`].
     #[inline]
+    #[track_caller]
     pub fn unlock_fair(s: Self) {
         // Safety: An RwLockUpgradableReadGuard always holds an upgradable lock.
         unsafe {
@@ -2346,6 +2421,7 @@ impl<R: RawRwLockUpgradeFair, T: ?Sized> ArcRwLockUpgradableReadGuard<R, T> {
     ///
     /// This is functionally equivalent to the `unlocked_fair` method on [`RwLockUpgradableReadGuard`].
     #[inline]
+    #[track_caller]
     pub fn unlocked_fair<F, U>(s: &mut Self, f: F) -> U
     where
         F: FnOnce() -> U,
@@ -2362,6 +2438,7 @@ impl<R: RawRwLockUpgradeFair, T: ?Sized> ArcRwLockUpgradableReadGuard<R, T> {
     ///
     /// This method is functionally equivalent to calling `bump` on [`RwLockUpgradableReadGuard`].
     #[inline]
+    #[track_caller]
     pub fn bump(s: &mut Self) {
         // Safety: An RwLockUpgradableReadGuard always holds an upgradable lock.
         unsafe {
@@ -2379,6 +2456,7 @@ impl<R: RawRwLockUpgradeDowngrade, T: ?Sized> ArcRwLockUpgradableReadGuard<R, T>
     /// Note that if there are any writers currently waiting to take the lock
     /// then other readers may not be able to acquire the lock even if it was
     /// downgraded.
+    #[track_caller]
     pub fn downgrade(s: Self) -> ArcRwLockReadGuard<R, T> {
         // Safety: An RwLockUpgradableReadGuard always holds an upgradable lock.
         unsafe {
@@ -2405,6 +2483,7 @@ impl<R: RawRwLockUpgradeDowngrade, T: ?Sized> ArcRwLockUpgradableReadGuard<R, T>
     ///
     /// This function only requires a mutable reference to the guard, unlike
     /// `upgrade` which takes the guard by value.
+    #[track_caller]
     pub fn with_upgraded<Ret, F: FnOnce(&mut T) -> Ret>(&mut self, f: F) -> Ret {
         unsafe {
             self.rwlock.raw.upgrade();
@@ -2430,6 +2509,7 @@ impl<R: RawRwLockUpgradeDowngrade, T: ?Sized> ArcRwLockUpgradableReadGuard<R, T>
     ///
     /// This function only requires a mutable reference to the guard, unlike
     /// `try_upgrade` which takes the guard by value.
+    #[track_caller]
     pub fn try_with_upgraded<Ret, F: FnOnce(&mut T) -> Ret>(&mut self, f: F) -> Option<Ret> {
         if unsafe { self.rwlock.raw.try_upgrade() } {
             // Safety: We just upgraded the lock, so we have mutable access to the data.
@@ -2453,6 +2533,7 @@ impl<R: RawRwLockUpgradeTimed, T: ?Sized> ArcRwLockUpgradableReadGuard<R, T> {
     ///
     /// If the access could not be granted before the timeout expires, then
     /// the current guard is returned.
+    #[track_caller]
     pub fn try_upgrade_for(
         s: Self,
         timeout: R::Duration,
@@ -2478,6 +2559,7 @@ impl<R: RawRwLockUpgradeTimed, T: ?Sized> ArcRwLockUpgradableReadGuard<R, T> {
     /// If the access could not be granted before the timeout expires, then
     /// the current guard is returned.
     #[inline]
+    #[track_caller]
     pub fn try_upgrade_until(
         s: Self,
         timeout: R::Instant,
@@ -2514,6 +2596,7 @@ impl<R: RawRwLockUpgradeTimed + RawRwLockUpgradeDowngrade, T: ?Sized>
     ///
     /// This function only requires a mutable reference to the guard, unlike
     /// `try_upgrade_for` which takes the guard by value.
+    #[track_caller]
     pub fn try_with_upgraded_for<Ret, F: FnOnce(&mut T) -> Ret>(
         &mut self,
         timeout: R::Duration,
@@ -2545,6 +2628,7 @@ impl<R: RawRwLockUpgradeTimed + RawRwLockUpgradeDowngrade, T: ?Sized>
     ///
     /// This function only requires a mutable reference to the guard, unlike
     /// `try_upgrade_until` which takes the guard by value.
+    #[track_caller]
     pub fn try_with_upgraded_until<Ret, F: FnOnce(&mut T) -> Ret>(
         &mut self,
         timeout: R::Instant,
@@ -2690,6 +2774,7 @@ impl<'a, R: RawRwLockFair + 'a, T: ?Sized + 'a> MappedRwLockReadGuard<'a, R, T> 
     /// the lock to pass on to a waiting thread if there is one. This is done by
     /// using this method instead of dropping the `MappedRwLockReadGuard` normally.
     #[inline]
+    #[track_caller]
     pub fn unlock_fair(s: Self) {
         // Safety: A MappedRwLockReadGuard always holds a shared lock.
         unsafe {
@@ -2829,6 +2914,7 @@ impl<'a, R: RawRwLockFair + 'a, T: ?Sized + 'a> MappedRwLockWriteGuard<'a, R, T>
     /// the lock to pass on to a waiting thread if there is one. This is done by
     /// using this method instead of dropping the `MappedRwLockWriteGuard` normally.
     #[inline]
+    #[track_caller]
     pub fn unlock_fair(s: Self) {
         // Safety: A MappedRwLockWriteGuard always holds an exclusive lock.
         unsafe {


### PR DESCRIPTION
This PR marks some of the `lock` functions in `lock_api` with `#[track_caller]` where they might reasonably panic for fallible locks.

I would like to write a `RawMutex` implementation that behaves like a mutable-borrow-only `RefCell`. This is fairly trivial, but the main difference is that `RefCell` leverages `#[track_caller]` and `std::panic::Location::caller` to provide great panic messages when `debug_assertions` are enabled, indicating where the prior borrow occurred when panicking. I'd like to replicate that, but the issue is that `lock_api::Mutex`'s `lock` function doesn't have the `#[track_caller]` attribute which results in error messages saying "could not borrow when previously borrows here: [in the lock_api::Mutex::lock function]".

In general, if a RawMutex's `lock` implementation ever fails AND the writer of the `RawMutex` impl marked the `lock` function with `#[track_caller]`, I think it's much more helpful for any panic to indicate where the user of the `lock_api::Mutex` called `lock` rather than where `lock_api::Mutex` called `lock_api::RawMutex::lock`. The latter is useless information, the former is very useful for... well, making an unsynchronized RefCell-like lock (the RawMutex is !Sync and the Guard is !Send).

