### PR TITLE
build(core): allow `windows-targets` 0.53.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,8 @@ hardware-lock-elision = []
 
 [workspace]
 exclude = ["benchmark"]
+
+# TODO: Consume a release of `backtrace` that contains
+# <https://github.com/rust-lang/backtrace-rs/pull/694>.
+[patch.crates-io]
+backtrace = { git = "https://github.com/erichdongubler-contrib/backtrace-rs", rev = "43e7db9bf1f9d60333a04cf1b0cbe86a679aaad0" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,7 +27,7 @@ libc = "0.2.95"
 redox_syscall = "0.5"
 
 [target.'cfg(windows)'.dependencies]
-windows-targets = "0.52.0"
+windows-targets = ">=0.52.0,<0.54.0"
 
 [features]
 nightly = []


### PR DESCRIPTION
Depends on <https://github.com/rust-lang/backtrace-rs/pull/694>.