### PR TITLE
Replace `doc_auto_cfg` with `doc_cfg`

### DIFF
--- a/lock_api/src/lib.rs
+++ b/lock_api/src/lib.rs
@@ -86,7 +86,7 @@
 //!   requires the `alloc` crate to be present.
 
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
 


### PR DESCRIPTION
- Closes #494 

`doc_auto_cfg` was merged into `doc_cfg` in https://github.com/rust-lang/rust/pull/138907.