### PR TITLE
Use postcard instead of bincode in tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ lock_api = { path = "lock_api", version = "0.4.14" }
 rand = "0.8.3"
 
 # Used when testing out serde support.
-bincode = "1.3.3"
+postcard = {version = "1.1.3", default-features = false, features = ["use-std"]}
 
 [features]
 default = []

--- a/core/src/thread_parker/sgx.rs
+++ b/core/src/thread_parker/sgx.rs
@@ -66,7 +66,8 @@ impl super::ThreadParkerT for ThreadParker {
                     return false;
                 }
             };
-            let remaining_nanos = u128::min(remaining.as_nanos(), WAIT_INDEFINITE as u128 - 1) as u64;
+            let remaining_nanos =
+                u128::min(remaining.as_nanos(), WAIT_INDEFINITE as u128 - 1) as u64;
 
             if let Err(e) = usercalls::wait(EV_UNPARK, remaining_nanos) {
                 if e.kind() == ErrorKind::TimedOut || e.kind() == ErrorKind::WouldBlock {

--- a/src/fair_mutex.rs
+++ b/src/fair_mutex.rs
@@ -108,7 +108,7 @@ mod tests {
     use std::thread;
 
     #[cfg(feature = "serde")]
-    use bincode::{deserialize, serialize};
+    use postcard::{from_bytes, to_stdvec};
 
     #[derive(Eq, PartialEq, Debug)]
     struct NonCopy(i32);
@@ -265,8 +265,8 @@ mod tests {
         let contents: Vec<u8> = vec![0, 1, 2];
         let mutex = FairMutex::new(contents.clone());
 
-        let serialized = serialize(&mutex).unwrap();
-        let deserialized: FairMutex<Vec<u8>> = deserialize(&serialized).unwrap();
+        let serialized = to_stdvec(&mutex).unwrap();
+        let deserialized: FairMutex<Vec<u8>> = from_bytes(&serialized).unwrap();
 
         assert_eq!(*(mutex.lock()), *(deserialized.lock()));
         assert_eq!(contents, *(deserialized.lock()));

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -119,7 +119,7 @@ mod tests {
     use std::thread;
 
     #[cfg(feature = "serde")]
-    use bincode::{deserialize, serialize};
+    use postcard::{from_bytes, to_stdvec};
 
     struct Packet<T>(Arc<(Mutex<T>, Condvar)>);
 
@@ -304,8 +304,8 @@ mod tests {
         let contents: Vec<u8> = vec![0, 1, 2];
         let mutex = Mutex::new(contents.clone());
 
-        let serialized = serialize(&mutex).unwrap();
-        let deserialized: Mutex<Vec<u8>> = deserialize(&serialized).unwrap();
+        let serialized = to_stdvec(&mutex).unwrap();
+        let deserialized: Mutex<Vec<u8>> = from_bytes(&serialized).unwrap();
 
         assert_eq!(*(mutex.lock()), *(deserialized.lock()));
         assert_eq!(contents, *(deserialized.lock()));

--- a/src/remutex.rs
+++ b/src/remutex.rs
@@ -78,7 +78,7 @@ mod tests {
     use std::thread;
 
     #[cfg(feature = "serde")]
-    use bincode::{deserialize, serialize};
+    use postcard::{from_bytes, to_stdvec};
 
     #[test]
     fn smoke() {
@@ -162,8 +162,8 @@ mod tests {
         let contents: Vec<u8> = vec![0, 1, 2];
         let mutex = ReentrantMutex::new(contents.clone());
 
-        let serialized = serialize(&mutex).unwrap();
-        let deserialized: ReentrantMutex<Vec<u8>> = deserialize(&serialized).unwrap();
+        let serialized = to_stdvec(&mutex).unwrap();
+        let deserialized: ReentrantMutex<Vec<u8>> = from_bytes(&serialized).unwrap();
 
         assert_eq!(*(mutex.lock()), *(deserialized.lock()));
         assert_eq!(contents, *(deserialized.lock()));

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -135,7 +135,7 @@ mod tests {
     use std::time::Duration;
 
     #[cfg(feature = "serde")]
-    use bincode::{deserialize, serialize};
+    use postcard::{from_bytes, to_stdvec};
 
     #[derive(Eq, PartialEq, Debug)]
     struct NonCopy(i32);
@@ -590,8 +590,8 @@ mod tests {
         let contents: Vec<u8> = vec![0, 1, 2];
         let mutex = RwLock::new(contents.clone());
 
-        let serialized = serialize(&mutex).unwrap();
-        let deserialized: RwLock<Vec<u8>> = deserialize(&serialized).unwrap();
+        let serialized = to_stdvec(&mutex).unwrap();
+        let deserialized: RwLock<Vec<u8>> = from_bytes(&serialized).unwrap();
 
         assert_eq!(*(mutex.read()), *(deserialized.read()));
         assert_eq!(contents, *(deserialized.read()));


### PR DESCRIPTION
Someone in contact with the bincode maintainers has mentioned that it's not really maintained anymore and [recommended the ecosystem switch away from it](https://old.reddit.com/r/rust/comments/1pmw2c0/whats_going_on_with_bincode/nu48fce/):

> Bincode has spent a good probably most of its life at this point only being barely maintained with an occasional punctuation of activity, and help from the community has not been forthcoming (while a large part of that is because bincode is largely done as in feature complete and has been for some time, given it's maintenance status, it's quite frankly terrifying how much of the rust ecosystem depends on it, many of these projects would be much better served in multiple ways by using something that's not bincode).

This PR isn't really "it's important that parking_lot needs to stop using bincode in its tests and switch to something else". It's moreso that parking_lot is a very popular reverse dependency of bincode, and the hope is that by switching away from it, the broader ecosystem is encouraged to look for alternatives and stop reaching for bincode just because it's already popular.