### PR TITLE
Use Release/Acquire ordering in thread_parker::windows::Backend::create

### DIFF
--- a/core/src/thread_parker/windows/mod.rs
+++ b/core/src/thread_parker/windows/mod.rs
@@ -55,7 +55,7 @@ impl Backend {
             ptr::null_mut(),
             backend_ptr,
             Ordering::Release,
-            Ordering::Relaxed,
+            Ordering::Acquire,
         ) {
             Ok(_) => unsafe { &*backend_ptr },
             Err(global_backend_ptr) => {


### PR DESCRIPTION
If I understand correctly, the `failure` ordering of Acquire is required to synchronize with the race-winner's Release and thereby allow use of the returned pointer - like how `Backend::get` itself uses Acquire ordering.