### PR TITLE
Replace `winapi` with `windows-sys` in benchmark crate

### DIFF
--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -14,4 +14,4 @@ nightly = ["parking_lot/nightly"]
 deadlock_detection = ["parking_lot/deadlock_detection"]
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["synchapi"] }
+windows-sys = { version = "0.60", features = ["Win32_System_Threading"] }

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -9,14 +9,6 @@ parking_lot = {path = ".."}
 seqlock = "0.2"
 libc = "0.2"
 
-[[bin]]
-name = "mutex"
-path = "src/mutex.rs"
-
-[[bin]]
-name = "rwlock"
-path = "src/rwlock.rs"
-
 [features]
 nightly = ["parking_lot/nightly"]
 deadlock_detection = ["parking_lot/deadlock_detection"]

--- a/benchmark/src/args.rs
+++ b/benchmark/src/args.rs
@@ -46,12 +46,9 @@ fn print_usage(names: &[&str], error_msg: Option<String>) -> ! {
 }
 
 fn parse_num(names: &[&str], name: &str, value: &str) -> usize {
-    value.parse().unwrap_or_else(|_| {
-        print_usage(
-            names,
-            Some(format!("Invalid value for {name}: {value}")),
-        )
-    })
+    value
+        .parse()
+        .unwrap_or_else(|_| print_usage(names, Some(format!("Invalid value for {name}: {value}"))))
 }
 
 fn parse_one(names: &[&str], name: &str, value: &str) -> ArgRange {
@@ -69,10 +66,7 @@ fn parse_one(names: &[&str], name: &str, value: &str) -> ArgRange {
             let start = parse_num(names, name, components[0]);
             let end = parse_num(names, name, components[1]);
             if start > end {
-                print_usage(
-                    names,
-                    Some(format!("Invalid range for {name}: {value}")),
-                );
+                print_usage(names, Some(format!("Invalid range for {name}: {value}")));
             }
             ArgRange {
                 current: start,
@@ -85,10 +79,7 @@ fn parse_one(names: &[&str], name: &str, value: &str) -> ArgRange {
             let end = parse_num(names, name, components[1]);
             let step = parse_num(names, name, components[2]);
             if start > end {
-                print_usage(
-                    names,
-                    Some(format!("Invalid range for {name}: {value}")),
-                );
+                print_usage(names, Some(format!("Invalid range for {name}: {value}")));
             }
             ArgRange {
                 current: start,
@@ -96,10 +87,7 @@ fn parse_one(names: &[&str], name: &str, value: &str) -> ArgRange {
                 step,
             }
         }
-        _ => print_usage(
-            names,
-            Some(format!("Invalid value for {name}: {value}")),
-        ),
+        _ => print_usage(names, Some(format!("Invalid value for {name}: {value}"))),
     }
 }
 

--- a/benchmark/src/args.rs
+++ b/benchmark/src/args.rs
@@ -35,7 +35,7 @@ impl Iterator for ArgRange {
 
 fn print_usage(names: &[&str], error_msg: Option<String>) -> ! {
     if let Some(error) = error_msg {
-        println!("{}", error);
+        println!("{error}");
     }
     println!("Usage: {} {}", env::args().next().unwrap(), names.join(" "));
     println!(
@@ -49,7 +49,7 @@ fn parse_num(names: &[&str], name: &str, value: &str) -> usize {
     value.parse().unwrap_or_else(|_| {
         print_usage(
             names,
-            Some(format!("Invalid value for {}: {}", name, value)),
+            Some(format!("Invalid value for {name}: {value}")),
         )
     })
 }
@@ -71,7 +71,7 @@ fn parse_one(names: &[&str], name: &str, value: &str) -> ArgRange {
             if start > end {
                 print_usage(
                     names,
-                    Some(format!("Invalid range for {}: {}", name, value)),
+                    Some(format!("Invalid range for {name}: {value}")),
                 );
             }
             ArgRange {
@@ -87,18 +87,18 @@ fn parse_one(names: &[&str], name: &str, value: &str) -> ArgRange {
             if start > end {
                 print_usage(
                     names,
-                    Some(format!("Invalid range for {}: {}", name, value)),
+                    Some(format!("Invalid range for {name}: {value}")),
                 );
             }
             ArgRange {
                 current: start,
                 limit: end,
-                step: step,
+                step,
             }
         }
         _ => print_usage(
             names,
-            Some(format!("Invalid value for {}: {}", name, value)),
+            Some(format!("Invalid value for {name}: {value}")),
         ),
     }
 }

--- a/benchmark/src/bin/mutex.rs
+++ b/benchmark/src/bin/mutex.rs
@@ -227,16 +227,15 @@ fn run_all(
         return;
     }
     if *first || !args[0].is_single() {
-        println!("- Running with {} threads", num_threads);
+        println!("- Running with {num_threads} threads");
     }
     if *first || !args[1].is_single() || !args[2].is_single() {
         println!(
-            "- {} iterations inside lock, {} iterations outside lock",
-            work_per_critical_section, work_between_critical_sections
+            "- {work_per_critical_section} iterations inside lock, {work_between_critical_sections} iterations outside lock"
         );
     }
     if *first || !args[3].is_single() {
-        println!("- {} seconds per test", seconds_per_test);
+        println!("- {seconds_per_test} seconds per test");
     }
     *first = false;
 

--- a/benchmark/src/bin/mutex.rs
+++ b/benchmark/src/bin/mutex.rs
@@ -5,8 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-mod args;
-use crate::args::ArgRange;
+use parking_lot_benchmark::args;
+use parking_lot_benchmark::args::ArgRange;
 
 #[cfg(any(windows, unix))]
 use std::cell::UnsafeCell;

--- a/benchmark/src/bin/mutex.rs
+++ b/benchmark/src/bin/mutex.rs
@@ -71,15 +71,14 @@ unsafe impl<T: Send> Send for SrwLock<T> {}
 #[cfg(windows)]
 impl<T> Mutex<T> for SrwLock<T> {
     fn new(v: T) -> Self {
-        let mut h: synchapi::SRWLOCK = synchapi::SRWLOCK { Ptr: std::ptr::null_mut() };
+        let mut h: synchapi::SRWLOCK = synchapi::SRWLOCK {
+            Ptr: std::ptr::null_mut(),
+        };
 
         unsafe {
             synchapi::InitializeSRWLock(&mut h);
         }
-        SrwLock(
-            UnsafeCell::new(v),
-            UnsafeCell::new(h),
-        )
+        SrwLock(UnsafeCell::new(v), UnsafeCell::new(h))
     }
     fn lock<F, R>(&self, f: F) -> R
     where

--- a/benchmark/src/bin/rwlock.rs
+++ b/benchmark/src/bin/rwlock.rs
@@ -107,15 +107,14 @@ unsafe impl<T: Send> Send for SrwLock<T> {}
 #[cfg(windows)]
 impl<T> RwLock<T> for SrwLock<T> {
     fn new(v: T) -> Self {
-        let mut h: synchapi::SRWLOCK = synchapi::SRWLOCK { Ptr: std::ptr::null_mut() };
+        let mut h: synchapi::SRWLOCK = synchapi::SRWLOCK {
+            Ptr: std::ptr::null_mut(),
+        };
 
         unsafe {
             synchapi::InitializeSRWLock(&mut h);
         }
-        SrwLock(
-            UnsafeCell::new(v),
-            UnsafeCell::new(h),
-        )
+        SrwLock(UnsafeCell::new(v), UnsafeCell::new(h))
     }
     fn read<F, R>(&self, f: F) -> R
     where

--- a/benchmark/src/bin/rwlock.rs
+++ b/benchmark/src/bin/rwlock.rs
@@ -5,8 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-mod args;
-use crate::args::ArgRange;
+use parking_lot_benchmark::args;
+use parking_lot_benchmark::args::ArgRange;
 
 #[cfg(any(windows, unix))]
 use std::cell::UnsafeCell;

--- a/benchmark/src/bin/rwlock.rs
+++ b/benchmark/src/bin/rwlock.rs
@@ -304,8 +304,8 @@ fn run_benchmark_iterations<M: RwLock<f64> + Send + Sync + 'static>(
     println!(
         "{:20} - [write] {:10.3} kHz [read] {:10.3} kHz",
         M::name(),
-        total_writers as f64 / seconds_per_test as f64 / 1000.0,
-        total_readers as f64 / seconds_per_test as f64 / 1000.0
+        total_writers / seconds_per_test as f64 / 1000.0,
+        total_readers / seconds_per_test as f64 / 1000.0
     );
 }
 
@@ -324,18 +324,16 @@ fn run_all(
     }
     if *first || !args[0].is_single() || !args[1].is_single() {
         println!(
-            "- Running with {} writer threads and {} reader threads",
-            num_writer_threads, num_reader_threads
+            "- Running with {num_writer_threads} writer threads and {num_reader_threads} reader threads"
         );
     }
     if *first || !args[2].is_single() || !args[3].is_single() {
         println!(
-            "- {} iterations inside lock, {} iterations outside lock",
-            work_per_critical_section, work_between_critical_sections
+            "- {work_per_critical_section} iterations inside lock, {work_between_critical_sections} iterations outside lock"
         );
     }
     if *first || !args[4].is_single() {
-        println!("- {} seconds per test", seconds_per_test);
+        println!("- {seconds_per_test} seconds per test");
     }
     *first = false;
 

--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod args;

--- a/benchmark/src/rwlock.rs
+++ b/benchmark/src/rwlock.rs
@@ -355,8 +355,16 @@ fn run_all(
         seconds_per_test,
         test_iterations,
     );
+    run_benchmark_iterations::<std::sync::RwLock<f64>>(
+        num_writer_threads,
+        num_reader_threads,
+        work_per_critical_section,
+        work_between_critical_sections,
+        seconds_per_test,
+        test_iterations,
+    );
     if cfg!(windows) {
-        run_benchmark_iterations::<std::sync::RwLock<f64>>(
+        run_benchmark_iterations::<SrwLock<f64>>(
             num_writer_threads,
             num_reader_threads,
             work_per_critical_section,

--- a/benchmark/src/rwlock.rs
+++ b/benchmark/src/rwlock.rs
@@ -164,7 +164,7 @@ impl<T> RwLock<T> for PthreadRwLock<T> {
         F: FnOnce(&T) -> R,
     {
         unsafe {
-            libc::pthread_rwlock_wrlock(self.1.get());
+            libc::pthread_rwlock_rdlock(self.1.get());
             let res = f(&*self.0.get());
             libc::pthread_rwlock_unlock(self.1.get());
             res


### PR DESCRIPTION
This is on top of #486, thus created as a draft PR, let me know if you want them to be pulled as a single PR.

`windows-sys` is the actively maintained successor to `winapi` and maintained by Microsoft.