### PR TITLE
Split `RawMutex` and `RawRwLock` into core and init traits

### DIFF
--- a/lock_api/src/mutex.rs
+++ b/lock_api/src/mutex.rs
@@ -33,6 +33,89 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 ///
 /// Implementations of this trait must ensure that the mutex is actually
 /// exclusive: a lock can't be acquired while the mutex is already locked.
+pub unsafe trait RawMutexCore {
+    /// Marker type which determines whether a lock guard should be `Send`. Use
+    /// one of the `GuardSend` or `GuardNoSend` helper types here.
+    type GuardMarker;
+
+    /// Acquires this mutex, blocking the current thread until it is able to do so.
+    fn lock(&self);
+
+    /// Attempts to acquire this mutex without blocking. Returns `true`
+    /// if the lock was successfully acquired and `false` otherwise.
+    fn try_lock(&self) -> bool;
+
+    /// Unlocks this mutex.
+    ///
+    /// # Safety
+    ///
+    /// This method may only be called if the mutex is held in the current context, i.e. it must
+    /// be paired with a successful call to [`lock`], [`try_lock`], [`try_lock_for`] or [`try_lock_until`].
+    ///
+    /// [`lock`]: RawMutexCore::lock
+    /// [`try_lock`]: RawMutexCore::try_lock
+    /// [`try_lock_for`]: RawMutexTimed::try_lock_for
+    /// [`try_lock_until`]: RawMutexTimed::try_lock_until
+    unsafe fn unlock(&self);
+
+    /// Checks whether the mutex is currently locked.
+    #[inline]
+    fn is_locked(&self) -> bool {
+        let acquired_lock = self.try_lock();
+        if acquired_lock {
+            // Safety: The lock has been successfully acquired above.
+            unsafe {
+                self.unlock();
+            }
+        }
+        !acquired_lock
+    }
+}
+
+unsafe impl<R: RawMutex> RawMutexCore for R {
+    type GuardMarker = <Self as RawMutex>::GuardMarker;
+
+    fn lock(&self) {
+        <Self as RawMutex>::lock(self);
+    }
+
+    fn try_lock(&self) -> bool {
+        <Self as RawMutex>::try_lock(self)
+    }
+
+    unsafe fn unlock(&self) {
+        unsafe {
+            <Self as RawMutex>::unlock(self);
+        }
+    }
+
+    fn is_locked(&self) -> bool {
+        <Self as RawMutex>::is_locked(self)
+    }
+}
+
+/// Provides a constant default value for an unlocked mutex.
+pub unsafe trait RawMutexInit {
+    /// Initial value for an unlocked mutex.
+    // A “non-constant” const item is a legacy way to supply an initialized value to downstream
+    // static items. Can hopefully be replaced with `const fn new() -> Self` at some point.
+    #[allow(clippy::declare_interior_mutable_const)]
+    const INIT: Self;
+}
+
+unsafe impl<R: RawMutex> RawMutexInit for R {
+    const INIT: Self = <Self as RawMutex>::INIT;
+}
+
+/// Basic operations for a mutex.
+///
+/// Types implementing this trait can be used by `Mutex` to form a safe and
+/// fully-functioning mutex type.
+///
+/// # Safety
+///
+/// Implementations of this trait must ensure that the mutex is actually
+/// exclusive: a lock can't be acquired while the mutex is already locked.
 pub unsafe trait RawMutex {
     /// Initial value for an unlocked mutex.
     // A “non-constant” const item is a legacy way to supply an initialized value to downstream
@@ -84,13 +167,13 @@ pub unsafe trait RawMutex {
 /// thread if there is one, without giving other threads the opportunity to
 /// "steal" the lock in the meantime. This is typically slower than unfair
 /// unlocking, but may be necessary in certain circumstances.
-pub unsafe trait RawMutexFair: RawMutex {
+pub unsafe trait RawMutexFair: RawMutexCore {
     /// Unlocks this mutex using a fair unlock protocol.
     ///
     /// # Safety
     ///
     /// This method may only be called if the mutex is held in the current context, see
-    /// the documentation of [`unlock`](RawMutex::unlock).
+    /// the documentation of [`unlock`](RawMutexCore::unlock).
     unsafe fn unlock_fair(&self);
 
     /// Temporarily yields the mutex to a waiting thread if there is one.
@@ -102,7 +185,7 @@ pub unsafe trait RawMutexFair: RawMutex {
     /// # Safety
     ///
     /// This method may only be called if the mutex is held in the current context, see
-    /// the documentation of [`unlock`](RawMutex::unlock).
+    /// the documentation of [`unlock`](RawMutexCore::unlock).
     unsafe fn bump(&self) {
         self.unlock_fair();
         self.lock();
@@ -113,7 +196,7 @@ pub unsafe trait RawMutexFair: RawMutex {
 ///
 /// The `Duration` and `Instant` types are specified as associated types so that
 /// this trait is usable even in `no_std` environments.
-pub unsafe trait RawMutexTimed: RawMutex {
+pub unsafe trait RawMutexTimed: RawMutexCore {
     /// Duration type used for `try_lock_for`.
     type Duration;
 
@@ -140,10 +223,10 @@ pub struct Mutex<R, T: ?Sized> {
     data: UnsafeCell<T>,
 }
 
-unsafe impl<R: RawMutex + Send, T: ?Sized + Send> Send for Mutex<R, T> {}
-unsafe impl<R: RawMutex + Sync, T: ?Sized + Send> Sync for Mutex<R, T> {}
+unsafe impl<R: RawMutexCore + Send, T: ?Sized + Send> Send for Mutex<R, T> {}
+unsafe impl<R: RawMutexCore + Sync, T: ?Sized + Send> Sync for Mutex<R, T> {}
 
-impl<R: RawMutex, T> Mutex<R, T> {
+impl<R: RawMutexInit, T> Mutex<R, T> {
     /// Creates a new mutex in an unlocked state ready for use.
     #[inline]
     pub const fn new(val: T) -> Mutex<R, T> {
@@ -152,7 +235,9 @@ impl<R: RawMutex, T> Mutex<R, T> {
             data: UnsafeCell::new(val),
         }
     }
+}
 
+impl<R: RawMutexCore, T> Mutex<R, T> {
     /// Consumes this mutex, returning the underlying data.
     #[inline]
     pub fn into_inner(self) -> T {
@@ -181,7 +266,7 @@ impl<R, T> Mutex<R, T> {
     }
 }
 
-impl<R: RawMutex, T: ?Sized> Mutex<R, T> {
+impl<R: RawMutexCore, T: ?Sized> Mutex<R, T> {
     /// Creates a new `MutexGuard` without checking if the mutex is locked.
     ///
     /// # Safety
@@ -268,7 +353,7 @@ impl<R: RawMutex, T: ?Sized> Mutex<R, T> {
 
     /// Returns the underlying raw mutex object.
     ///
-    /// Note that you will most likely need to import the `RawMutex` trait from
+    /// Note that you will most likely need to import the `RawMutexCore` trait from
     /// `lock_api` to be able to call functions on the raw mutex.
     ///
     /// # Safety
@@ -431,21 +516,21 @@ impl<R: RawMutexTimed, T: ?Sized> Mutex<R, T> {
     }
 }
 
-impl<R: RawMutex, T: ?Sized + Default> Default for Mutex<R, T> {
+impl<R: RawMutexInit, T: ?Sized + Default> Default for Mutex<R, T> {
     #[inline]
     fn default() -> Mutex<R, T> {
         Mutex::new(Default::default())
     }
 }
 
-impl<R: RawMutex, T> From<T> for Mutex<R, T> {
+impl<R: RawMutexInit, T> From<T> for Mutex<R, T> {
     #[inline]
     fn from(t: T) -> Mutex<R, T> {
         Mutex::new(t)
     }
 }
 
-impl<R: RawMutex, T: ?Sized + fmt::Debug> fmt::Debug for Mutex<R, T> {
+impl<R: RawMutexCore, T: ?Sized + fmt::Debug> fmt::Debug for Mutex<R, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.try_lock() {
             Some(guard) => f.debug_struct("Mutex").field("data", &&*guard).finish(),
@@ -469,7 +554,7 @@ impl<R: RawMutex, T: ?Sized + fmt::Debug> fmt::Debug for Mutex<R, T> {
 #[cfg(feature = "serde")]
 impl<R, T> Serialize for Mutex<R, T>
 where
-    R: RawMutex,
+    R: RawMutexCore,
     T: Serialize + ?Sized,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -483,7 +568,7 @@ where
 #[cfg(feature = "serde")]
 impl<'de, R, T> Deserialize<'de> for Mutex<R, T>
 where
-    R: RawMutex,
+    R: RawMutexInit,
     T: Deserialize<'de> + ?Sized,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -501,14 +586,14 @@ where
 /// `Deref` and `DerefMut` implementations.
 #[clippy::has_significant_drop]
 #[must_use = "if unused the Mutex will immediately unlock"]
-pub struct MutexGuard<'a, R: RawMutex, T: ?Sized> {
+pub struct MutexGuard<'a, R: RawMutexCore, T: ?Sized> {
     mutex: &'a Mutex<R, T>,
     marker: PhantomData<(&'a mut T, R::GuardMarker)>,
 }
 
-unsafe impl<'a, R: RawMutex + Sync + 'a, T: ?Sized + Sync + 'a> Sync for MutexGuard<'a, R, T> {}
+unsafe impl<'a, R: RawMutexCore + Sync + 'a, T: ?Sized + Sync + 'a> Sync for MutexGuard<'a, R, T> {}
 
-impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> MutexGuard<'a, R, T> {
+impl<'a, R: RawMutexCore + 'a, T: ?Sized + 'a> MutexGuard<'a, R, T> {
     /// Returns a reference to the original `Mutex` object.
     pub fn mutex(s: &Self) -> &'a Mutex<R, T> {
         s.mutex
@@ -683,7 +768,7 @@ impl<'a, R: RawMutexFair + 'a, T: ?Sized + 'a> MutexGuard<'a, R, T> {
     }
 }
 
-impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> Deref for MutexGuard<'a, R, T> {
+impl<'a, R: RawMutexCore + 'a, T: ?Sized + 'a> Deref for MutexGuard<'a, R, T> {
     type Target = T;
     #[inline]
     fn deref(&self) -> &T {
@@ -691,14 +776,14 @@ impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> Deref for MutexGuard<'a, R, T> {
     }
 }
 
-impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> DerefMut for MutexGuard<'a, R, T> {
+impl<'a, R: RawMutexCore + 'a, T: ?Sized + 'a> DerefMut for MutexGuard<'a, R, T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut T {
         unsafe { &mut *self.mutex.data.get() }
     }
 }
 
-impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> Drop for MutexGuard<'a, R, T> {
+impl<'a, R: RawMutexCore + 'a, T: ?Sized + 'a> Drop for MutexGuard<'a, R, T> {
     #[inline]
     fn drop(&mut self) {
         // Safety: A MutexGuard always holds the lock.
@@ -708,20 +793,22 @@ impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> Drop for MutexGuard<'a, R, T> {
     }
 }
 
-impl<'a, R: RawMutex + 'a, T: fmt::Debug + ?Sized + 'a> fmt::Debug for MutexGuard<'a, R, T> {
+impl<'a, R: RawMutexCore + 'a, T: fmt::Debug + ?Sized + 'a> fmt::Debug for MutexGuard<'a, R, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
 
-impl<'a, R: RawMutex + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display for MutexGuard<'a, R, T> {
+impl<'a, R: RawMutexCore + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
+    for MutexGuard<'a, R, T>
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (**self).fmt(f)
     }
 }
 
 #[cfg(feature = "owning_ref")]
-unsafe impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> StableAddress for MutexGuard<'a, R, T> {}
+unsafe impl<'a, R: RawMutexCore + 'a, T: ?Sized + 'a> StableAddress for MutexGuard<'a, R, T> {}
 
 /// An RAII mutex guard returned by the `Arc` locking operations on `Mutex`.
 ///
@@ -730,24 +817,24 @@ unsafe impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> StableAddress for MutexGuard<'
 #[cfg(feature = "arc_lock")]
 #[clippy::has_significant_drop]
 #[must_use = "if unused the Mutex will immediately unlock"]
-pub struct ArcMutexGuard<R: RawMutex, T: ?Sized> {
+pub struct ArcMutexGuard<R: RawMutexCore, T: ?Sized> {
     mutex: Arc<Mutex<R, T>>,
     marker: PhantomData<*const ()>,
 }
 
 #[cfg(feature = "arc_lock")]
-unsafe impl<R: RawMutex + Send + Sync, T: Send + ?Sized> Send for ArcMutexGuard<R, T> where
+unsafe impl<R: RawMutexCore + Send + Sync, T: Send + ?Sized> Send for ArcMutexGuard<R, T> where
     R::GuardMarker: Send
 {
 }
 #[cfg(feature = "arc_lock")]
-unsafe impl<R: RawMutex + Sync, T: Sync + ?Sized> Sync for ArcMutexGuard<R, T> where
+unsafe impl<R: RawMutexCore + Sync, T: Sync + ?Sized> Sync for ArcMutexGuard<R, T> where
     R::GuardMarker: Sync
 {
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawMutex, T: ?Sized> ArcMutexGuard<R, T> {
+impl<R: RawMutexCore, T: ?Sized> ArcMutexGuard<R, T> {
     /// Returns a reference to the `Mutex` this is guarding, contained in its `Arc`.
     #[inline]
     pub fn mutex(s: &Self) -> &Arc<Mutex<R, T>> {
@@ -838,7 +925,7 @@ impl<R: RawMutexFair, T: ?Sized> ArcMutexGuard<R, T> {
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawMutex, T: ?Sized> Deref for ArcMutexGuard<R, T> {
+impl<R: RawMutexCore, T: ?Sized> Deref for ArcMutexGuard<R, T> {
     type Target = T;
     #[inline]
     fn deref(&self) -> &T {
@@ -847,7 +934,7 @@ impl<R: RawMutex, T: ?Sized> Deref for ArcMutexGuard<R, T> {
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawMutex, T: ?Sized> DerefMut for ArcMutexGuard<R, T> {
+impl<R: RawMutexCore, T: ?Sized> DerefMut for ArcMutexGuard<R, T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut T {
         unsafe { &mut *self.mutex.data.get() }
@@ -855,7 +942,7 @@ impl<R: RawMutex, T: ?Sized> DerefMut for ArcMutexGuard<R, T> {
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawMutex, T: ?Sized> Drop for ArcMutexGuard<R, T> {
+impl<R: RawMutexCore, T: ?Sized> Drop for ArcMutexGuard<R, T> {
     #[inline]
     fn drop(&mut self) {
         // Safety: A MutexGuard always holds the lock.
@@ -874,22 +961,22 @@ impl<R: RawMutex, T: ?Sized> Drop for ArcMutexGuard<R, T> {
 /// thread.
 #[clippy::has_significant_drop]
 #[must_use = "if unused the Mutex will immediately unlock"]
-pub struct MappedMutexGuard<'a, R: RawMutex, T: ?Sized> {
+pub struct MappedMutexGuard<'a, R: RawMutexCore, T: ?Sized> {
     raw: &'a R,
     data: *mut T,
     marker: PhantomData<&'a mut T>,
 }
 
-unsafe impl<'a, R: RawMutex + Sync + 'a, T: ?Sized + Sync + 'a> Sync
+unsafe impl<'a, R: RawMutexCore + Sync + 'a, T: ?Sized + Sync + 'a> Sync
     for MappedMutexGuard<'a, R, T>
 {
 }
-unsafe impl<'a, R: RawMutex + 'a, T: ?Sized + Send + 'a> Send for MappedMutexGuard<'a, R, T> where
+unsafe impl<'a, R: RawMutexCore + 'a, T: ?Sized + Send + 'a> Send for MappedMutexGuard<'a, R, T> where
     R::GuardMarker: Send
 {
 }
 
-impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> MappedMutexGuard<'a, R, T> {
+impl<'a, R: RawMutexCore + 'a, T: ?Sized + 'a> MappedMutexGuard<'a, R, T> {
     /// Makes a new `MappedMutexGuard` for a component of the locked data.
     ///
     /// This operation cannot fail as the `MappedMutexGuard` passed
@@ -996,7 +1083,7 @@ impl<'a, R: RawMutexFair + 'a, T: ?Sized + 'a> MappedMutexGuard<'a, R, T> {
     }
 }
 
-impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> Deref for MappedMutexGuard<'a, R, T> {
+impl<'a, R: RawMutexCore + 'a, T: ?Sized + 'a> Deref for MappedMutexGuard<'a, R, T> {
     type Target = T;
     #[inline]
     fn deref(&self) -> &T {
@@ -1004,14 +1091,14 @@ impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> Deref for MappedMutexGuard<'a, R, T> 
     }
 }
 
-impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> DerefMut for MappedMutexGuard<'a, R, T> {
+impl<'a, R: RawMutexCore + 'a, T: ?Sized + 'a> DerefMut for MappedMutexGuard<'a, R, T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut T {
         unsafe { &mut *self.data }
     }
 }
 
-impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> Drop for MappedMutexGuard<'a, R, T> {
+impl<'a, R: RawMutexCore + 'a, T: ?Sized + 'a> Drop for MappedMutexGuard<'a, R, T> {
     #[inline]
     fn drop(&mut self) {
         // Safety: A MappedMutexGuard always holds the lock.
@@ -1021,13 +1108,15 @@ impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> Drop for MappedMutexGuard<'a, R, T> {
     }
 }
 
-impl<'a, R: RawMutex + 'a, T: fmt::Debug + ?Sized + 'a> fmt::Debug for MappedMutexGuard<'a, R, T> {
+impl<'a, R: RawMutexCore + 'a, T: fmt::Debug + ?Sized + 'a> fmt::Debug
+    for MappedMutexGuard<'a, R, T>
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
 
-impl<'a, R: RawMutex + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
+impl<'a, R: RawMutexCore + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
     for MappedMutexGuard<'a, R, T>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1036,4 +1125,4 @@ impl<'a, R: RawMutex + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
 }
 
 #[cfg(feature = "owning_ref")]
-unsafe impl<'a, R: RawMutex + 'a, T: ?Sized + 'a> StableAddress for MappedMutexGuard<'a, R, T> {}
+unsafe impl<'a, R: RawMutexCore + 'a, T: ?Sized + 'a> StableAddress for MappedMutexGuard<'a, R, T> {}

--- a/lock_api/src/remutex.rs
+++ b/lock_api/src/remutex.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::{
-    mutex::{RawMutex, RawMutexFair, RawMutexTimed},
+    mutex::{RawMutexCore, RawMutexFair, RawMutexInit, RawMutexTimed},
     GuardNoSend,
 };
 use core::{
@@ -68,10 +68,10 @@ pub struct RawReentrantMutex<R, G> {
     get_thread_id: G,
 }
 
-unsafe impl<R: RawMutex + Send, G: GetThreadId + Send> Send for RawReentrantMutex<R, G> {}
-unsafe impl<R: RawMutex + Sync, G: GetThreadId + Sync> Sync for RawReentrantMutex<R, G> {}
+unsafe impl<R: RawMutexCore + Send, G: GetThreadId + Send> Send for RawReentrantMutex<R, G> {}
+unsafe impl<R: RawMutexCore + Sync, G: GetThreadId + Sync> Sync for RawReentrantMutex<R, G> {}
 
-impl<R: RawMutex, G: GetThreadId> RawReentrantMutex<R, G> {
+impl<R: RawMutexInit, G: GetThreadId> RawReentrantMutex<R, G> {
     /// Initial value for an unlocked mutex.
     #[allow(clippy::declare_interior_mutable_const)]
     pub const INIT: Self = RawReentrantMutex {
@@ -80,7 +80,9 @@ impl<R: RawMutex, G: GetThreadId> RawReentrantMutex<R, G> {
         mutex: R::INIT,
         get_thread_id: G::INIT,
     };
+}
 
+impl<R: RawMutexCore, G: GetThreadId> RawReentrantMutex<R, G> {
     #[inline]
     fn lock_internal<F: FnOnce() -> bool>(&self, try_lock: F) -> bool {
         let id = self.get_thread_id.nonzero_thread_id().get();
@@ -218,16 +220,16 @@ pub struct ReentrantMutex<R, G, T: ?Sized> {
     data: UnsafeCell<T>,
 }
 
-unsafe impl<R: RawMutex + Send, G: GetThreadId + Send, T: ?Sized + Send> Send
+unsafe impl<R: RawMutexCore + Send, G: GetThreadId + Send, T: ?Sized + Send> Send
     for ReentrantMutex<R, G, T>
 {
 }
-unsafe impl<R: RawMutex + Sync, G: GetThreadId + Sync, T: ?Sized + Send> Sync
+unsafe impl<R: RawMutexCore + Sync, G: GetThreadId + Sync, T: ?Sized + Send> Sync
     for ReentrantMutex<R, G, T>
 {
 }
 
-impl<R: RawMutex, G: GetThreadId, T> ReentrantMutex<R, G, T> {
+impl<R: RawMutexInit, G: GetThreadId, T> ReentrantMutex<R, G, T> {
     /// Creates a new reentrant mutex in an unlocked state ready for use.
     #[inline]
     pub const fn new(val: T) -> ReentrantMutex<R, G, T> {
@@ -241,7 +243,9 @@ impl<R: RawMutex, G: GetThreadId, T> ReentrantMutex<R, G, T> {
             },
         }
     }
+}
 
+impl<R: RawMutexCore, G: GetThreadId, T> ReentrantMutex<R, G, T> {
     /// Consumes this mutex, returning the underlying data.
     #[inline]
     pub fn into_inner(self) -> T {
@@ -278,7 +282,7 @@ impl<R, G, T> ReentrantMutex<R, G, T> {
     }
 }
 
-impl<R: RawMutex, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
+impl<R: RawMutexCore, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     /// Creates a new `ReentrantMutexGuard` without checking if the lock is held.
     ///
     /// # Safety
@@ -373,7 +377,7 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
 
     /// Returns the underlying raw mutex object.
     ///
-    /// Note that you will most likely need to import the `RawMutex` trait from
+    /// Note that you will most likely need to import the `RawMutexCore` trait from
     /// `lock_api` to be able to call functions on the raw mutex.
     ///
     /// # Safety
@@ -540,21 +544,23 @@ impl<R: RawMutexTimed, G: GetThreadId, T: ?Sized> ReentrantMutex<R, G, T> {
     }
 }
 
-impl<R: RawMutex, G: GetThreadId, T: ?Sized + Default> Default for ReentrantMutex<R, G, T> {
+impl<R: RawMutexInit, G: GetThreadId, T: ?Sized + Default> Default for ReentrantMutex<R, G, T> {
     #[inline]
     fn default() -> ReentrantMutex<R, G, T> {
         ReentrantMutex::new(Default::default())
     }
 }
 
-impl<R: RawMutex, G: GetThreadId, T> From<T> for ReentrantMutex<R, G, T> {
+impl<R: RawMutexInit, G: GetThreadId, T> From<T> for ReentrantMutex<R, G, T> {
     #[inline]
     fn from(t: T) -> ReentrantMutex<R, G, T> {
         ReentrantMutex::new(t)
     }
 }
 
-impl<R: RawMutex, G: GetThreadId, T: ?Sized + fmt::Debug> fmt::Debug for ReentrantMutex<R, G, T> {
+impl<R: RawMutexCore, G: GetThreadId, T: ?Sized + fmt::Debug> fmt::Debug
+    for ReentrantMutex<R, G, T>
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.try_lock() {
             Some(guard) => f
@@ -581,7 +587,7 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized + fmt::Debug> fmt::Debug for Reentra
 #[cfg(feature = "serde")]
 impl<R, G, T> Serialize for ReentrantMutex<R, G, T>
 where
-    R: RawMutex,
+    R: RawMutexCore,
     G: GetThreadId,
     T: Serialize + ?Sized,
 {
@@ -596,7 +602,7 @@ where
 #[cfg(feature = "serde")]
 impl<'de, R, G, T> Deserialize<'de> for ReentrantMutex<R, G, T>
 where
-    R: RawMutex,
+    R: RawMutexInit,
     G: GetThreadId,
     T: Deserialize<'de> + ?Sized,
 {
@@ -615,17 +621,19 @@ where
 /// `Deref` implementation.
 #[clippy::has_significant_drop]
 #[must_use = "if unused the ReentrantMutex will immediately unlock"]
-pub struct ReentrantMutexGuard<'a, R: RawMutex, G: GetThreadId, T: ?Sized> {
+pub struct ReentrantMutexGuard<'a, R: RawMutexCore, G: GetThreadId, T: ?Sized> {
     remutex: &'a ReentrantMutex<R, G, T>,
     marker: PhantomData<(&'a T, GuardNoSend)>,
 }
 
-unsafe impl<'a, R: RawMutex + Sync + 'a, G: GetThreadId + Sync + 'a, T: ?Sized + Sync + 'a> Sync
+unsafe impl<'a, R: RawMutexCore + Sync + 'a, G: GetThreadId + Sync + 'a, T: ?Sized + Sync + 'a> Sync
     for ReentrantMutexGuard<'a, R, G, T>
 {
 }
 
-impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> ReentrantMutexGuard<'a, R, G, T> {
+impl<'a, R: RawMutexCore + 'a, G: GetThreadId + 'a, T: ?Sized + 'a>
+    ReentrantMutexGuard<'a, R, G, T>
+{
     /// Returns a reference to the original `ReentrantMutex` object.
     pub fn remutex(s: &Self) -> &'a ReentrantMutex<R, G, T> {
         s.remutex
@@ -794,7 +802,7 @@ impl<'a, R: RawMutexFair + 'a, G: GetThreadId + 'a, T: ?Sized + 'a>
     }
 }
 
-impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> Deref
+impl<'a, R: RawMutexCore + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> Deref
     for ReentrantMutexGuard<'a, R, G, T>
 {
     type Target = T;
@@ -804,7 +812,7 @@ impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> Deref
     }
 }
 
-impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> Drop
+impl<'a, R: RawMutexCore + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> Drop
     for ReentrantMutexGuard<'a, R, G, T>
 {
     #[inline]
@@ -816,7 +824,7 @@ impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> Drop
     }
 }
 
-impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: fmt::Debug + ?Sized + 'a> fmt::Debug
+impl<'a, R: RawMutexCore + 'a, G: GetThreadId + 'a, T: fmt::Debug + ?Sized + 'a> fmt::Debug
     for ReentrantMutexGuard<'a, R, G, T>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -824,7 +832,7 @@ impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: fmt::Debug + ?Sized + 'a> fmt
     }
 }
 
-impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
+impl<'a, R: RawMutexCore + 'a, G: GetThreadId + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
     for ReentrantMutexGuard<'a, R, G, T>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -833,7 +841,7 @@ impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: fmt::Display + ?Sized + 'a> f
 }
 
 #[cfg(feature = "owning_ref")]
-unsafe impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> StableAddress
+unsafe impl<'a, R: RawMutexCore + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> StableAddress
     for ReentrantMutexGuard<'a, R, G, T>
 {
 }
@@ -846,13 +854,13 @@ unsafe impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> StableAdd
 #[cfg(feature = "arc_lock")]
 #[clippy::has_significant_drop]
 #[must_use = "if unused the ReentrantMutex will immediately unlock"]
-pub struct ArcReentrantMutexGuard<R: RawMutex, G: GetThreadId, T: ?Sized> {
+pub struct ArcReentrantMutexGuard<R: RawMutexCore, G: GetThreadId, T: ?Sized> {
     remutex: Arc<ReentrantMutex<R, G, T>>,
     marker: PhantomData<GuardNoSend>,
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawMutex, G: GetThreadId, T: ?Sized> ArcReentrantMutexGuard<R, G, T> {
+impl<R: RawMutexCore, G: GetThreadId, T: ?Sized> ArcReentrantMutexGuard<R, G, T> {
     /// Returns a reference to the `ReentrantMutex` this object is guarding, contained in its `Arc`.
     pub fn remutex(s: &Self) -> &Arc<ReentrantMutex<R, G, T>> {
         &s.remutex
@@ -941,7 +949,7 @@ impl<R: RawMutexFair, G: GetThreadId, T: ?Sized> ArcReentrantMutexGuard<R, G, T>
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawMutex, G: GetThreadId, T: ?Sized> Deref for ArcReentrantMutexGuard<R, G, T> {
+impl<R: RawMutexCore, G: GetThreadId, T: ?Sized> Deref for ArcReentrantMutexGuard<R, G, T> {
     type Target = T;
     #[inline]
     fn deref(&self) -> &T {
@@ -950,7 +958,7 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> Deref for ArcReentrantMutexGuard<R,
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawMutex, G: GetThreadId, T: ?Sized> Drop for ArcReentrantMutexGuard<R, G, T> {
+impl<R: RawMutexCore, G: GetThreadId, T: ?Sized> Drop for ArcReentrantMutexGuard<R, G, T> {
     #[inline]
     fn drop(&mut self) {
         // Safety: A ReentrantMutexGuard always holds the lock.
@@ -969,18 +977,18 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> Drop for ArcReentrantMutexGuard<R, 
 /// thread.
 #[clippy::has_significant_drop]
 #[must_use = "if unused the ReentrantMutex will immediately unlock"]
-pub struct MappedReentrantMutexGuard<'a, R: RawMutex, G: GetThreadId, T: ?Sized> {
+pub struct MappedReentrantMutexGuard<'a, R: RawMutexCore, G: GetThreadId, T: ?Sized> {
     raw: &'a RawReentrantMutex<R, G>,
     data: *const T,
     marker: PhantomData<&'a T>,
 }
 
-unsafe impl<'a, R: RawMutex + Sync + 'a, G: GetThreadId + Sync + 'a, T: ?Sized + Sync + 'a> Sync
+unsafe impl<'a, R: RawMutexCore + Sync + 'a, G: GetThreadId + Sync + 'a, T: ?Sized + Sync + 'a> Sync
     for MappedReentrantMutexGuard<'a, R, G, T>
 {
 }
 
-impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a>
+impl<'a, R: RawMutexCore + 'a, G: GetThreadId + 'a, T: ?Sized + 'a>
     MappedReentrantMutexGuard<'a, R, G, T>
 {
     /// Makes a new `MappedReentrantMutexGuard` for a component of the locked data.
@@ -1094,7 +1102,7 @@ impl<'a, R: RawMutexFair + 'a, G: GetThreadId + 'a, T: ?Sized + 'a>
     }
 }
 
-impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> Deref
+impl<'a, R: RawMutexCore + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> Deref
     for MappedReentrantMutexGuard<'a, R, G, T>
 {
     type Target = T;
@@ -1104,7 +1112,7 @@ impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> Deref
     }
 }
 
-impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> Drop
+impl<'a, R: RawMutexCore + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> Drop
     for MappedReentrantMutexGuard<'a, R, G, T>
 {
     #[inline]
@@ -1116,7 +1124,7 @@ impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> Drop
     }
 }
 
-impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: fmt::Debug + ?Sized + 'a> fmt::Debug
+impl<'a, R: RawMutexCore + 'a, G: GetThreadId + 'a, T: fmt::Debug + ?Sized + 'a> fmt::Debug
     for MappedReentrantMutexGuard<'a, R, G, T>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1124,7 +1132,7 @@ impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: fmt::Debug + ?Sized + 'a> fmt
     }
 }
 
-impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
+impl<'a, R: RawMutexCore + 'a, G: GetThreadId + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
     for MappedReentrantMutexGuard<'a, R, G, T>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1133,7 +1141,7 @@ impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: fmt::Display + ?Sized + 'a> f
 }
 
 #[cfg(feature = "owning_ref")]
-unsafe impl<'a, R: RawMutex + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> StableAddress
+unsafe impl<'a, R: RawMutexCore + 'a, G: GetThreadId + 'a, T: ?Sized + 'a> StableAddress
     for MappedReentrantMutexGuard<'a, R, G, T>
 {
 }

--- a/lock_api/src/rwlock.rs
+++ b/lock_api/src/rwlock.rs
@@ -35,6 +35,127 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// exclusive: an exclusive lock can't be acquired while an exclusive or shared
 /// lock exists, and a shared lock can't be acquire while an exclusive lock
 /// exists.
+pub unsafe trait RawRwLockCore {
+    /// Marker type which determines whether a lock guard should be `Send`. Use
+    /// one of the `GuardSend` or `GuardNoSend` helper types here.
+    type GuardMarker;
+
+    /// Acquires a shared lock, blocking the current thread until it is able to do so.
+    fn lock_shared(&self);
+
+    /// Attempts to acquire a shared lock without blocking.
+    fn try_lock_shared(&self) -> bool;
+
+    /// Releases a shared lock.
+    ///
+    /// # Safety
+    ///
+    /// This method may only be called if a shared lock is held in the current context.
+    unsafe fn unlock_shared(&self);
+
+    /// Acquires an exclusive lock, blocking the current thread until it is able to do so.
+    fn lock_exclusive(&self);
+
+    /// Attempts to acquire an exclusive lock without blocking.
+    fn try_lock_exclusive(&self) -> bool;
+
+    /// Releases an exclusive lock.
+    ///
+    /// # Safety
+    ///
+    /// This method may only be called if an exclusive lock is held in the current context.
+    unsafe fn unlock_exclusive(&self);
+
+    /// Checks if this `RwLock` is currently locked in any way.
+    #[inline]
+    fn is_locked(&self) -> bool {
+        let acquired_lock = self.try_lock_exclusive();
+        if acquired_lock {
+            // Safety: A lock was successfully acquired above.
+            unsafe {
+                self.unlock_exclusive();
+            }
+        }
+        !acquired_lock
+    }
+
+    /// Check if this `RwLock` is currently exclusively locked.
+    fn is_locked_exclusive(&self) -> bool {
+        let acquired_lock = self.try_lock_shared();
+        if acquired_lock {
+            // Safety: A shared lock was successfully acquired above.
+            unsafe {
+                self.unlock_shared();
+            }
+        }
+        !acquired_lock
+    }
+}
+
+unsafe impl<R: RawRwLock> RawRwLockCore for R {
+    type GuardMarker = <Self as RawRwLock>::GuardMarker;
+
+    fn lock_shared(&self) {
+        <Self as RawRwLock>::lock_shared(self);
+    }
+
+    fn try_lock_shared(&self) -> bool {
+        <Self as RawRwLock>::try_lock_shared(self)
+    }
+
+    unsafe fn unlock_shared(&self) {
+        unsafe {
+            <Self as RawRwLock>::unlock_shared(self);
+        }
+    }
+
+    fn lock_exclusive(&self) {
+        <Self as RawRwLock>::lock_exclusive(self);
+    }
+
+    fn try_lock_exclusive(&self) -> bool {
+        <Self as RawRwLock>::try_lock_exclusive(self)
+    }
+
+    unsafe fn unlock_exclusive(&self) {
+        unsafe {
+            <Self as RawRwLock>::unlock_exclusive(self);
+        }
+    }
+
+    fn is_locked(&self) -> bool {
+        <Self as RawRwLock>::is_locked(self)
+    }
+
+    fn is_locked_exclusive(&self) -> bool {
+        <Self as RawRwLock>::is_locked_exclusive(self)
+    }
+}
+
+/// Provides a constant default value for an unlocked reader-writer lock.
+pub unsafe trait RawRwLockInit {
+    /// Initial value for an unlocked `RwLock`.
+    // A “non-constant” const item is a legacy way to supply an initialized value to downstream
+    // static items. Can hopefully be replaced with `const fn new() -> Self` at some point.
+    #[allow(clippy::declare_interior_mutable_const)]
+    const INIT: Self;
+}
+
+unsafe impl<R: RawRwLock> RawRwLockInit for R {
+    const INIT: Self = <Self as RawRwLock>::INIT;
+}
+
+/// Basic operations for a reader-writer lock.
+///
+/// Types implementing this trait can be used by `RwLock` to form a safe and
+/// fully-functioning `RwLock` type.
+///
+/// # Safety
+///
+/// Implementations of this trait must ensure that the `RwLock` is actually
+/// exclusive: an exclusive lock can't be acquired while an exclusive or shared
+/// lock exists, and a shared lock can't be acquire while an exclusive lock
+/// exists.
 pub unsafe trait RawRwLock {
     /// Initial value for an unlocked `RwLock`.
     // A “non-constant” const item is a legacy way to supply an initialized value to downstream
@@ -104,7 +225,7 @@ pub unsafe trait RawRwLock {
 /// thread if there is one, without giving other threads the opportunity to
 /// "steal" the lock in the meantime. This is typically slower than unfair
 /// unlocking, but may be necessary in certain circumstances.
-pub unsafe trait RawRwLockFair: RawRwLock {
+pub unsafe trait RawRwLockFair: RawRwLockCore {
     /// Releases a shared lock using a fair unlock protocol.
     ///
     /// # Safety
@@ -150,7 +271,7 @@ pub unsafe trait RawRwLockFair: RawRwLock {
 
 /// Additional methods for `RwLock`s which support atomically downgrading an
 /// exclusive lock to a shared lock.
-pub unsafe trait RawRwLockDowngrade: RawRwLock {
+pub unsafe trait RawRwLockDowngrade: RawRwLockCore {
     /// Atomically downgrades an exclusive lock into a shared lock without
     /// allowing any thread to take an exclusive lock in the meantime.
     ///
@@ -164,7 +285,7 @@ pub unsafe trait RawRwLockDowngrade: RawRwLock {
 ///
 /// The `Duration` and `Instant` types are specified as associated types so that
 /// this trait is usable even in `no_std` environments.
-pub unsafe trait RawRwLockTimed: RawRwLock {
+pub unsafe trait RawRwLockTimed: RawRwLockCore {
     /// Duration type used for `try_lock_for`.
     type Duration;
 
@@ -191,7 +312,7 @@ pub unsafe trait RawRwLockTimed: RawRwLock {
 /// to recursively lock a `RwLock`. However using this method can cause
 /// writers to starve since readers no longer block if a writer is waiting
 /// for the lock.
-pub unsafe trait RawRwLockRecursive: RawRwLock {
+pub unsafe trait RawRwLockRecursive: RawRwLockCore {
     /// Acquires a shared lock without deadlocking in case of a recursive lock.
     fn lock_shared_recursive(&self);
 
@@ -216,7 +337,7 @@ pub unsafe trait RawRwLockRecursiveTimed: RawRwLockRecursive + RawRwLockTimed {
 /// This requires acquiring a special "upgradable read lock" instead of a
 /// normal shared lock. There may only be one upgradable lock at any time,
 /// otherwise deadlocks could occur when upgrading.
-pub unsafe trait RawRwLockUpgrade: RawRwLock {
+pub unsafe trait RawRwLockUpgrade: RawRwLockCore {
     /// Acquires an upgradable lock, blocking the current thread until it is able to do so.
     fn lock_upgradable(&self);
 
@@ -336,7 +457,7 @@ pub struct RwLock<R, T: ?Sized> {
 #[cfg(feature = "serde")]
 impl<R, T> Serialize for RwLock<R, T>
 where
-    R: RawRwLock,
+    R: RawRwLockCore,
     T: Serialize + ?Sized,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -350,7 +471,7 @@ where
 #[cfg(feature = "serde")]
 impl<'de, R, T> Deserialize<'de> for RwLock<R, T>
 where
-    R: RawRwLock,
+    R: RawRwLockInit,
     T: Deserialize<'de> + ?Sized,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -361,10 +482,10 @@ where
     }
 }
 
-unsafe impl<R: RawRwLock + Send, T: ?Sized + Send> Send for RwLock<R, T> {}
-unsafe impl<R: RawRwLock + Sync, T: ?Sized + Send + Sync> Sync for RwLock<R, T> {}
+unsafe impl<R: RawRwLockCore + Send, T: ?Sized + Send> Send for RwLock<R, T> {}
+unsafe impl<R: RawRwLockCore + Sync, T: ?Sized + Send + Sync> Sync for RwLock<R, T> {}
 
-impl<R: RawRwLock, T> RwLock<R, T> {
+impl<R: RawRwLockInit, T> RwLock<R, T> {
     /// Creates a new instance of an `RwLock<T>` which is unlocked.
     #[inline]
     pub const fn new(val: T) -> RwLock<R, T> {
@@ -373,7 +494,9 @@ impl<R: RawRwLock, T> RwLock<R, T> {
             raw: R::INIT,
         }
     }
+}
 
+impl<R: RawRwLockCore, T> RwLock<R, T> {
     /// Consumes this `RwLock`, returning the underlying data.
     #[inline]
     #[allow(unused_unsafe)]
@@ -406,7 +529,7 @@ impl<R, T> RwLock<R, T> {
     }
 }
 
-impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
+impl<R: RawRwLockCore, T: ?Sized> RwLock<R, T> {
     /// Creates a new `RwLockReadGuard` without checking if the lock is held.
     ///
     /// # Safety
@@ -571,7 +694,7 @@ impl<R: RawRwLock, T: ?Sized> RwLock<R, T> {
 
     /// Returns the underlying raw reader-writer lock object.
     ///
-    /// Note that you will most likely need to import the `RawRwLock` trait from
+    /// Note that you will most likely need to import the `RawRwLockCore` trait from
     /// `lock_api` to be able to call functions on the raw
     /// reader-writer lock.
     ///
@@ -1218,21 +1341,21 @@ impl<R: RawRwLockUpgradeTimed, T: ?Sized> RwLock<R, T> {
     }
 }
 
-impl<R: RawRwLock, T: ?Sized + Default> Default for RwLock<R, T> {
+impl<R: RawRwLockInit, T: ?Sized + Default> Default for RwLock<R, T> {
     #[inline]
     fn default() -> RwLock<R, T> {
         RwLock::new(Default::default())
     }
 }
 
-impl<R: RawRwLock, T> From<T> for RwLock<R, T> {
+impl<R: RawRwLockInit, T> From<T> for RwLock<R, T> {
     #[inline]
     fn from(t: T) -> RwLock<R, T> {
         RwLock::new(t)
     }
 }
 
-impl<R: RawRwLock, T: ?Sized + fmt::Debug> fmt::Debug for RwLock<R, T> {
+impl<R: RawRwLockCore, T: ?Sized + fmt::Debug> fmt::Debug for RwLock<R, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_struct("RwLock");
         match self.try_read() {
@@ -1250,14 +1373,14 @@ impl<R: RawRwLock, T: ?Sized + fmt::Debug> fmt::Debug for RwLock<R, T> {
 /// dropped.
 #[clippy::has_significant_drop]
 #[must_use = "if unused the RwLock will immediately unlock"]
-pub struct RwLockReadGuard<'a, R: RawRwLock, T: ?Sized> {
+pub struct RwLockReadGuard<'a, R: RawRwLockCore, T: ?Sized> {
     rwlock: &'a RwLock<R, T>,
     marker: PhantomData<(&'a T, R::GuardMarker)>,
 }
 
-unsafe impl<R: RawRwLock + Sync, T: Sync + ?Sized> Sync for RwLockReadGuard<'_, R, T> {}
+unsafe impl<R: RawRwLockCore + Sync, T: Sync + ?Sized> Sync for RwLockReadGuard<'_, R, T> {}
 
-impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> RwLockReadGuard<'a, R, T> {
+impl<'a, R: RawRwLockCore + 'a, T: ?Sized + 'a> RwLockReadGuard<'a, R, T> {
     /// Returns a reference to the original reader-writer lock object.
     pub fn rwlock(s: &Self) -> &'a RwLock<R, T> {
         s.rwlock
@@ -1421,7 +1544,7 @@ impl<'a, R: RawRwLockFair + 'a, T: ?Sized + 'a> RwLockReadGuard<'a, R, T> {
     }
 }
 
-impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> Deref for RwLockReadGuard<'a, R, T> {
+impl<'a, R: RawRwLockCore + 'a, T: ?Sized + 'a> Deref for RwLockReadGuard<'a, R, T> {
     type Target = T;
     #[inline]
     fn deref(&self) -> &T {
@@ -1429,7 +1552,7 @@ impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> Deref for RwLockReadGuard<'a, R, T> 
     }
 }
 
-impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> Drop for RwLockReadGuard<'a, R, T> {
+impl<'a, R: RawRwLockCore + 'a, T: ?Sized + 'a> Drop for RwLockReadGuard<'a, R, T> {
     #[inline]
     fn drop(&mut self) {
         // Safety: An RwLockReadGuard always holds a shared lock.
@@ -1439,13 +1562,15 @@ impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> Drop for RwLockReadGuard<'a, R, T> {
     }
 }
 
-impl<'a, R: RawRwLock + 'a, T: fmt::Debug + ?Sized + 'a> fmt::Debug for RwLockReadGuard<'a, R, T> {
+impl<'a, R: RawRwLockCore + 'a, T: fmt::Debug + ?Sized + 'a> fmt::Debug
+    for RwLockReadGuard<'a, R, T>
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
 
-impl<'a, R: RawRwLock + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
+impl<'a, R: RawRwLockCore + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
     for RwLockReadGuard<'a, R, T>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1454,7 +1579,7 @@ impl<'a, R: RawRwLock + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
 }
 
 #[cfg(feature = "owning_ref")]
-unsafe impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> StableAddress for RwLockReadGuard<'a, R, T> {}
+unsafe impl<'a, R: RawRwLockCore + 'a, T: ?Sized + 'a> StableAddress for RwLockReadGuard<'a, R, T> {}
 
 /// An RAII rwlock guard returned by the `Arc` locking operations on `RwLock`.
 ///
@@ -1463,13 +1588,13 @@ unsafe impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> StableAddress for RwLockReadG
 #[cfg(feature = "arc_lock")]
 #[clippy::has_significant_drop]
 #[must_use = "if unused the RwLock will immediately unlock"]
-pub struct ArcRwLockReadGuard<R: RawRwLock, T: ?Sized> {
+pub struct ArcRwLockReadGuard<R: RawRwLockCore, T: ?Sized> {
     rwlock: Arc<RwLock<R, T>>,
     marker: PhantomData<R::GuardMarker>,
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawRwLock, T: ?Sized> ArcRwLockReadGuard<R, T> {
+impl<R: RawRwLockCore, T: ?Sized> ArcRwLockReadGuard<R, T> {
     /// Returns a reference to the rwlock, contained in its `Arc`.
     pub fn rwlock(s: &Self) -> &Arc<RwLock<R, T>> {
         &s.rwlock
@@ -1557,7 +1682,7 @@ impl<R: RawRwLockFair, T: ?Sized> ArcRwLockReadGuard<R, T> {
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawRwLock, T: ?Sized> Deref for ArcRwLockReadGuard<R, T> {
+impl<R: RawRwLockCore, T: ?Sized> Deref for ArcRwLockReadGuard<R, T> {
     type Target = T;
     #[inline]
     fn deref(&self) -> &T {
@@ -1566,7 +1691,7 @@ impl<R: RawRwLock, T: ?Sized> Deref for ArcRwLockReadGuard<R, T> {
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawRwLock, T: ?Sized> Drop for ArcRwLockReadGuard<R, T> {
+impl<R: RawRwLockCore, T: ?Sized> Drop for ArcRwLockReadGuard<R, T> {
     #[inline]
     fn drop(&mut self) {
         // Safety: An RwLockReadGuard always holds a shared lock.
@@ -1577,14 +1702,14 @@ impl<R: RawRwLock, T: ?Sized> Drop for ArcRwLockReadGuard<R, T> {
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawRwLock, T: fmt::Debug + ?Sized> fmt::Debug for ArcRwLockReadGuard<R, T> {
+impl<R: RawRwLockCore, T: fmt::Debug + ?Sized> fmt::Debug for ArcRwLockReadGuard<R, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawRwLock, T: fmt::Display + ?Sized> fmt::Display for ArcRwLockReadGuard<R, T> {
+impl<R: RawRwLockCore, T: fmt::Display + ?Sized> fmt::Display for ArcRwLockReadGuard<R, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (**self).fmt(f)
     }
@@ -1594,14 +1719,14 @@ impl<R: RawRwLock, T: fmt::Display + ?Sized> fmt::Display for ArcRwLockReadGuard
 /// dropped.
 #[clippy::has_significant_drop]
 #[must_use = "if unused the RwLock will immediately unlock"]
-pub struct RwLockWriteGuard<'a, R: RawRwLock, T: ?Sized> {
+pub struct RwLockWriteGuard<'a, R: RawRwLockCore, T: ?Sized> {
     rwlock: &'a RwLock<R, T>,
     marker: PhantomData<(&'a mut T, R::GuardMarker)>,
 }
 
-unsafe impl<R: RawRwLock + Sync, T: Sync + ?Sized> Sync for RwLockWriteGuard<'_, R, T> {}
+unsafe impl<R: RawRwLockCore + Sync, T: Sync + ?Sized> Sync for RwLockWriteGuard<'_, R, T> {}
 
-impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> RwLockWriteGuard<'a, R, T> {
+impl<'a, R: RawRwLockCore + 'a, T: ?Sized + 'a> RwLockWriteGuard<'a, R, T> {
     /// Returns a reference to the original reader-writer lock object.
     pub fn rwlock(s: &Self) -> &'a RwLock<R, T> {
         s.rwlock
@@ -1809,7 +1934,7 @@ impl<'a, R: RawRwLockFair + 'a, T: ?Sized + 'a> RwLockWriteGuard<'a, R, T> {
     }
 }
 
-impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> Deref for RwLockWriteGuard<'a, R, T> {
+impl<'a, R: RawRwLockCore + 'a, T: ?Sized + 'a> Deref for RwLockWriteGuard<'a, R, T> {
     type Target = T;
     #[inline]
     fn deref(&self) -> &T {
@@ -1817,14 +1942,14 @@ impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> Deref for RwLockWriteGuard<'a, R, T>
     }
 }
 
-impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> DerefMut for RwLockWriteGuard<'a, R, T> {
+impl<'a, R: RawRwLockCore + 'a, T: ?Sized + 'a> DerefMut for RwLockWriteGuard<'a, R, T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut T {
         unsafe { &mut *self.rwlock.data.get() }
     }
 }
 
-impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> Drop for RwLockWriteGuard<'a, R, T> {
+impl<'a, R: RawRwLockCore + 'a, T: ?Sized + 'a> Drop for RwLockWriteGuard<'a, R, T> {
     #[inline]
     fn drop(&mut self) {
         // Safety: An RwLockWriteGuard always holds an exclusive lock.
@@ -1834,13 +1959,15 @@ impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> Drop for RwLockWriteGuard<'a, R, T> 
     }
 }
 
-impl<'a, R: RawRwLock + 'a, T: fmt::Debug + ?Sized + 'a> fmt::Debug for RwLockWriteGuard<'a, R, T> {
+impl<'a, R: RawRwLockCore + 'a, T: fmt::Debug + ?Sized + 'a> fmt::Debug
+    for RwLockWriteGuard<'a, R, T>
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
 
-impl<'a, R: RawRwLock + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
+impl<'a, R: RawRwLockCore + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
     for RwLockWriteGuard<'a, R, T>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1849,7 +1976,10 @@ impl<'a, R: RawRwLock + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
 }
 
 #[cfg(feature = "owning_ref")]
-unsafe impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> StableAddress for RwLockWriteGuard<'a, R, T> {}
+unsafe impl<'a, R: RawRwLockCore + 'a, T: ?Sized + 'a> StableAddress
+    for RwLockWriteGuard<'a, R, T>
+{
+}
 
 /// An RAII rwlock guard returned by the `Arc` locking operations on `RwLock`.
 /// This is similar to the `RwLockWriteGuard` struct, except instead of using a reference to unlock the `RwLock`
@@ -1857,13 +1987,13 @@ unsafe impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> StableAddress for RwLockWrite
 #[cfg(feature = "arc_lock")]
 #[clippy::has_significant_drop]
 #[must_use = "if unused the RwLock will immediately unlock"]
-pub struct ArcRwLockWriteGuard<R: RawRwLock, T: ?Sized> {
+pub struct ArcRwLockWriteGuard<R: RawRwLockCore, T: ?Sized> {
     rwlock: Arc<RwLock<R, T>>,
     marker: PhantomData<R::GuardMarker>,
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawRwLock, T: ?Sized> ArcRwLockWriteGuard<R, T> {
+impl<R: RawRwLockCore, T: ?Sized> ArcRwLockWriteGuard<R, T> {
     /// Returns a reference to the rwlock, contained in its `Arc`.
     pub fn rwlock(s: &Self) -> &Arc<RwLock<R, T>> {
         &s.rwlock
@@ -1999,7 +2129,7 @@ impl<R: RawRwLockFair, T: ?Sized> ArcRwLockWriteGuard<R, T> {
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawRwLock, T: ?Sized> Deref for ArcRwLockWriteGuard<R, T> {
+impl<R: RawRwLockCore, T: ?Sized> Deref for ArcRwLockWriteGuard<R, T> {
     type Target = T;
     #[inline]
     fn deref(&self) -> &T {
@@ -2008,7 +2138,7 @@ impl<R: RawRwLock, T: ?Sized> Deref for ArcRwLockWriteGuard<R, T> {
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawRwLock, T: ?Sized> DerefMut for ArcRwLockWriteGuard<R, T> {
+impl<R: RawRwLockCore, T: ?Sized> DerefMut for ArcRwLockWriteGuard<R, T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut T {
         unsafe { &mut *self.rwlock.data.get() }
@@ -2016,7 +2146,7 @@ impl<R: RawRwLock, T: ?Sized> DerefMut for ArcRwLockWriteGuard<R, T> {
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawRwLock, T: ?Sized> Drop for ArcRwLockWriteGuard<R, T> {
+impl<R: RawRwLockCore, T: ?Sized> Drop for ArcRwLockWriteGuard<R, T> {
     #[inline]
     fn drop(&mut self) {
         // Safety: An RwLockWriteGuard always holds an exclusive lock.
@@ -2027,14 +2157,14 @@ impl<R: RawRwLock, T: ?Sized> Drop for ArcRwLockWriteGuard<R, T> {
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawRwLock, T: fmt::Debug + ?Sized> fmt::Debug for ArcRwLockWriteGuard<R, T> {
+impl<R: RawRwLockCore, T: fmt::Debug + ?Sized> fmt::Debug for ArcRwLockWriteGuard<R, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
 
 #[cfg(feature = "arc_lock")]
-impl<R: RawRwLock, T: fmt::Display + ?Sized> fmt::Display for ArcRwLockWriteGuard<R, T> {
+impl<R: RawRwLockCore, T: fmt::Display + ?Sized> fmt::Display for ArcRwLockWriteGuard<R, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (**self).fmt(f)
     }
@@ -2792,19 +2922,24 @@ impl<R: RawRwLockUpgrade, T: fmt::Display + ?Sized> fmt::Display
 /// thread.
 #[clippy::has_significant_drop]
 #[must_use = "if unused the RwLock will immediately unlock"]
-pub struct MappedRwLockReadGuard<'a, R: RawRwLock, T: ?Sized> {
+pub struct MappedRwLockReadGuard<'a, R: RawRwLockCore, T: ?Sized> {
     raw: &'a R,
     data: *const T,
     marker: PhantomData<&'a T>,
 }
 
-unsafe impl<'a, R: RawRwLock + 'a, T: ?Sized + Sync + 'a> Sync for MappedRwLockReadGuard<'a, R, T> {}
-unsafe impl<'a, R: RawRwLock + 'a, T: ?Sized + Sync + 'a> Send for MappedRwLockReadGuard<'a, R, T> where
-    R::GuardMarker: Send
+unsafe impl<'a, R: RawRwLockCore + 'a, T: ?Sized + Sync + 'a> Sync
+    for MappedRwLockReadGuard<'a, R, T>
+{
+}
+unsafe impl<'a, R: RawRwLockCore + 'a, T: ?Sized + Sync + 'a> Send
+    for MappedRwLockReadGuard<'a, R, T>
+where
+    R::GuardMarker: Send,
 {
 }
 
-impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> MappedRwLockReadGuard<'a, R, T> {
+impl<'a, R: RawRwLockCore + 'a, T: ?Sized + 'a> MappedRwLockReadGuard<'a, R, T> {
     /// Make a new `MappedRwLockReadGuard` for a component of the locked data.
     ///
     /// This operation cannot fail as the `MappedRwLockReadGuard` passed
@@ -2911,7 +3046,7 @@ impl<'a, R: RawRwLockFair + 'a, T: ?Sized + 'a> MappedRwLockReadGuard<'a, R, T> 
     }
 }
 
-impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> Deref for MappedRwLockReadGuard<'a, R, T> {
+impl<'a, R: RawRwLockCore + 'a, T: ?Sized + 'a> Deref for MappedRwLockReadGuard<'a, R, T> {
     type Target = T;
     #[inline]
     fn deref(&self) -> &T {
@@ -2919,7 +3054,7 @@ impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> Deref for MappedRwLockReadGuard<'a, 
     }
 }
 
-impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> Drop for MappedRwLockReadGuard<'a, R, T> {
+impl<'a, R: RawRwLockCore + 'a, T: ?Sized + 'a> Drop for MappedRwLockReadGuard<'a, R, T> {
     #[inline]
     fn drop(&mut self) {
         // Safety: A MappedRwLockReadGuard always holds a shared lock.
@@ -2929,7 +3064,7 @@ impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> Drop for MappedRwLockReadGuard<'a, R
     }
 }
 
-impl<'a, R: RawRwLock + 'a, T: fmt::Debug + ?Sized + 'a> fmt::Debug
+impl<'a, R: RawRwLockCore + 'a, T: fmt::Debug + ?Sized + 'a> fmt::Debug
     for MappedRwLockReadGuard<'a, R, T>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -2937,7 +3072,7 @@ impl<'a, R: RawRwLock + 'a, T: fmt::Debug + ?Sized + 'a> fmt::Debug
     }
 }
 
-impl<'a, R: RawRwLock + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
+impl<'a, R: RawRwLockCore + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
     for MappedRwLockReadGuard<'a, R, T>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -2946,7 +3081,7 @@ impl<'a, R: RawRwLock + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
 }
 
 #[cfg(feature = "owning_ref")]
-unsafe impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> StableAddress
+unsafe impl<'a, R: RawRwLockCore + 'a, T: ?Sized + 'a> StableAddress
     for MappedRwLockReadGuard<'a, R, T>
 {
 }
@@ -2960,22 +3095,24 @@ unsafe impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> StableAddress
 /// thread.
 #[clippy::has_significant_drop]
 #[must_use = "if unused the RwLock will immediately unlock"]
-pub struct MappedRwLockWriteGuard<'a, R: RawRwLock, T: ?Sized> {
+pub struct MappedRwLockWriteGuard<'a, R: RawRwLockCore, T: ?Sized> {
     raw: &'a R,
     data: *mut T,
     marker: PhantomData<&'a mut T>,
 }
 
-unsafe impl<'a, R: RawRwLock + 'a, T: ?Sized + Sync + 'a> Sync
+unsafe impl<'a, R: RawRwLockCore + 'a, T: ?Sized + Sync + 'a> Sync
     for MappedRwLockWriteGuard<'a, R, T>
 {
 }
-unsafe impl<'a, R: RawRwLock + 'a, T: ?Sized + Send + 'a> Send for MappedRwLockWriteGuard<'a, R, T> where
-    R::GuardMarker: Send
+unsafe impl<'a, R: RawRwLockCore + 'a, T: ?Sized + Send + 'a> Send
+    for MappedRwLockWriteGuard<'a, R, T>
+where
+    R::GuardMarker: Send,
 {
 }
 
-impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> MappedRwLockWriteGuard<'a, R, T> {
+impl<'a, R: RawRwLockCore + 'a, T: ?Sized + 'a> MappedRwLockWriteGuard<'a, R, T> {
     /// Make a new `MappedRwLockWriteGuard` for a component of the locked data.
     ///
     /// This operation cannot fail as the `MappedRwLockWriteGuard` passed
@@ -3082,7 +3219,7 @@ impl<'a, R: RawRwLockFair + 'a, T: ?Sized + 'a> MappedRwLockWriteGuard<'a, R, T>
     }
 }
 
-impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> Deref for MappedRwLockWriteGuard<'a, R, T> {
+impl<'a, R: RawRwLockCore + 'a, T: ?Sized + 'a> Deref for MappedRwLockWriteGuard<'a, R, T> {
     type Target = T;
     #[inline]
     fn deref(&self) -> &T {
@@ -3090,14 +3227,14 @@ impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> Deref for MappedRwLockWriteGuard<'a,
     }
 }
 
-impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> DerefMut for MappedRwLockWriteGuard<'a, R, T> {
+impl<'a, R: RawRwLockCore + 'a, T: ?Sized + 'a> DerefMut for MappedRwLockWriteGuard<'a, R, T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut T {
         unsafe { &mut *self.data }
     }
 }
 
-impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> Drop for MappedRwLockWriteGuard<'a, R, T> {
+impl<'a, R: RawRwLockCore + 'a, T: ?Sized + 'a> Drop for MappedRwLockWriteGuard<'a, R, T> {
     #[inline]
     fn drop(&mut self) {
         // Safety: A MappedRwLockWriteGuard always holds an exclusive lock.
@@ -3107,7 +3244,7 @@ impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> Drop for MappedRwLockWriteGuard<'a, 
     }
 }
 
-impl<'a, R: RawRwLock + 'a, T: fmt::Debug + ?Sized + 'a> fmt::Debug
+impl<'a, R: RawRwLockCore + 'a, T: fmt::Debug + ?Sized + 'a> fmt::Debug
     for MappedRwLockWriteGuard<'a, R, T>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -3115,7 +3252,7 @@ impl<'a, R: RawRwLock + 'a, T: fmt::Debug + ?Sized + 'a> fmt::Debug
     }
 }
 
-impl<'a, R: RawRwLock + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
+impl<'a, R: RawRwLockCore + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
     for MappedRwLockWriteGuard<'a, R, T>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -3124,7 +3261,7 @@ impl<'a, R: RawRwLock + 'a, T: fmt::Display + ?Sized + 'a> fmt::Display
 }
 
 #[cfg(feature = "owning_ref")]
-unsafe impl<'a, R: RawRwLock + 'a, T: ?Sized + 'a> StableAddress
+unsafe impl<'a, R: RawRwLockCore + 'a, T: ?Sized + 'a> StableAddress
     for MappedRwLockWriteGuard<'a, R, T>
 {
 }


### PR DESCRIPTION
# Objective

- Fix #117
- Fix #400

## Solution

- Solution based on previously approved suggestion [here](https://github.com/Amanieu/parking_lot/issues/400#issuecomment-1707454078).
- Created a new pair of traits which supersede `RawMutex`: `RawMutexCore` and `RawMutexInit`. `RawMutex` is left unchanged, and the new traits are blanket implemented for any type implementing this original trait. This allows the split to be a non-breaking change.
- Created a new pair of traits which supersede `RawRwLock`: `RawRwLockCore` and `RawRwLockInit`. The same blanket implementation as used for `RawMutex` is also used for `RawRwLock`.
- Replaced trait bounds across `parking_lot` to refer to core and init traits as required.
- Ensured `parking_lot` and other downstream crates observe no breakage from this change.

---

## Notes

- No AI tooling of any kind was used during the creation of this PR.
- `RawRwLock` and `RawMutex` could be deprecated, or removed entirely (justifying renaming `RawMutexCore` to `RawMutex`). I have not done this, but I'd be happy to amend the PR to do so.