### PR TITLE
Add missing into_arc(_fair) methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,4 +56,7 @@ pub use self::rwlock::{
 pub use ::lock_api;
 
 #[cfg(feature = "arc_lock")]
-pub use self::lock_api::{ArcMutexGuard, ArcReentrantMutexGuard, ArcRwLockReadGuard, ArcRwLockUpgradableReadGuard, ArcRwLockWriteGuard};
+pub use self::lock_api::{
+    ArcMutexGuard, ArcReentrantMutexGuard, ArcRwLockReadGuard, ArcRwLockUpgradableReadGuard,
+    ArcRwLockWriteGuard,
+};


### PR DESCRIPTION
In addition I also minimized the amount of unsafe code a bit by re-writing `unlock_fair` as simply `drop(T::into_arc_fair(s))`.