### PR TITLE
lock_api: drop build script and `autocfg` dependency

### DIFF
--- a/lock_api/Cargo.toml
+++ b/lock_api/Cargo.toml
@@ -23,9 +23,6 @@ owning_ref = { version = "0.4.1", optional = true }
 # support, just pass "--features serde" when building this crate.
 serde = { version = "1.0.126", default-features = false, optional = true }
 
-[build-dependencies]
-autocfg = "1.1.0"
-
 [features]
 default = ["atomic_usize"]
 nightly = []

--- a/lock_api/build.rs
+++ b/lock_api/build.rs
@@ -1,9 +1,0 @@
-fn main() {
-    let cfg = autocfg::new();
-
-    println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rustc-check-cfg=cfg(has_const_fn_trait_bound)");
-    if cfg.probe_rustc_version(1, 61) {
-        println!("cargo:rustc-cfg=has_const_fn_trait_bound");
-    }
-}

--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -145,19 +145,8 @@ unsafe impl<R: RawMutex + Sync, T: ?Sized + Send> Sync for Mutex<R, T> {}
 
 impl<R: RawMutex, T> Mutex<R, T> {
     /// Creates a new mutex in an unlocked state ready for use.
-    #[cfg(has_const_fn_trait_bound)]
     #[inline]
     pub const fn new(val: T) -> Mutex<R, T> {
-        Mutex {
-            raw: R::INIT,
-            data: UnsafeCell::new(val),
-        }
-    }
-
-    /// Creates a new mutex in an unlocked state ready for use.
-    #[cfg(not(has_const_fn_trait_bound))]
-    #[inline]
-    pub fn new(val: T) -> Mutex<R, T> {
         Mutex {
             raw: R::INIT,
             data: UnsafeCell::new(val),

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -229,24 +229,8 @@ unsafe impl<R: RawMutex + Sync, G: GetThreadId + Sync, T: ?Sized + Send> Sync
 
 impl<R: RawMutex, G: GetThreadId, T> ReentrantMutex<R, G, T> {
     /// Creates a new reentrant mutex in an unlocked state ready for use.
-    #[cfg(has_const_fn_trait_bound)]
     #[inline]
     pub const fn new(val: T) -> ReentrantMutex<R, G, T> {
-        ReentrantMutex {
-            data: UnsafeCell::new(val),
-            raw: RawReentrantMutex {
-                owner: AtomicUsize::new(0),
-                lock_count: Cell::new(0),
-                mutex: R::INIT,
-                get_thread_id: G::INIT,
-            },
-        }
-    }
-
-    /// Creates a new reentrant mutex in an unlocked state ready for use.
-    #[cfg(not(has_const_fn_trait_bound))]
-    #[inline]
-    pub fn new(val: T) -> ReentrantMutex<R, G, T> {
         ReentrantMutex {
             data: UnsafeCell::new(val),
             raw: RawReentrantMutex {

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -366,19 +366,8 @@ unsafe impl<R: RawRwLock + Sync, T: ?Sized + Send + Sync> Sync for RwLock<R, T> 
 
 impl<R: RawRwLock, T> RwLock<R, T> {
     /// Creates a new instance of an `RwLock<T>` which is unlocked.
-    #[cfg(has_const_fn_trait_bound)]
     #[inline]
     pub const fn new(val: T) -> RwLock<R, T> {
-        RwLock {
-            data: UnsafeCell::new(val),
-            raw: R::INIT,
-        }
-    }
-
-    /// Creates a new instance of an `RwLock<T>` which is unlocked.
-    #[cfg(not(has_const_fn_trait_bound))]
-    #[inline]
-    pub fn new(val: T) -> RwLock<R, T> {
         RwLock {
             data: UnsafeCell::new(val),
             raw: R::INIT,


### PR DESCRIPTION
This drops the build script and the dependency on `autocfg` for `lock_api`, which isn't needed anymore given that the MSRV is higher than the version the build script was adding special handling for.