### PR TITLE
Fix a false positive in deadlock detection when upgrading lock

### DIFF
--- a/src/raw_rwlock.rs
+++ b/src/raw_rwlock.rs
@@ -870,7 +870,10 @@ impl RawRwLock {
 
     #[cold]
     fn upgrade_slow(&self, timeout: Option<Instant>) -> bool {
-        self.wait_for_readers(timeout, ONE_READER | UPGRADABLE_BIT)
+        self.deadlock_release();
+        let result = self.wait_for_readers(timeout, ONE_READER | UPGRADABLE_BIT);
+        self.deadlock_acquire();
+        result
     }
 
     #[cold]


### PR DESCRIPTION
Fixes <https://github.com/Amanieu/parking_lot/issues/489>

Applies the suggestion from <https://github.com/Amanieu/parking_lot/issues/489#issuecomment-3250629090>.