### PR TITLE
lock_api: Make `raw` methods safe

### DIFF
--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -273,10 +273,13 @@ impl<R: RawMutex, T: ?Sized> Mutex<R, T> {
     ///
     /// # Safety
     ///
-    /// This method is unsafe because it allows unlocking a mutex while
-    /// still holding a reference to a `MutexGuard`.
+    /// If the returned mutex is manually unlocked via [`RawMutex::unlock`], it
+    /// is your responsibility to avoid double unlocks and data races with alive
+    /// `MutexGuard`s. For example, it is sufficient to ensure that the current
+    /// thread logically owns a `MutexGuard`, but that guard has been discarded
+    /// using `mem::forget`.
     #[inline]
-    pub unsafe fn raw(&self) -> &R {
+    pub fn raw(&self) -> &R {
         &self.raw
     }
 

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -378,10 +378,13 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     ///
     /// # Safety
     ///
-    /// This method is unsafe because it allows unlocking a mutex while
-    /// still holding a reference to a `ReentrantMutexGuard`.
+    /// If the returned mutex is manually unlocked via [`RawMutex::unlock`], it
+    /// is your responsibility to avoid double unlocks and data races with alive
+    /// `ReentrantMutexGuard`s. For example, it is sufficient to ensure that the
+    /// current thread logically owns a `ReentrantMutexGuard`, but that guard
+    /// has been discarded using `mem::forget`.
     #[inline]
-    pub unsafe fn raw(&self) -> &R {
+    pub fn raw(&self) -> &R {
         &self.raw.mutex
     }
 

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -577,9 +577,13 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
     ///
     /// # Safety
     ///
-    /// This method is unsafe because it allows unlocking a mutex while
-    /// still holding a reference to a lock guard.
-    pub unsafe fn raw(&self) -> &R {
+    /// If the returned mutex is manually unlocked via
+    /// [`RawRwLock::unlock_shared`] or [`RawRwLock::unlock_exclusive`], it is
+    /// your responsibility to avoid double unlocks and data races with alive
+    /// lock guards. For example, it is sufficient to ensure that the current
+    /// thread logically owns a guard of the type corresponding to the unlock
+    /// method, but that guard has been discarded using `mem::forget`.
+    pub fn raw(&self) -> &R {
         &self.raw
     }
 

--- a/src/condvar.rs
+++ b/src/condvar.rs
@@ -253,7 +253,7 @@ impl Condvar {
     /// with a different `Mutex` object.
     #[inline]
     pub fn wait<T: ?Sized>(&self, mutex_guard: &mut MutexGuard<'_, T>) {
-        self.wait_until_internal(unsafe { MutexGuard::mutex(mutex_guard).raw() }, None);
+        self.wait_until_internal(MutexGuard::mutex(mutex_guard).raw(), None);
     }
 
     /// Waits on this condition variable for a notification, timing out after
@@ -285,10 +285,7 @@ impl Condvar {
         mutex_guard: &mut MutexGuard<'_, T>,
         timeout: Instant,
     ) -> WaitTimeoutResult {
-        self.wait_until_internal(
-            unsafe { MutexGuard::mutex(mutex_guard).raw() },
-            Some(timeout),
-        )
+        self.wait_until_internal(MutexGuard::mutex(mutex_guard).raw(), Some(timeout))
     }
 
     // This is a non-generic function to reduce the monomorphization cost of
@@ -384,7 +381,7 @@ impl Condvar {
         timeout: Duration,
     ) -> WaitTimeoutResult {
         let deadline = util::to_deadline(timeout);
-        self.wait_until_internal(unsafe { MutexGuard::mutex(mutex_guard).raw() }, deadline)
+        self.wait_until_internal(MutexGuard::mutex(mutex_guard).raw(), deadline)
     }
 
     #[inline]
@@ -401,8 +398,7 @@ impl Condvar {
         let mut result = WaitTimeoutResult(false);
 
         while !result.timed_out() && condition(mutex_guard.deref_mut()) {
-            result =
-                self.wait_until_internal(unsafe { MutexGuard::mutex(mutex_guard).raw() }, timeout);
+            result = self.wait_until_internal(MutexGuard::mutex(mutex_guard).raw(), timeout);
         }
 
         result


### PR DESCRIPTION
Since `unlock*` methods are unsafe since #243, it doesn't make much sense to keep `raw` unsafe.

P.S. While removing `unsafe` from uses in `parking_lot`, I've noticed that `parking_lot` seems to play fast-and-loose with whether unlocking is considered `unsafe`: e.g. the `unlock` trait methods are `unsafe`, but the various `unlock_slow`privater methods are safe, and `CondVar::wait_until_internal` is not marked `unsafe` despite taking a reference to an arbitrary lock, and `RawRwLock` has an unsafe method `bump_shared_slow`, but a safe method `bump_exclusive_slow`. What is the convention here, if any?