### PR TITLE
Fix RawRwLock::bump_*() not releasing lock when there are multiple readers

### DIFF
--- a/src/raw_rwlock.rs
+++ b/src/raw_rwlock.rs
@@ -173,9 +173,7 @@ unsafe impl lock_api::RawRwLockFair for RawRwLock {
 
     #[inline]
     unsafe fn bump_shared(&self) {
-        if self.state.load(Ordering::Relaxed) & (READERS_MASK | WRITER_BIT)
-            == ONE_READER | WRITER_BIT
-        {
+        if self.state.load(Ordering::Relaxed) & WRITER_BIT != 0 {
             self.bump_shared_slow();
         }
     }
@@ -420,7 +418,7 @@ unsafe impl lock_api::RawRwLockUpgradeFair for RawRwLock {
 
     #[inline]
     unsafe fn bump_upgradable(&self) {
-        if self.state.load(Ordering::Relaxed) == ONE_READER | UPGRADABLE_BIT | PARKED_BIT {
+        if self.state.load(Ordering::Relaxed) & PARKED_BIT != 0 {
             self.bump_upgradable_slow();
         }
     }


### PR DESCRIPTION
The docs for `RawRwLockFair::bump_shared` state (and similarly for `bump_upgradable`):

> This method is functionally equivalent to calling `unlock_shared_fair` followed by `lock_shared`, however it can be much more efficient in the case where there are no waiting threads.

If there is more than one reader and a pending writer currently `bump` is a no-op, but it should release the lock and block trying to re-acquire it.