### PR TITLE
Support for asynchronous parking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.vscode

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,5 +29,7 @@ redox_syscall = "0.5"
 windows-link = "0.2.0"
 
 [features]
+default = ["async"]
 nightly = []
+async = []
 deadlock_detection = ["petgraph", "backtrace"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,6 +18,7 @@ cfg-if = "1.0.0"
 smallvec = "1.6.1"
 petgraph = { version = "0.6.0", optional = true }
 backtrace = { version = "0.3.60", optional = true }
+futures = { version = "0.3.31", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.95"
@@ -29,7 +30,6 @@ redox_syscall = "0.5"
 windows-link = "0.2.0"
 
 [features]
-default = ["async"]
 nightly = []
-async = []
+async = ["dep:futures"]
 deadlock_detection = ["petgraph", "backtrace"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,6 +16,7 @@ rustdoc-args = ["--generate-link-to-definition"]
 [dependencies]
 cfg-if = "1.0.0"
 smallvec = "1.6.1"
+scopeguard = { version = "1.1.0", default-features = false }
 petgraph = { version = "0.6.0", optional = true }
 backtrace = { version = "0.3.60", optional = true }
 futures = { version = "0.3.31", optional = true }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -61,7 +61,10 @@ mod util;
 mod word_lock;
 
 pub use self::parking_lot::deadlock;
+#[cfg(feature = "async")]
+pub use self::parking_lot::park_task;
 pub use self::parking_lot::{park, unpark_all, unpark_filter, unpark_one, unpark_requeue};
+
 pub use self::parking_lot::{
     FilterOp, ParkResult, ParkToken, RequeueOp, UnparkResult, UnparkToken,
 };

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -54,6 +54,8 @@
 
 mod parking_lot;
 mod spinwait;
+#[cfg(feature = "async")]
+mod task_parker;
 mod thread_parker;
 mod util;
 mod word_lock;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -61,9 +61,15 @@ mod util;
 mod word_lock;
 
 pub use self::parking_lot::deadlock;
-#[cfg(feature = "async")]
-pub use self::parking_lot::park_task;
 pub use self::parking_lot::{park, unpark_all, unpark_filter, unpark_one, unpark_requeue};
+#[cfg(feature = "async")]
+pub use self::{
+    parking_lot::park_task,
+    util::{
+        assume_immediate, assume_immediate_unchecked, immediate, immediate_with, waker, Immediate,
+        ImmediateFuture,
+    },
+};
 
 pub use self::parking_lot::{
     FilterOp, ParkResult, ParkToken, RequeueOp, UnparkResult, UnparkToken,

--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -9,13 +9,15 @@ use crate::task_parker::{TaskParker, TaskParkerT};
 use crate::thread_parker::{ThreadParker, ThreadParkerT, UnparkHandleT};
 use crate::util::UncheckedOptionExt;
 #[cfg(feature = "async")]
-use crate::util::{immediate, Immediate, ImmediateFuture};
+use crate::util::{immediate, ImmediateFuture};
 use crate::word_lock::WordLock;
 use core::{
     cell::{Cell, UnsafeCell},
     ptr,
     sync::atomic::{AtomicPtr, AtomicUsize, Ordering},
 };
+#[cfg(feature = "async")]
+use scopeguard::{guard, ScopeGuard};
 use smallvec::SmallVec;
 #[cfg(feature = "async")]
 use std::future::{poll_fn, Future};
@@ -281,24 +283,22 @@ impl ParkData {
 
     #[cfg(feature = "async")]
     #[inline]
-    fn task() -> Immediate<fn(&mut Context<'_>) -> ParkData> {
-        immediate(|cx| {
-            // Keep track of the total number of live ThreadData objects and resize
-            // the hash table accordingly.
-            let num_threads = NUM_THREADS.fetch_add(1, Ordering::Relaxed) + 1;
-            grow_hashtable(num_threads);
+    fn task(cx: &mut Context<'_>) -> ParkData {
+        // Keep track of the total number of live ThreadData objects and resize
+        // the hash table accordingly.
+        let num_threads = NUM_THREADS.fetch_add(1, Ordering::Relaxed) + 1;
+        grow_hashtable(num_threads);
 
-            ParkData {
-                parker: TaskParker::new(cx).into(),
-                key: AtomicUsize::new(0),
-                next_in_queue: Cell::new(ptr::null()),
-                unpark_token: Cell::new(DEFAULT_UNPARK_TOKEN),
-                park_token: Cell::new(DEFAULT_PARK_TOKEN),
-                parked_with_timeout: Cell::new(false),
-                #[cfg(feature = "deadlock_detection")]
-                deadlock_data: deadlock::DeadlockData::new(),
-            }
-        })
+        ParkData {
+            parker: TaskParker::new(cx).into(),
+            key: AtomicUsize::new(0),
+            next_in_queue: Cell::new(ptr::null()),
+            unpark_token: Cell::new(DEFAULT_UNPARK_TOKEN),
+            park_token: Cell::new(DEFAULT_PARK_TOKEN),
+            parked_with_timeout: Cell::new(false),
+            #[cfg(feature = "deadlock_detection")]
+            deadlock_data: deadlock::DeadlockData::new(),
+        }
     }
     #[inline]
     fn prepare_insert(&self, key: usize, park_token: ParkToken, timeout: &Option<Instant>) {
@@ -948,15 +948,11 @@ pub unsafe fn park(
 /// primitives.
 ///
 /// The `validate` and `timed_out` futures are called while the queue is
-/// locked and must not panic or call into any function in `parking_lot`.
+/// locked and must not call into any function in `parking_lot`.
 ///
 /// The `before_sleep` future is run outside the queue lock and is allowed
 /// to call `unpark_one`, `unpark_all`, `unpark_requeue` or `unpark_filter`, but
-/// it is not allowed to call `park`, `park_task` or panic.
-///
-/// Once polled this future must be run to completion before being dropped or forgotten,
-/// to ensure its data in the queue actually lives until its removal,
-/// but leaking it is fine as the queue never remains locked across yielding await points.
+/// it is not allowed to call `park` or `park_task`.
 #[cfg(feature = "async")]
 #[inline]
 pub async unsafe fn park_task(
@@ -970,7 +966,7 @@ pub async unsafe fn park_task(
     // Grab our task data, this also ensures that the hash table exists.
     // Because `park_task` is a future we can't use a hypothetical
     // `with_task_data` scoped callback here.
-    let task_data = &ParkData::task().await;
+    let task_data = &*Box::new(immediate(ParkData::task).await);
     // SAFETY: Constructed with `ParkData::task`.
     let task_parker = unsafe { task_data.parker.get_task().unchecked_unwrap() };
 
@@ -979,24 +975,38 @@ pub async unsafe fn park_task(
 
     // Lock the bucket for the given key
     let bucket = lock_bucket(key);
+    let bucket_guard = guard(bucket, |bucket| {
+        // SAFETY: We hold the lock here, as required
+        bucket.mutex.unlock();
+    });
 
     // If the validation function fails, just return.
     // Awaiting an ImmediateFuture is guaranteed not to stall progress
     // and therefore fine to do even while the bucket remains locked.
     if !validate.await {
-        // SAFETY: We hold the lock here, as required
-        bucket.mutex.unlock();
         return ParkResult::Invalid;
     }
-
     // Append our task data to the queue and unlock the bucket
     task_data.prepare_insert(key, park_token, &timeout);
     // Awaiting an ImmediateFuture is guaranteed not to stall progress
     // and therefore fine to do even while the bucket remains locked.
     immediate(|cx| task_parker.prepare_park(cx)).await;
     queue_append_one(&bucket.queue_head, &bucket.queue_tail, task_data);
-    // SAFETY: We hold the lock here, as required
-    bucket.mutex.unlock();
+    drop(bucket_guard);
+
+    let drop_guard = guard(task_data, |task_data| {
+        // Lock our bucket again. Note that the hashtable may have been rehashed in
+        // the meantime. Our key may also have changed if we were requeued.
+        let (key, bucket) = lock_bucket_checked(&task_data.key);
+        // We were dropped, so we now need to remove our task from the queue
+        let (removed, _) = queue_remove_one(key, &bucket.queue_head, &bucket.queue_tail, |data| {
+            ptr::eq(data, task_data)
+        });
+        debug_assert!(removed.is_null() || ptr::eq(removed, task_data));
+        // Unlock the bucket, we are done
+        // SAFETY: We hold the lock here, as required
+        bucket.mutex.unlock();
+    });
 
     // Invoke the pre-sleep callback
     // Note that this is the only non-immediate future among the different callbacks.
@@ -1011,10 +1021,12 @@ pub async unsafe fn park_task(
         None => {
             poll_fn(|cx| task_parker.park(cx)).await;
             // call deadlock detection on_unpark hook
-            deadlock::on_unpark(task_data);
+            deadlock::on_unpark(&*drop_guard);
             true
         }
     };
+
+    ScopeGuard::into_inner(drop_guard);
 
     // If we were unparked, return now
     if unparked {
@@ -1024,17 +1036,17 @@ pub async unsafe fn park_task(
     // Lock our bucket again. Note that the hashtable may have been rehashed in
     // the meantime. Our key may also have changed if we were requeued.
     let (key, bucket) = lock_bucket_checked(&task_data.key);
-
+    let _bucket_guard = guard(bucket, |bucket| {
+        // SAFETY: We hold the lock here, as required
+        bucket.mutex.unlock();
+    });
     // Now we need to check again if we were unparked or timed out. Unlike the
     // last check this is precise because we hold the bucket lock.
     // Awaiting an ImmediateFuture is guaranteed not to stall progress
     // and therefore fine to do even while the bucket remains locked.
     if !immediate(|cx| task_parker.timed_out(cx)).await {
-        // SAFETY: We hold the lock here, as required
-        bucket.mutex.unlock();
         return ParkResult::Unparked(task_data.unpark_token.get());
     }
-
     // We timed out, so we now need to remove our task from the queue
     let (removed, was_last_entry) =
         queue_remove_one(key, &bucket.queue_head, &bucket.queue_tail, |data| {
@@ -1051,9 +1063,6 @@ pub async unsafe fn park_task(
     // and therefore fine to do even while the bucket remains locked.
     timed_out.await(key, was_last_entry);
 
-    // Unlock the bucket, we are done
-    // SAFETY: We hold the lock here, as required
-    bucket.mutex.unlock();
     ParkResult::TimedOut
 }
 
@@ -1698,14 +1707,23 @@ mod deadlock_impl {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "async")]
+    use super::FilterOp;
     use super::{ParkData, DEFAULT_PARK_TOKEN, DEFAULT_UNPARK_TOKEN};
     use crate::parking_lot::CURRENT_PARK_DATA;
     #[cfg(feature = "async")]
-    use crate::util::immediate;
+    use crate::{park_task, unpark_filter, util::immediate, ParkResult, ParkToken};
     #[cfg(feature = "async")]
     use futures::{executor::block_on, future::join_all};
     #[cfg(feature = "async")]
-    use std::future::ready;
+    use std::{
+        cell::Cell,
+        future::{poll_fn, ready, Future},
+        mem::{forget, take},
+        panic::{catch_unwind, AssertUnwindSafe, Location},
+        task::{Context, Poll, Waker},
+        time::Instant,
+    };
     use std::{
         ptr,
         sync::{
@@ -2084,6 +2102,179 @@ mod tests {
 
         fn semaphore_addr(&self) -> usize {
             &self.semaphore as *const _ as usize
+        }
+    }
+
+    #[cfg(feature = "async")]
+    #[test]
+    fn park_task_memory_safe() {
+        let key = &() as *const _ as usize;
+        let find = |unpark| {
+            let mut found = false;
+            unsafe {
+                unpark_filter(
+                    key,
+                    |token| {
+                        if token == ParkToken(key) {
+                            found = true;
+                            if unpark {
+                                FilterOp::Unpark
+                            } else {
+                                FilterOp::Stop
+                            }
+                        } else if found {
+                            FilterOp::Stop
+                        } else {
+                            FilterOp::Skip
+                        }
+                    },
+                    |_| DEFAULT_UNPARK_TOKEN,
+                )
+            };
+            found
+        };
+        let pending = || {
+            let cx = &mut Context::from_waker(Waker::noop());
+            let mut task = unsafe {
+                Box::pin(park_task(
+                    key,
+                    ready(true),
+                    {
+                        let mut once = true;
+                        poll_fn(move |_| {
+                            if take(&mut once) {
+                                Poll::Pending
+                            } else {
+                                Poll::Ready(())
+                            }
+                        })
+                    },
+                    immediate(|_| |_, _| unreachable!()),
+                    ParkToken(key),
+                    None,
+                ))
+            };
+            assert!(!find(false));
+            let Poll::Pending = task.as_mut().poll(cx) else {
+                unreachable!()
+            };
+            task
+        };
+
+        assert!(!find(false));
+        let task = pending();
+        assert!(find(false));
+        drop(task);
+        assert!(!find(false));
+
+        let task = pending();
+        assert!(find(true));
+        assert!(!find(false));
+        drop(task);
+        assert!(!find(false));
+
+        let mut task = pending();
+        let cx = &mut Context::from_waker(Waker::noop());
+        assert!(find(true));
+        let Poll::Ready(ParkResult::Unparked(DEFAULT_UNPARK_TOKEN)) = task.as_mut().poll(cx) else {
+            unreachable!()
+        };
+        assert!(!find(false));
+
+        if option_env!("MIRIFLAGS").is_some_and(|flags| flags.contains("-Zmiri-ignore-leaks")) {
+            let task = pending();
+            assert!(find(false));
+            // Will cause leak
+            forget(task);
+            assert!(find(true));
+            assert!(!find(false));
+        } else {
+            println!(
+                "{}: note: also run with \"MIRIFLAGS=-Zmiri-ignore-leaks\" for more testing",
+                Location::caller()
+            )
+        }
+    }
+
+    #[cfg(feature = "async")]
+    #[test]
+    fn park_task_panic_safe() {
+        let key = &() as *const _ as usize;
+        let find = |unpark| {
+            let mut found = false;
+            unsafe {
+                unpark_filter(
+                    key,
+                    |token| {
+                        if token == ParkToken(key) {
+                            found = true;
+                            if unpark {
+                                FilterOp::Unpark
+                            } else {
+                                FilterOp::Stop
+                            }
+                        } else if found {
+                            FilterOp::Stop
+                        } else {
+                            FilterOp::Skip
+                        }
+                    },
+                    |_| DEFAULT_UNPARK_TOKEN,
+                )
+            };
+            found
+        };
+        let check = |panic: usize| {
+            let out = &Cell::new(0);
+            let mut task = unsafe {
+                Box::pin(park_task(
+                    key,
+                    immediate(move |_| {
+                        if panic == 1 {
+                            out.set(panic);
+                            panic!()
+                        } else {
+                            true
+                        }
+                    }),
+                    {
+                        poll_fn(move |_| {
+                            assert!(find(false));
+                            if panic == 2 {
+                                out.set(panic);
+                                panic!()
+                            } else {
+                                Poll::Ready(())
+                            }
+                        })
+                    },
+                    immediate(move |_| {
+                        move |_, _| {
+                            if panic == 3 {
+                                out.set(panic);
+                                panic!()
+                            }
+                        }
+                    }),
+                    ParkToken(key),
+                    Some(Instant::now()),
+                ))
+            };
+            assert!(!find(false));
+            let catch = catch_unwind(AssertUnwindSafe(|| {
+                let cx = &mut Context::from_waker(Waker::noop());
+                _ = task.as_mut().poll(cx);
+            }));
+            if panic == 0 {
+                catch.unwrap();
+            } else {
+                catch.unwrap_err();
+            }
+            assert!(!find(false));
+            assert_eq!(out.get(), panic);
+        };
+        for x in 0..=3 {
+            check(x);
         }
     }
 }

--- a/core/src/task_parker/mod.rs
+++ b/core/src/task_parker/mod.rs
@@ -1,0 +1,45 @@
+#[cfg(feature = "async")]
+use std::{
+    task::{Context, Poll},
+    time::Instant,
+};
+
+#[cfg(feature = "async")]
+/// Trait for the platform task parker implementation.
+///
+/// All unsafe methods are unsafe to mirror the [ThreadParkerT] methods.
+pub trait TaskParkerT {
+    type UnparkHandle: UnparkHandleT;
+
+    const IS_CHEAP_TO_CONSTRUCT: bool;
+
+    fn new(cx: &mut Context<'_>) -> Self;
+
+    /// Prepares the parker. This should be called before adding it to the queue.
+    unsafe fn prepare_park(&self);
+
+    /// Checks if the park timed out. This should be called while holding the
+    /// queue lock after `park_until` has returned false.
+    unsafe fn timed_out(&self) -> bool;
+
+    /// Parks the thread until it is unparked. This should be called after it has
+    /// been added to the queue, after unlocking the queue.
+    unsafe fn park(&self, cx: &mut Context<'_>) -> Poll<()>;
+
+    /// Parks the thread until it is unparked or the timeout is reached. This
+    /// should be called after it has been added to the queue, after unlocking
+    /// the queue. Returns true if we were unparked and false if we timed out.
+    unsafe fn park_until(&self, cx: &mut Context<'_>, timeout: Instant) -> Poll<bool>;
+
+    /// Locks the parker to prevent the target thread from exiting. This is
+    /// necessary to ensure that thread-local `ThreadData` objects remain valid.
+    /// This should be called while holding the queue lock.
+    unsafe fn unpark_lock(&self) -> Self::UnparkHandle;
+}
+#[cfg(feature = "async")]
+mod waker;
+#[cfg(feature = "async")]
+pub use waker::{task_yield, TaskParker};
+
+#[cfg(feature = "async")]
+use crate::thread_parker::UnparkHandleT;

--- a/core/src/task_parker/mod.rs
+++ b/core/src/task_parker/mod.rs
@@ -12,6 +12,8 @@ pub trait TaskParkerT {
 
     fn new(cx: &mut Context<'_>) -> Self;
 
+    fn is_from(&self, cx: &mut Context<'_>) -> bool;
+
     /// Prepares the parker. This should be called before adding it to the queue.
     unsafe fn prepare_park(&self, cx: &mut Context<'_>);
 

--- a/core/src/task_parker/mod.rs
+++ b/core/src/task_parker/mod.rs
@@ -1,37 +1,36 @@
 use crate::thread_parker::UnparkHandleT;
-use std::{
-    task::{Context, Poll},
-    time::Instant,
-};
+use std::{task::Poll, time::Instant};
 
 /// Trait for the platform task parker implementation.
 ///
-/// All unsafe methods are unsafe to mirror the [ThreadParkerT] methods.
+/// All unsafe methods are unsafe to mirror the `ThreadParkerT` methods.
 pub trait TaskParkerT {
+    type Context<'a>;
     type UnparkHandle: UnparkHandleT;
 
-    fn new(cx: &mut Context<'_>) -> Self;
+    fn new(cx: &mut Self::Context<'_>) -> Self;
 
-    fn is_from(&self, cx: &mut Context<'_>) -> bool;
+    /// Checks whether this is a valid `context` to use with this parker.
+    fn is_valid_context(&self, cx: &mut Self::Context<'_>) -> bool;
 
     /// Prepares the parker. This should be called before adding it to the queue.
-    unsafe fn prepare_park(&self, cx: &mut Context<'_>);
+    unsafe fn prepare_park(&self, cx: &mut Self::Context<'_>);
 
     /// Checks if the park timed out. This should be called while holding the
     /// queue lock after `park_until` has returned false.
-    unsafe fn timed_out(&self, cx: &mut Context<'_>) -> bool;
+    unsafe fn timed_out(&self, cx: &mut Self::Context<'_>) -> bool;
 
-    /// Parks the thread until it is unparked. This should be called after it has
+    /// Parks the task until it is unparked. This should be called after it has
     /// been added to the queue, after unlocking the queue.
-    unsafe fn park(&self, cx: &mut Context<'_>) -> Poll<()>;
+    unsafe fn park(&self, cx: &mut Self::Context<'_>) -> Poll<()>;
 
-    /// Parks the thread until it is unparked or the timeout is reached. This
+    /// Parks the task until it is unparked or the timeout is reached. This
     /// should be called after it has been added to the queue, after unlocking
     /// the queue. Returns true if we were unparked and false if we timed out.
-    unsafe fn park_until(&self, cx: &mut Context<'_>, timeout: Instant) -> Poll<bool>;
+    unsafe fn park_until(&self, cx: &mut Self::Context<'_>, timeout: Instant) -> Poll<bool>;
 
-    /// Locks the parker to prevent the target thread from exiting. This is
-    /// necessary to ensure that thread-local `ThreadData` objects remain valid.
+    /// Locks the parker to prevent the target task from exiting.
+    /// This is to mirror `ThreadParkerT::unpark_lock`.
     /// This should be called while holding the queue lock.
     unsafe fn unpark_lock(&self) -> Self::UnparkHandle;
 }

--- a/core/src/task_parker/waker.rs
+++ b/core/src/task_parker/waker.rs
@@ -8,7 +8,7 @@
 //! A simple Context/Waker based task parker.
 
 use crate::thread_parker::UnparkHandleT;
-use crate::util::{current_waker, ImmediateFuture};
+use crate::util::{waker, ImmediateFuture};
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::collections::BinaryHeap;
 use std::sync::mpsc::{channel, Receiver, Sender};
@@ -33,7 +33,7 @@ impl super::TaskParkerT for TaskParker {
         TaskParker {
             parked: AtomicBool::new(false),
             wake_scheduled: AtomicBool::new(true),
-            waker: current_waker().poll_ready(cx),
+            waker: waker().poll_ready(cx),
         }
     }
 
@@ -169,7 +169,7 @@ fn rooster(rx: Receiver<Sleeper>) {
 fn sanity_sleeper_heap_order() {
     use futures::executor::block_on;
     block_on(async {
-        let waker = current_waker().await;
+        let waker = waker().await;
         let now = Instant::now();
         let next = now + Duration::from_secs(1);
         let mut heap = BinaryHeap::from_iter([

--- a/core/src/task_parker/waker.rs
+++ b/core/src/task_parker/waker.rs
@@ -9,6 +9,7 @@
 //! parking facilities available.
 
 use crate::thread_parker::UnparkHandleT;
+use crate::util::{current_waker, ImmediateFuture};
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::collections::BinaryHeap;
 use std::sync::mpsc::{channel, Receiver, Sender};
@@ -30,7 +31,7 @@ impl super::TaskParkerT for TaskParker {
     fn new(cx: &mut Context<'_>) -> TaskParker {
         TaskParker {
             parked: AtomicBool::new(false),
-            waker: cx.waker().clone(),
+            waker: current_waker().poll_ready(cx),
         }
     }
 

--- a/core/src/task_parker/waker.rs
+++ b/core/src/task_parker/waker.rs
@@ -1,0 +1,106 @@
+// Copyright 2016 Amanieu d'Antras
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! A simple spin lock based thread parker. Used on platforms without better
+//! parking facilities available.
+
+use core::sync::atomic::{AtomicBool, Ordering};
+use std::future::Future;
+use std::mem::take;
+use std::pin::Pin;
+use std::task::{Context, Poll, Waker};
+use std::time::Instant;
+
+use crate::thread_parker::UnparkHandleT;
+
+// Helper type for putting a thread to sleep until some other thread wakes it up
+pub struct TaskParker {
+    parked: AtomicBool,
+    waker: Waker,
+}
+
+impl super::TaskParkerT for TaskParker {
+    type UnparkHandle = UnparkHandle;
+
+    const IS_CHEAP_TO_CONSTRUCT: bool = true;
+
+    #[inline]
+    fn new(cx: &mut Context<'_>) -> TaskParker {
+        TaskParker {
+            parked: AtomicBool::new(false),
+            waker: cx.waker().clone(),
+        }
+    }
+
+    #[inline]
+    unsafe fn prepare_park(&self) {
+        self.parked.store(true, Ordering::Relaxed);
+    }
+
+    #[inline]
+    unsafe fn timed_out(&self) -> bool {
+        self.parked.load(Ordering::Relaxed) != false
+    }
+
+    #[inline]
+    unsafe fn park(&self, cx: &mut Context<'_>) -> Poll<()> {
+        assert!(
+            self.waker.will_wake(cx.waker()),
+            "Called TaskParker::park with unrelated context."
+        );
+        if self.parked.load(Ordering::Acquire) {
+            Poll::Pending
+        } else {
+            Poll::Ready(())
+        }
+    }
+
+    #[inline]
+    unsafe fn park_until(&self, cx: &mut Context<'_>, timeout: Instant) -> Poll<bool> {
+        match self.park(cx) {
+            Poll::Ready(()) => Poll::Ready(true),
+            Poll::Pending if Instant::now() >= timeout => Poll::Ready(false),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    #[inline]
+    unsafe fn unpark_lock(&self) -> UnparkHandle {
+        // We don't need to lock anything, just clear the state
+        self.parked.store(false, Ordering::Release);
+        UnparkHandle(self.waker.clone())
+    }
+}
+
+pub struct UnparkHandle(Waker);
+
+impl UnparkHandleT for UnparkHandle {
+    #[inline]
+    unsafe fn unpark(self) {
+        self.0.wake();
+    }
+}
+
+#[derive(Debug)]
+pub struct Yield {
+    once: bool,
+}
+impl Future for Yield {
+    type Output = ();
+    fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if take(&mut self.once) {
+            Poll::Pending
+        } else {
+            Poll::Ready(())
+        }
+    }
+}
+
+#[inline]
+pub async fn task_yield() -> Yield {
+    Yield { once: true }
+}

--- a/core/src/task_parker/waker.rs
+++ b/core/src/task_parker/waker.rs
@@ -86,11 +86,6 @@ impl super::TaskParkerT for TaskParker {
             Poll::Pending => {
                 if !self.wake_scheduled.swap(true, Ordering::Acquire) {
                     schedule_wake(timeout, self.waker.clone());
-                } else {
-                    debug_assert!(
-                        false,
-                        "TaskParker::park_until was called again prematurely."
-                    );
                 }
                 Poll::Pending
             }
@@ -99,21 +94,25 @@ impl super::TaskParkerT for TaskParker {
 
     #[inline]
     unsafe fn unpark_lock(&self) -> UnparkHandle {
-        // We don't need to lock anything, just clear the state
-        self.parked.store(false, Ordering::Release);
-        self.wake_scheduled.store(true, Ordering::Release);
-        UnparkHandle(self.waker.clone())
+        // SAFETY: Only mark as unparked AFTER everything else to avoid
+        //      our owning task spuriously waking before dropping and
+        //      overwriting us while we are still accessing self.
+        self.wake_scheduled.store(true, Ordering::Relaxed);
+        UnparkHandle(&self.parked, self.waker.clone())
     }
 }
 
-pub struct UnparkHandle(Waker);
+pub struct UnparkHandle(*const AtomicBool, Waker);
 impl UnparkHandleT for UnparkHandle {
     #[inline]
     unsafe fn unpark(self) {
-        self.0.wake();
+        // SAFETY: Only mark as unparked AFTER everything else to avoid
+        //      its owning task spuriously waking before dropping and
+        //      overwriting ParkData while we are still accessing it.
+        (&*self.0).store(false, Ordering::Release);
+        self.1.wake();
     }
 }
-
 fn schedule_wake(instant: Instant, waker: Waker) {
     let (tx, rooster) = &*ROOSTER;
     tx.send(Sleeper {

--- a/core/src/task_parker/waker.rs
+++ b/core/src/task_parker/waker.rs
@@ -39,7 +39,7 @@ impl super::TaskParkerT for TaskParker {
 
     #[inline]
     fn is_valid_context(&self, cx: &mut Context<'_>) -> bool {
-        self.waker.will_wake(cx.waker())
+        self.waker.vtable() == Waker::noop().vtable() || self.waker.will_wake(cx.waker())
     }
 
     #[inline]

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -22,7 +22,7 @@ impl<T> UncheckedOptionExt<T> for Option<T> {
 
 // hint::unreachable_unchecked() in release mode
 #[inline]
-unsafe fn unreachable() -> ! {
+pub unsafe fn unreachable() -> ! {
     if cfg!(debug_assertions) {
         unreachable!();
     } else {

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -44,9 +44,9 @@ mod immediate {
     /// and therefore can directly return its output without needing to wrap
     /// it in [Poll::Ready].
     ///
-    /// Usefull as a kind of halfway-point between sync and async execution,
-    /// where you do need to be inside of / building an asynchronous environment,
-    /// but don't actually need or want to be asynchronous yourself.
+    /// Usefull as a kind of halfway-point/intermediary between sync and async execution,
+    /// where you do need an asynchronous environment, but don't actually need or want
+    /// to be asynchronous yourself.
     pub trait ImmediateFuture: Future {
         /// Consumes this [Future] to immediately return
         /// its output without having to wrap it in [Poll].
@@ -96,8 +96,8 @@ mod immediate {
     /// the return value as its [Future::Output].
     ///
     /// Usefull as a kind of halfway-point/intermediary between sync and async execution,
-    /// where you do need to be inside of / building an asynchronous environment,
-    /// but don't actually need or want to be asynchronous yourself.
+    /// where you do need an asynchronous environment, but don't actually need or want
+    /// to be asynchronous yourself.
     pub fn immediate<T, F: FnOnce(&mut Context<'_>) -> T>(f: F) -> Immediate<F> {
         Immediate::from(f)
     }
@@ -106,8 +106,8 @@ mod immediate {
     /// and yielding the return value as its [Future::Output].
     ///
     /// Usefull as a kind of halfway-point/intermediary between sync and async execution,
-    /// where you do need to be inside of / building an asynchronous environment,
-    /// but don't actually need or want to be asynchronous yourself.
+    /// where you do need an asynchronous environment, but don't actually need or want
+    /// to be asynchronous yourself.
     pub fn immediate_with<T, F: FnOnce(T, &mut Context<'_>) -> U, U>(
         t: T,
         f: F,
@@ -135,7 +135,7 @@ mod immediate {
     ///
     /// # Safety
     ///
-    /// The underlying future must yield [Poll::Ready] on its first poll.
+    /// The underlying future must immediately yield [Poll::Ready].
     pub unsafe fn assume_immediate_unchecked<F: Future>(
         f: F,
     ) -> Immediate<(F, fn(F, &mut Context<'_>) -> F::Output)> {

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -29,3 +29,65 @@ pub unsafe fn unreachable() -> ! {
         core::hint::unreachable_unchecked()
     }
 }
+
+#[cfg(feature = "async")]
+mod immediate {
+    use std::{
+        future::{Future, Ready},
+        pin::Pin,
+        task::{Context, Poll, Waker},
+    };
+    pub trait ImmediateFuture: Future {
+        fn poll_ready(self, cx: &mut Context<'_>) -> Self::Output;
+    }
+    impl<T> ImmediateFuture for Ready<T> {
+        fn poll_ready(self, _: &mut Context<'_>) -> Self::Output {
+            self.into_inner()
+        }
+    }
+    pub struct Immediate<F = fn(&mut Context<'_>)>(Option<F>);
+    impl<F> From<F> for Immediate<F> {
+        fn from(value: F) -> Self {
+            Self(Some(value))
+        }
+    }
+    impl<F> Unpin for Immediate<F> {}
+    impl<T, F: FnOnce(&mut Context<'_>) -> T> Future for Immediate<F> {
+        type Output = T;
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            Poll::Ready(self.0.take().expect("polled twice")(cx))
+        }
+    }
+    impl<T, F: FnOnce(&mut Context<'_>) -> T> ImmediateFuture for Immediate<F> {
+        fn poll_ready(self, cx: &mut Context<'_>) -> Self::Output {
+            self.0.expect("polled twice")(cx)
+        }
+    }
+    impl<T, U, F: FnOnce(T, &mut Context<'_>) -> U> Future for Immediate<(T, F)> {
+        type Output = U;
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let (t, f) = self.0.take().expect("polled twice");
+            Poll::Ready(f(t, cx))
+        }
+    }
+    impl<T, U, F: FnOnce(T, &mut Context<'_>) -> U> ImmediateFuture for Immediate<(T, F)> {
+        fn poll_ready(self, cx: &mut Context<'_>) -> Self::Output {
+            let (t, f) = self.0.expect("polled twice");
+            f(t, cx)
+        }
+    }
+    pub fn immediate<T, F: FnOnce(&mut Context<'_>) -> T>(f: F) -> Immediate<F> {
+        Immediate::from(f)
+    }
+    pub fn immediate_with<T, U, F: FnOnce(T, &mut Context<'_>) -> U>(
+        t: T,
+        f: F,
+    ) -> Immediate<(T, F)> {
+        Immediate::from((t, f))
+    }
+    pub fn current_waker() -> Immediate<fn(&mut Context<'_>) -> Waker> {
+        immediate(|cx| cx.waker().clone())
+    }
+}
+#[cfg(feature = "async")]
+pub use immediate::*;

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -20,7 +20,8 @@ impl<T> UncheckedOptionExt<T> for Option<T> {
     }
 }
 
-// hint::unreachable_unchecked() in release mode
+/// `core::macros::unreachable` in debug mode,
+/// `core::hint::unreachable_unchecked()` in release mode
 #[inline]
 pub unsafe fn unreachable() -> ! {
     if cfg!(debug_assertions) {
@@ -32,12 +33,23 @@ pub unsafe fn unreachable() -> ! {
 
 #[cfg(feature = "async")]
 mod immediate {
+    use crate::util::unreachable;
     use std::{
         future::{Future, Ready},
-        pin::Pin,
+        pin::{pin, Pin},
         task::{Context, Poll, Waker},
     };
+    /// An immediate future is one that only needs to access the [Context]
+    /// to immediately finish without ever yielding [Poll::Pending]
+    /// and therefore can directly return its output without needing to wrap
+    /// it in [Poll::Ready].
+    ///
+    /// Usefull as a kind of halfway-point between sync and async execution,
+    /// where you do need to be inside of / building an asynchronous environment,
+    /// but don't actually need or want to be asynchronous yourself.
     pub trait ImmediateFuture: Future {
+        /// Consumes this [Future] to immediately return
+        /// its output without having to wrap it in [Poll].
         fn poll_ready(self, cx: &mut Context<'_>) -> Self::Output;
     }
     impl<T> ImmediateFuture for Ready<T> {
@@ -45,27 +57,97 @@ mod immediate {
             self.into_inner()
         }
     }
+    /// A future that immediately finishes without ever yielding [Poll::Pending].
+    ///
+    /// Created by [immediate]. See its and [ImmediateFuture]s documentation for more information.
     pub struct Immediate<F = fn(&mut Context<'_>)>(Option<F>);
+    impl<F> Unpin for Immediate<F> {}
     impl<F> From<F> for Immediate<F> {
         fn from(value: F) -> Self {
             Self(Some(value))
         }
     }
-    impl<T, F: Unpin + FnOnce(&mut Context<'_>) -> T> Future for Immediate<F> {
+    impl<T, F: FnOnce(&mut Context<'_>) -> T> Future for Immediate<F> {
         type Output = T;
         fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
             Poll::Ready(self.0.take().expect("polled twice")(cx))
         }
     }
-    impl<T, F: Unpin + FnOnce(&mut Context<'_>) -> T> ImmediateFuture for Immediate<F> {
+    impl<T, F: FnOnce(&mut Context<'_>) -> T> ImmediateFuture for Immediate<F> {
         fn poll_ready(self, cx: &mut Context<'_>) -> Self::Output {
             self.0.expect("polled twice")(cx)
         }
     }
+    impl<T, F> Future for Immediate<(F, fn(F, &mut Context<'_>) -> T)> {
+        type Output = T;
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let (f, ready) = self.0.take().expect("polled twice");
+            Poll::Ready(ready(f, cx))
+        }
+    }
+    impl<T, F> ImmediateFuture for Immediate<(F, fn(F, &mut Context<'_>) -> T)> {
+        fn poll_ready(mut self, cx: &mut Context<'_>) -> Self::Output {
+            let (f, ready) = self.0.take().expect("polled twice");
+            ready(f, cx)
+        }
+    }
+    /// Creates a new [ImmediateFuture] wrapping around a function
+    /// taking a mutable [Context] reference as its argument and yielding
+    /// the return value as its [Future::Output].
+    ///
+    /// Usefull as a kind of halfway-point/intermediary between sync and async execution,
+    /// where you do need to be inside of / building an asynchronous environment,
+    /// but don't actually need or want to be asynchronous yourself.
     pub fn immediate<T, F: FnOnce(&mut Context<'_>) -> T>(f: F) -> Immediate<F> {
         Immediate::from(f)
     }
-    pub fn current_waker() -> Immediate<fn(&mut Context<'_>) -> Waker> {
+    /// Creates a new [ImmediateFuture] wrapping around a value and function
+    /// taking that value as well as a mutable [Context] reference as its arguments
+    /// and yielding the return value as its [Future::Output].
+    ///
+    /// Usefull as a kind of halfway-point/intermediary between sync and async execution,
+    /// where you do need to be inside of / building an asynchronous environment,
+    /// but don't actually need or want to be asynchronous yourself.
+    pub fn immediate_with<T, F: FnOnce(T, &mut Context<'_>) -> U, U>(
+        t: T,
+        f: F,
+    ) -> Immediate<(T, F)> {
+        Immediate::from((t, f))
+    }
+    /// Creates an [Immediate] wrapping around a future by assuming
+    /// that polling it will immediately yield [Poll::Ready],
+    /// and panicking if it doesn't.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `poll(_ready)` if the underlying future fails to yield [Poll::Ready].
+    pub fn assume_immediate<F: Future>(
+        f: F,
+    ) -> Immediate<(F, fn(F, &mut Context<'_>) -> F::Output)> {
+        let ready: fn(F, &mut Context<'_>) -> F::Output = |f, cx| match pin!(f).poll(cx) {
+            Poll::Ready(v) => v,
+            Poll::Pending => panic!("The future passed to as_immediate yielded Poll::Pending."),
+        };
+        Immediate::from((f, ready))
+    }
+    /// Creates an [Immediate] wrapping around a future by assuming
+    /// that polling it will immediately yield [Poll::Ready].
+    ///
+    /// # Safety
+    ///
+    /// The underlying future must yield [Poll::Ready] on its first poll.
+    pub unsafe fn assume_immediate_unchecked<F: Future>(
+        f: F,
+    ) -> Immediate<(F, fn(F, &mut Context<'_>) -> F::Output)> {
+        let ready: fn(F, &mut Context<'_>) -> F::Output = |f, cx| match pin!(f).poll(cx) {
+            Poll::Ready(v) => v,
+            Poll::Pending => unreachable(),
+        };
+        Immediate::from((f, ready))
+    }
+    /// Returns an [ImmediateFuture] that returns the [Waker]
+    /// for the current asynchronous [Context].
+    pub fn waker() -> Immediate<fn(&mut Context<'_>) -> Waker> {
         immediate(|cx| cx.waker().clone())
     }
 }


### PR DESCRIPTION
# Summary
Added support for asynchronous parking to parking_lot_core behind a feature flag, and in the process also made all the (un)park-methods reuse their queue manipulation logic, as well as added a future extension trait and methods to util.
# Motivation
I was recently playing around with synchronization primitives and sync/async interop. While trying to implement [something](https://github.com/Wulf0x67E7/conutex) using parking_lot_core, I wanted to add async support, but realized that parking lot didn't support what I needed for that. I then thought that extending it myself would be a fun and doable project.
# Changes
 - Added feature "async"

 - Added optional dependency "futures" (couldn't work out how to make it a feature dependent dev-dependency)
 - Added function `parking_lot_core::park_task`
 - Added `ImmediateFuture` utility trait, struct, and functions
 - Refactored `park` and `park_task` to reuse shared queue manipulation logic
 - Refactored the various `unpark` methods to also reuse the shared queue manipulation logic
 - Extended the testing tools to also work with async and mixed sync/async operations and made it pass both normally and under miri
 - Added documentation and comments for the new/refactored code
 - [025af7e] Added dependency `scopeguard = { version = "1.1.0", default-features = false }`
# Issues
 - Full optional "futures" dependency instead of just dev-dependency
 - [025af7e] ~`park_task` has even stricter safety requirements then `park`, namely that the resulting future can not be dropped or forgotten before being unparked or timed out.~
 - [025af7e] ~Because of that, when using `park_task` to implement e.g. an asynchronous-aware Mutex its unsafety cannot be fully mitigated unless you yourself are the one synchronously polling it to completion, which kinda defeats the point.~
# Notes
 - [025af7e] Leaking the future from `park_task`~, unlike dropping or forgetting,~ is actually fine and won't even block other things from making progress because `ImmediateFuture` ensures it cant yield while still holding the queue lock.
 - [025af7e]~Thinking about it now, leaking `park_task`s `ParkData` at the beginning and then only "un-leaking"  and dropping it at the end could fix the extra unsafety, but would require allocation and, obviously, risk leaking memory.~
 - The aproach used in [025af7e]  to make `park_task` panic safe could also be applied to `park`.