### PR TITLE
Check MSRV using cargo-msrv in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,14 +17,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos, windows]
-        channel: [1.56.0, stable, beta, nightly]
+        channel: [stable, beta, nightly]
         feature: [arc_lock, serde, deadlock_detection]
-        exclude:
-          - feature: deadlock_detection
-            channel: '1.56.0'
-            # Versions before 1.54 fail to build on the latest XCode.
-          - os: macos
-            channel: '1.56.0'
         include:
           - channel: nightly
             feature: nightly
@@ -41,6 +35,8 @@ jobs:
     - run: cargo build --all --features ${{ matrix.feature }}
     - run: cargo test --all --features ${{ matrix.feature }}
       if: matrix.feature == 'nightly'
+    - run: cargo install cargo-msrv
+    - run: cargo msrv --workspace verify
   build_other_platforms:
     runs-on: ubuntu-latest
     strategy:
@@ -48,8 +44,8 @@ jobs:
         target:
           - wasm32-unknown-unknown
           - x86_64-fortanix-unknown-sgx
-          #- x86_64-unknown-redox
-          #- x86_64-linux-android
+          - x86_64-unknown-redox
+          - x86_64-linux-android
     steps:
     - uses: actions/checkout@v4
     - run: rustup default nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["mutex", "condvar", "rwlock", "once", "thread"]
 categories = ["concurrency"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 features = ["arc_lock", "serde", "deadlock_detection"]

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ changes to the core API do not cause breaking changes for users of `parking_lot`
 
 ## Minimum Rust version
 
-The current minimum required Rust version is 1.56. Any change to this is
+The current minimum required Rust version is 1.64. Any change to this is
 considered a breaking change and will require a major version bump.
 
 ## License

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/Amanieu/parking_lot"
 keywords = ["mutex", "condvar", "rwlock", "once", "thread"]
 categories = ["concurrency"]
 edition = "2021"
-rust-version = "1.56.0"
+rust-version = "1.64.0"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--generate-link-to-definition"]

--- a/lock_api/Cargo.toml
+++ b/lock_api/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/Amanieu/parking_lot"
 keywords = ["mutex", "rwlock", "lock", "no_std"]
 categories = ["concurrency", "no-std"]
 edition = "2021"
-rust-version = "1.56.0"
+rust-version = "1.64.0"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This avoids breakages when our dev-dependencies drop support for older Rust versions.