### PR TITLE
Switch from `windows-targets` to `windows-link`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["mutex", "condvar", "rwlock", "once", "thread"]
 categories = ["concurrency"]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.71"
 
 [package.metadata.docs.rs]
 features = ["arc_lock", "serde", "deadlock_detection"]

--- a/README.md
+++ b/README.md
@@ -132,8 +132,7 @@ changes to the core API do not cause breaking changes for users of `parking_lot`
 
 ## Minimum Rust version
 
-The current minimum required Rust version is 1.64. Any change to this is
-considered a breaking change and will require a major version bump.
+The current minimum required Rust version is 1.71, but this may change at any time.
 
 ## License
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/Amanieu/parking_lot"
 keywords = ["mutex", "condvar", "rwlock", "once", "thread"]
 categories = ["concurrency"]
 edition = "2021"
-rust-version = "1.64.0"
+rust-version = "1.71.0"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--generate-link-to-definition"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,7 +26,7 @@ libc = "0.2.95"
 redox_syscall = "0.5"
 
 [target.'cfg(windows)'.dependencies]
-windows-targets = "0.52.0"
+windows-link = "0.2.0"
 
 [features]
 nightly = []

--- a/core/src/thread_parker/windows/bindings.rs
+++ b/core/src/thread_parker/windows/bindings.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 //! Manual bindings to the win32 API to avoid dependencies on windows-sys or winapi
 //! as these bindings will **never** change and `parking_lot_core` is a foundational
 //! dependency for the Rust ecosystem, so the dependencies used by it have an
@@ -24,8 +26,8 @@ pub type WaitOnAddress = unsafe extern "system" fn(
 ) -> BOOL;
 pub type WakeByAddressSingle = unsafe extern "system" fn(Address: *const std::ffi::c_void);
 
-windows_targets::link!("kernel32.dll" "system" fn GetLastError() -> u32);
-windows_targets::link!("kernel32.dll" "system" fn CloseHandle(hObject: HANDLE) -> BOOL);
-windows_targets::link!("kernel32.dll" "system" fn GetModuleHandleA(lpModuleName: *const u8) -> HINSTANCE);
-windows_targets::link!("kernel32.dll" "system" fn GetProcAddress(hModule: HINSTANCE, lpProcName: *const u8) -> FARPROC);
-windows_targets::link!("kernel32.dll" "system" fn Sleep(dwMilliseconds: u32) -> ());
+windows_link::link!("kernel32.dll" "system" fn GetLastError() -> u32);
+windows_link::link!("kernel32.dll" "system" fn CloseHandle(hObject: HANDLE) -> BOOL);
+windows_link::link!("kernel32.dll" "system" fn GetModuleHandleA(lpModuleName: *const u8) -> HINSTANCE);
+windows_link::link!("kernel32.dll" "system" fn GetProcAddress(hModule: HINSTANCE, lpProcName: *const u8) -> FARPROC);
+windows_link::link!("kernel32.dll" "system" fn Sleep(dwMilliseconds: u32) -> ());

--- a/lock_api/Cargo.toml
+++ b/lock_api/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/Amanieu/parking_lot"
 keywords = ["mutex", "rwlock", "lock", "no_std"]
 categories = ["concurrency", "no-std"]
 edition = "2021"
-rust-version = "1.64.0"
+rust-version = "1.71.0"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Supersedes #458

This raises the MSRV to 1.71, and removes the statement that changing the MSRV is considered a breaking change, as the last two versions did it too.