### PR TITLE
Do not use elision on Miri even if "hardware-lock-elision" feature is enabled

### DIFF
--- a/src/elision.rs
+++ b/src/elision.rs
@@ -27,6 +27,7 @@ pub trait AtomicElisionExt {
 pub fn have_elision() -> bool {
     cfg!(all(
         feature = "hardware-lock-elision",
+        not(miri),
         any(target_arch = "x86", target_arch = "x86_64"),
     ))
 }
@@ -35,6 +36,7 @@ pub fn have_elision() -> bool {
 // have_elision().
 #[cfg(not(all(
     feature = "hardware-lock-elision",
+    not(miri),
     any(target_arch = "x86", target_arch = "x86_64")
 )))]
 impl AtomicElisionExt for AtomicUsize {
@@ -53,6 +55,7 @@ impl AtomicElisionExt for AtomicUsize {
 
 #[cfg(all(
     feature = "hardware-lock-elision",
+    not(miri),
     any(target_arch = "x86", target_arch = "x86_64")
 ))]
 impl AtomicElisionExt for AtomicUsize {


### PR DESCRIPTION
I need to use `parking_lot` primitives with this feature enabled, but Miri runs error upon reaching the assembly. This is a massive pain to configure around in a workspace. Can this just be done?