### PR TITLE
Add `lock_api::{Lock}::into_inner_with_raw`

### DIFF
--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -179,6 +179,12 @@ impl<R, T> Mutex<R, T> {
     pub const fn const_new(raw_mutex: R, val: T) -> Mutex<R, T> {
         Self::from_raw(raw_mutex, val)
     }
+
+    /// Consumes this mutex, returning the underlying data and raw mutex.
+    #[inline]
+    pub fn into_inner_with_raw(self) -> (R, T) {
+        (self.raw, self.data.into_inner())
+    }
 }
 
 impl<R: RawMutex, T: ?Sized> Mutex<R, T> {

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -276,6 +276,17 @@ impl<R, G, T> ReentrantMutex<R, G, T> {
     pub const fn const_new(raw_mutex: R, get_thread_id: G, val: T) -> ReentrantMutex<R, G, T> {
         Self::from_raw(raw_mutex, get_thread_id, val)
     }
+
+    /// Consumes this mutex, returning the underlying data, raw mutex and
+    /// thread ID helper.
+    #[inline]
+    pub fn into_inner_with_raw(self) -> (R, G, T) {
+        (
+            self.raw.mutex,
+            self.raw.get_thread_id,
+            self.data.into_inner(),
+        )
+    }
 }
 
 impl<R: RawMutex, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -404,6 +404,12 @@ impl<R, T> RwLock<R, T> {
     pub const fn const_new(raw_rwlock: R, val: T) -> RwLock<R, T> {
         Self::from_raw(raw_rwlock, val)
     }
+
+    /// Consumes this read-write lock, returning the underlying data and raw lock.
+    #[inline]
+    pub fn into_inner_with_raw(self) -> (R, T) {
+        (self.raw, self.data.into_inner())
+    }
 }
 
 impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {


### PR DESCRIPTION
# Objective

- Fix #521 with the [agreed upon](https://github.com/Amanieu/parking_lot/issues/521#issuecomment-4654193357) solution.

## Solution

### `lock_api`

- Added `{Mutex, ReentrantMutex, RwLock}::into_inner_with_raw`, which returns the values required to call the relevant `from_raw` function.

---

## Notes

- No AI tooling of any kind was used during the creation of this PR.