### PR TITLE
add RwLock recursive detect

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ parking_lot = { version = "0.12", features = ["nightly"] }
 The experimental deadlock detector can be enabled with the
 `deadlock_detection` Cargo feature.
 
+With this feature enabled, recursive `RwLock` acquisitions are reported as
+warnings on stderr. Set `PARKING_LOT_PANIC_ON_DEADLOCK` to `1`, `true`, `yes`,
+or `on` to panic when such an acquisition is detected.
+
 To allow sending `MutexGuard`s and `RwLock*Guard`s to other threads, enable the
 `send_guard` option.
 

--- a/core/src/parking_lot.rs
+++ b/core/src/parking_lot.rs
@@ -1130,6 +1130,75 @@ pub mod deadlock {
         deadlock_impl::release_resource(_key);
     }
 
+    /// The kind of access held on an `RwLock` for recursive-lock detection.
+    #[derive(Clone, Copy, Debug)]
+    pub enum RwLockMode {
+        /// An ordinary shared read access.
+        Read,
+        /// An explicitly recursive shared read access.
+        RecursiveRead,
+        /// An upgradable shared access.
+        Upgradable,
+        /// An exclusive write access.
+        Write,
+    }
+
+    /// Checks whether acquiring an `RwLock` may deadlock with a lock held by
+    /// the current thread.
+    ///
+    /// With `deadlock_detection` disabled this is a no-op. With it enabled,
+    /// a warning is printed to stderr when a recursive acquisition is found.
+    /// Set `PARKING_LOT_PANIC_ON_DEADLOCK` to `1`, `true`, `yes`, or `on` to
+    /// panic instead of printing the warning.
+    ///
+    /// # Safety
+    ///
+    /// `key` must identify a live `RwLock` for the duration of the call.
+    #[inline]
+    pub unsafe fn check_rwlock_acquire(_key: usize, _mode: RwLockMode) {
+        #[cfg(feature = "deadlock_detection")]
+        deadlock_impl::check_rwlock_acquire(_key, _mode);
+    }
+
+    /// Records a successfully acquired `RwLock` access.
+    ///
+    /// With `deadlock_detection` disabled this is a no-op.
+    ///
+    /// # Safety
+    ///
+    /// Call this only after the access has been acquired.
+    #[inline]
+    pub unsafe fn acquire_rwlock(_key: usize, _mode: RwLockMode) {
+        #[cfg(feature = "deadlock_detection")]
+        deadlock_impl::acquire_rwlock(_key, _mode);
+    }
+
+    /// Records a released `RwLock` access.
+    ///
+    /// With `deadlock_detection` disabled this is a no-op.
+    ///
+    /// # Safety
+    ///
+    /// Call this only immediately before releasing the access.
+    #[inline]
+    pub unsafe fn release_rwlock(_key: usize, _mode: RwLockMode) {
+        #[cfg(feature = "deadlock_detection")]
+        deadlock_impl::release_rwlock(_key, _mode);
+    }
+
+    /// Records an atomic `RwLock` access-mode transition.
+    ///
+    /// With `deadlock_detection` disabled this is a no-op.
+    ///
+    /// # Safety
+    ///
+    /// The current thread must hold the access described by `from`.
+    #[inline]
+    pub unsafe fn transition_rwlock(_key: usize, _from: RwLockMode, _to: RwLockMode) {
+        #[cfg(feature = "deadlock_detection")]
+        deadlock_impl::transition_rwlock(_key, _from, _to);
+    }
+
     /// Returns all deadlocks detected *since* the last call.
     /// Each cycle consist of a vector of `DeadlockedThread`.
     #[cfg(feature = "deadlock_detection")]
@@ -1154,9 +1223,9 @@ mod deadlock_impl {
     use petgraph;
     use petgraph::graphmap::DiGraphMap;
     use std::cell::{Cell, UnsafeCell};
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
     use std::sync::atomic::Ordering;
-    use std::sync::mpsc;
+    use std::sync::{mpsc, OnceLock};
     use std::thread::ThreadId;
 
     /// Representation of a deadlocked thread
@@ -1181,6 +1250,9 @@ mod deadlock_impl {
         // Currently owned resources (keys)
         resources: UnsafeCell<Vec<usize>>,
 
+        // RwLocks currently held by this thread, keyed by lock address.
+        rwlocks: UnsafeCell<HashMap<usize, HeldRwLock>>,
+
         // Set when there's a pending callstack request
         deadlocked: Cell<bool>,
 
@@ -1191,10 +1263,18 @@ mod deadlock_impl {
         thread_id: ThreadId,
     }
 
+    #[derive(Default)]
+    struct HeldRwLock {
+        reads: usize,
+        upgradable: bool,
+        write: bool,
+    }
+
     impl DeadlockData {
         pub fn new() -> Self {
             DeadlockData {
                 resources: UnsafeCell::new(Vec::new()),
+                rwlocks: UnsafeCell::new(HashMap::new()),
                 deadlocked: Cell::new(false),
                 backtrace_sender: UnsafeCell::new(None),
                 thread_id: std::thread::current().id(),
@@ -1239,6 +1319,144 @@ mod deadlock_impl {
                 resources.swap_remove(p);
             }
         });
+    }
+
+    pub unsafe fn check_rwlock_acquire(key: usize, mode: super::deadlock::RwLockMode) {
+        with_thread_data(|thread_data| {
+            let rwlocks = &*thread_data.deadlock_data.rwlocks.get();
+            let Some(held) = rwlocks.get(&key) else {
+                return;
+            };
+
+            let recursive = match mode {
+                super::deadlock::RwLockMode::Read => held.reads != 0 || held.write,
+                super::deadlock::RwLockMode::RecursiveRead => held.write,
+                super::deadlock::RwLockMode::Upgradable => held.upgradable || held.write,
+                super::deadlock::RwLockMode::Write => {
+                    held.reads != 0 || held.upgradable || held.write
+                }
+            };
+
+            if recursive {
+                report_recursive_deadlock(key, mode);
+            }
+        });
+    }
+
+    pub unsafe fn acquire_rwlock(key: usize, mode: super::deadlock::RwLockMode) {
+        with_thread_data(|thread_data| {
+            let rwlocks = &mut *thread_data.deadlock_data.rwlocks.get();
+            let held = rwlocks.entry(key).or_default();
+            match mode {
+                super::deadlock::RwLockMode::Read | super::deadlock::RwLockMode::RecursiveRead => {
+                    held.reads += 1;
+                }
+                super::deadlock::RwLockMode::Upgradable => {
+                    debug_assert!(!held.upgradable);
+                    held.upgradable = true;
+                }
+                super::deadlock::RwLockMode::Write => {
+                    debug_assert!(!held.write);
+                    held.write = true;
+                }
+            }
+        });
+    }
+
+    pub unsafe fn release_rwlock(key: usize, mode: super::deadlock::RwLockMode) {
+        with_thread_data(|thread_data| {
+            let rwlocks = &mut *thread_data.deadlock_data.rwlocks.get();
+            let Some(held) = rwlocks.get_mut(&key) else {
+                return;
+            };
+
+            match mode {
+                super::deadlock::RwLockMode::Read | super::deadlock::RwLockMode::RecursiveRead => {
+                    debug_assert!(held.reads != 0);
+                    held.reads = held.reads.saturating_sub(1);
+                }
+                super::deadlock::RwLockMode::Upgradable => {
+                    debug_assert!(held.upgradable);
+                    held.upgradable = false;
+                }
+                super::deadlock::RwLockMode::Write => {
+                    debug_assert!(held.write);
+                    held.write = false;
+                }
+            }
+
+            if held.reads == 0 && !held.upgradable && !held.write {
+                rwlocks.remove(&key);
+            }
+        });
+    }
+
+    pub unsafe fn transition_rwlock(
+        key: usize,
+        from: super::deadlock::RwLockMode,
+        to: super::deadlock::RwLockMode,
+    ) {
+        with_thread_data(|thread_data| {
+            let rwlocks = &mut *thread_data.deadlock_data.rwlocks.get();
+            let Some(held) = rwlocks.get_mut(&key) else {
+                return;
+            };
+
+            match from {
+                super::deadlock::RwLockMode::Read | super::deadlock::RwLockMode::RecursiveRead => {
+                    debug_assert!(held.reads != 0);
+                    held.reads = held.reads.saturating_sub(1);
+                }
+                super::deadlock::RwLockMode::Upgradable => {
+                    debug_assert!(held.upgradable);
+                    held.upgradable = false;
+                }
+                super::deadlock::RwLockMode::Write => {
+                    debug_assert!(held.write);
+                    held.write = false;
+                }
+            }
+
+            match to {
+                super::deadlock::RwLockMode::Read | super::deadlock::RwLockMode::RecursiveRead => {
+                    held.reads += 1;
+                }
+                super::deadlock::RwLockMode::Upgradable => {
+                    debug_assert!(!held.upgradable);
+                    held.upgradable = true;
+                }
+                super::deadlock::RwLockMode::Write => {
+                    debug_assert!(!held.write);
+                    held.write = true;
+                }
+            }
+        });
+    }
+
+    fn report_recursive_deadlock(key: usize, mode: super::deadlock::RwLockMode) {
+        if panic_on_deadlock() {
+            panic!(
+                "parking_lot: possible recursive RwLock deadlock at 0x{key:x} while acquiring {mode:?}"
+            );
+        }
+        eprintln!(
+            "parking_lot: possible recursive RwLock deadlock at 0x{key:x} while acquiring {mode:?}"
+        );
+    }
+
+    fn panic_on_deadlock() -> bool {
+        static PANIC_ON_DEADLOCK: OnceLock<bool> = OnceLock::new();
+
+        *PANIC_ON_DEADLOCK.get_or_init(|| {
+            let Ok(value) = std::env::var("PARKING_LOT_PANIC_ON_DEADLOCK") else {
+                return false;
+            };
+            let value = value.trim();
+            value == "1"
+                || value.eq_ignore_ascii_case("true")
+                || value.eq_ignore_ascii_case("yes")
+                || value.eq_ignore_ascii_case("on")
+        })
     }
 
     pub fn check_deadlock() -> Vec<Vec<DeadlockedThread>> {

--- a/src/deadlock.rs
+++ b/src/deadlock.rs
@@ -2,6 +2,10 @@
 //!
 //! This feature is optional and can be enabled via the `deadlock_detection` feature flag.
 //!
+//! When this feature is enabled, recursive `RwLock` acquisitions are reported
+//! to stderr. Set `PARKING_LOT_PANIC_ON_DEADLOCK` to `1`, `true`, `yes`, or
+//! `on` to panic instead.
+//!
 //! # Example
 //!
 //! ```
@@ -36,6 +40,49 @@
 #[cfg(feature = "deadlock_detection")]
 pub use parking_lot_core::deadlock::check_deadlock;
 pub(crate) use parking_lot_core::deadlock::{acquire_resource, release_resource};
+
+#[derive(Clone, Copy)]
+pub(crate) enum RwLockMode {
+    Read,
+    RecursiveRead,
+    Upgradable,
+    Write,
+}
+
+#[inline]
+pub(crate) unsafe fn check_rwlock_acquire(_key: usize, _mode: RwLockMode) {
+    #[cfg(feature = "deadlock_detection")]
+    parking_lot_core::deadlock::check_rwlock_acquire(_key, to_core_mode(_mode));
+}
+
+#[inline]
+pub(crate) unsafe fn acquire_rwlock(_key: usize, _mode: RwLockMode) {
+    #[cfg(feature = "deadlock_detection")]
+    parking_lot_core::deadlock::acquire_rwlock(_key, to_core_mode(_mode));
+}
+
+#[inline]
+pub(crate) unsafe fn release_rwlock(_key: usize, _mode: RwLockMode) {
+    #[cfg(feature = "deadlock_detection")]
+    parking_lot_core::deadlock::release_rwlock(_key, to_core_mode(_mode));
+}
+
+#[inline]
+pub(crate) unsafe fn transition_rwlock(_key: usize, _from: RwLockMode, _to: RwLockMode) {
+    #[cfg(feature = "deadlock_detection")]
+    parking_lot_core::deadlock::transition_rwlock(_key, to_core_mode(_from), to_core_mode(_to));
+}
+
+#[cfg(feature = "deadlock_detection")]
+#[inline]
+fn to_core_mode(mode: RwLockMode) -> parking_lot_core::deadlock::RwLockMode {
+    match mode {
+        RwLockMode::Read => parking_lot_core::deadlock::RwLockMode::Read,
+        RwLockMode::RecursiveRead => parking_lot_core::deadlock::RwLockMode::RecursiveRead,
+        RwLockMode::Upgradable => parking_lot_core::deadlock::RwLockMode::Upgradable,
+        RwLockMode::Write => parking_lot_core::deadlock::RwLockMode::Write,
+    }
+}
 
 #[cfg(test)]
 #[cfg(feature = "deadlock_detection")]

--- a/src/raw_rwlock.rs
+++ b/src/raw_rwlock.rs
@@ -5,6 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::deadlock::{self, RwLockMode};
 use crate::elision::{have_elision, AtomicElisionExt};
 use crate::raw_mutex::{TOKEN_HANDOFF, TOKEN_NORMAL};
 use crate::util;
@@ -14,7 +15,7 @@ use core::{
 };
 use lock_api::{RawRwLock as RawRwLock_, RawRwLockUpgrade};
 use parking_lot_core::{
-    self, deadlock, FilterOp, ParkResult, ParkToken, SpinWait, UnparkResult, UnparkToken,
+    self, FilterOp, ParkResult, ParkToken, SpinWait, UnparkResult, UnparkToken,
 };
 use std::time::{Duration, Instant};
 
@@ -65,6 +66,7 @@ unsafe impl lock_api::RawRwLock for RawRwLock {
 
     #[inline]
     fn lock_exclusive(&self) {
+        self.deadlock_check(RwLockMode::Write);
         if self
             .state
             .compare_exchange_weak(0, WRITER_BIT, Ordering::Acquire, Ordering::Relaxed)
@@ -73,17 +75,18 @@ unsafe impl lock_api::RawRwLock for RawRwLock {
             let result = self.lock_exclusive_slow(None);
             debug_assert!(result);
         }
-        self.deadlock_acquire();
+        self.deadlock_acquire(RwLockMode::Write);
     }
 
     #[inline]
     fn try_lock_exclusive(&self) -> bool {
+        self.deadlock_check(RwLockMode::Write);
         if self
             .state
             .compare_exchange(0, WRITER_BIT, Ordering::Acquire, Ordering::Relaxed)
             .is_ok()
         {
-            self.deadlock_acquire();
+            self.deadlock_acquire(RwLockMode::Write);
             true
         } else {
             false
@@ -92,7 +95,7 @@ unsafe impl lock_api::RawRwLock for RawRwLock {
 
     #[inline]
     unsafe fn unlock_exclusive(&self) {
-        self.deadlock_release();
+        self.deadlock_release(RwLockMode::Write);
         if self
             .state
             .compare_exchange(WRITER_BIT, 0, Ordering::Release, Ordering::Relaxed)
@@ -105,29 +108,31 @@ unsafe impl lock_api::RawRwLock for RawRwLock {
 
     #[inline]
     fn lock_shared(&self) {
+        self.deadlock_check(RwLockMode::Read);
         if !self.try_lock_shared_fast(false) {
             let result = self.lock_shared_slow(false, None);
             debug_assert!(result);
         }
-        self.deadlock_acquire();
+        self.deadlock_acquire(RwLockMode::Read);
     }
 
     #[inline]
     fn try_lock_shared(&self) -> bool {
+        self.deadlock_check(RwLockMode::Read);
         let result = if self.try_lock_shared_fast(false) {
             true
         } else {
             self.try_lock_shared_slow(false)
         };
         if result {
-            self.deadlock_acquire();
+            self.deadlock_acquire(RwLockMode::Read);
         }
         result
     }
 
     #[inline]
     unsafe fn unlock_shared(&self) {
-        self.deadlock_release();
+        self.deadlock_release(RwLockMode::Read);
         let state = if have_elision() {
             self.state.elision_fetch_sub_release(ONE_READER)
         } else {
@@ -160,7 +165,7 @@ unsafe impl lock_api::RawRwLockFair for RawRwLock {
 
     #[inline]
     unsafe fn unlock_exclusive_fair(&self) {
-        self.deadlock_release();
+        self.deadlock_release(RwLockMode::Write);
         if self
             .state
             .compare_exchange(WRITER_BIT, 0, Ordering::Release, Ordering::Relaxed)
@@ -192,6 +197,11 @@ unsafe impl lock_api::RawRwLockDowngrade for RawRwLock {
         let state = self
             .state
             .fetch_add(ONE_READER - WRITER_BIT, Ordering::Release);
+        deadlock::transition_rwlock(
+            self as *const _ as usize,
+            RwLockMode::Write,
+            RwLockMode::Read,
+        );
 
         // Wake up parked shared and upgradable threads if there are any
         if state & PARKED_BIT != 0 {
@@ -206,32 +216,35 @@ unsafe impl lock_api::RawRwLockTimed for RawRwLock {
 
     #[inline]
     fn try_lock_shared_for(&self, timeout: Self::Duration) -> bool {
+        self.deadlock_check(RwLockMode::Read);
         let result = if self.try_lock_shared_fast(false) {
             true
         } else {
             self.lock_shared_slow(false, util::to_deadline(timeout))
         };
         if result {
-            self.deadlock_acquire();
+            self.deadlock_acquire(RwLockMode::Read);
         }
         result
     }
 
     #[inline]
     fn try_lock_shared_until(&self, timeout: Self::Instant) -> bool {
+        self.deadlock_check(RwLockMode::Read);
         let result = if self.try_lock_shared_fast(false) {
             true
         } else {
             self.lock_shared_slow(false, Some(timeout))
         };
         if result {
-            self.deadlock_acquire();
+            self.deadlock_acquire(RwLockMode::Read);
         }
         result
     }
 
     #[inline]
     fn try_lock_exclusive_for(&self, timeout: Duration) -> bool {
+        self.deadlock_check(RwLockMode::Write);
         let result = if self
             .state
             .compare_exchange_weak(0, WRITER_BIT, Ordering::Acquire, Ordering::Relaxed)
@@ -242,13 +255,14 @@ unsafe impl lock_api::RawRwLockTimed for RawRwLock {
             self.lock_exclusive_slow(util::to_deadline(timeout))
         };
         if result {
-            self.deadlock_acquire();
+            self.deadlock_acquire(RwLockMode::Write);
         }
         result
     }
 
     #[inline]
     fn try_lock_exclusive_until(&self, timeout: Instant) -> bool {
+        self.deadlock_check(RwLockMode::Write);
         let result = if self
             .state
             .compare_exchange_weak(0, WRITER_BIT, Ordering::Acquire, Ordering::Relaxed)
@@ -259,7 +273,7 @@ unsafe impl lock_api::RawRwLockTimed for RawRwLock {
             self.lock_exclusive_slow(Some(timeout))
         };
         if result {
-            self.deadlock_acquire();
+            self.deadlock_acquire(RwLockMode::Write);
         }
         result
     }
@@ -268,22 +282,24 @@ unsafe impl lock_api::RawRwLockTimed for RawRwLock {
 unsafe impl lock_api::RawRwLockRecursive for RawRwLock {
     #[inline]
     fn lock_shared_recursive(&self) {
+        self.deadlock_check(RwLockMode::RecursiveRead);
         if !self.try_lock_shared_fast(true) {
             let result = self.lock_shared_slow(true, None);
             debug_assert!(result);
         }
-        self.deadlock_acquire();
+        self.deadlock_acquire(RwLockMode::RecursiveRead);
     }
 
     #[inline]
     fn try_lock_shared_recursive(&self) -> bool {
+        self.deadlock_check(RwLockMode::RecursiveRead);
         let result = if self.try_lock_shared_fast(true) {
             true
         } else {
             self.try_lock_shared_slow(true)
         };
         if result {
-            self.deadlock_acquire();
+            self.deadlock_acquire(RwLockMode::RecursiveRead);
         }
         result
     }
@@ -292,26 +308,28 @@ unsafe impl lock_api::RawRwLockRecursive for RawRwLock {
 unsafe impl lock_api::RawRwLockRecursiveTimed for RawRwLock {
     #[inline]
     fn try_lock_shared_recursive_for(&self, timeout: Self::Duration) -> bool {
+        self.deadlock_check(RwLockMode::RecursiveRead);
         let result = if self.try_lock_shared_fast(true) {
             true
         } else {
             self.lock_shared_slow(true, util::to_deadline(timeout))
         };
         if result {
-            self.deadlock_acquire();
+            self.deadlock_acquire(RwLockMode::RecursiveRead);
         }
         result
     }
 
     #[inline]
     fn try_lock_shared_recursive_until(&self, timeout: Self::Instant) -> bool {
+        self.deadlock_check(RwLockMode::RecursiveRead);
         let result = if self.try_lock_shared_fast(true) {
             true
         } else {
             self.lock_shared_slow(true, Some(timeout))
         };
         if result {
-            self.deadlock_acquire();
+            self.deadlock_acquire(RwLockMode::RecursiveRead);
         }
         result
     }
@@ -320,29 +338,31 @@ unsafe impl lock_api::RawRwLockRecursiveTimed for RawRwLock {
 unsafe impl lock_api::RawRwLockUpgrade for RawRwLock {
     #[inline]
     fn lock_upgradable(&self) {
+        self.deadlock_check(RwLockMode::Upgradable);
         if !self.try_lock_upgradable_fast() {
             let result = self.lock_upgradable_slow(None);
             debug_assert!(result);
         }
-        self.deadlock_acquire();
+        self.deadlock_acquire(RwLockMode::Upgradable);
     }
 
     #[inline]
     fn try_lock_upgradable(&self) -> bool {
+        self.deadlock_check(RwLockMode::Upgradable);
         let result = if self.try_lock_upgradable_fast() {
             true
         } else {
             self.try_lock_upgradable_slow()
         };
         if result {
-            self.deadlock_acquire();
+            self.deadlock_acquire(RwLockMode::Upgradable);
         }
         result
     }
 
     #[inline]
     unsafe fn unlock_upgradable(&self) {
-        self.deadlock_release();
+        self.deadlock_release(RwLockMode::Upgradable);
         let state = self.state.load(Ordering::Relaxed);
         #[allow(clippy::collapsible_if)]
         if state & PARKED_BIT == 0 {
@@ -371,12 +391,18 @@ unsafe impl lock_api::RawRwLockUpgrade for RawRwLock {
         if state & READERS_MASK != ONE_READER {
             let result = self.upgrade_slow(None);
             debug_assert!(result);
+        } else {
+            deadlock::transition_rwlock(
+                self as *const _ as usize,
+                RwLockMode::Upgradable,
+                RwLockMode::Write,
+            );
         }
     }
 
     #[inline]
     unsafe fn try_upgrade(&self) -> bool {
-        if self
+        let result = if self
             .state
             .compare_exchange_weak(
                 ONE_READER | UPGRADABLE_BIT,
@@ -389,14 +415,22 @@ unsafe impl lock_api::RawRwLockUpgrade for RawRwLock {
             true
         } else {
             self.try_upgrade_slow()
+        };
+        if result {
+            deadlock::transition_rwlock(
+                self as *const _ as usize,
+                RwLockMode::Upgradable,
+                RwLockMode::Write,
+            );
         }
+        result
     }
 }
 
 unsafe impl lock_api::RawRwLockUpgradeFair for RawRwLock {
     #[inline]
     unsafe fn unlock_upgradable_fair(&self) {
-        self.deadlock_release();
+        self.deadlock_release(RwLockMode::Upgradable);
         let state = self.state.load(Ordering::Relaxed);
         #[allow(clippy::collapsible_if)]
         if state & PARKED_BIT == 0 {
@@ -428,6 +462,11 @@ unsafe impl lock_api::RawRwLockUpgradeDowngrade for RawRwLock {
     #[inline]
     unsafe fn downgrade_upgradable(&self) {
         let state = self.state.fetch_sub(UPGRADABLE_BIT, Ordering::Relaxed);
+        deadlock::transition_rwlock(
+            self as *const _ as usize,
+            RwLockMode::Upgradable,
+            RwLockMode::Read,
+        );
 
         // Wake up parked upgradable threads if there are any
         if state & PARKED_BIT != 0 {
@@ -441,6 +480,11 @@ unsafe impl lock_api::RawRwLockUpgradeDowngrade for RawRwLock {
             (ONE_READER | UPGRADABLE_BIT) - WRITER_BIT,
             Ordering::Release,
         );
+        deadlock::transition_rwlock(
+            self as *const _ as usize,
+            RwLockMode::Write,
+            RwLockMode::Upgradable,
+        );
 
         // Wake up parked shared threads if there are any
         if state & PARKED_BIT != 0 {
@@ -452,26 +496,28 @@ unsafe impl lock_api::RawRwLockUpgradeDowngrade for RawRwLock {
 unsafe impl lock_api::RawRwLockUpgradeTimed for RawRwLock {
     #[inline]
     fn try_lock_upgradable_until(&self, timeout: Instant) -> bool {
+        self.deadlock_check(RwLockMode::Upgradable);
         let result = if self.try_lock_upgradable_fast() {
             true
         } else {
             self.lock_upgradable_slow(Some(timeout))
         };
         if result {
-            self.deadlock_acquire();
+            self.deadlock_acquire(RwLockMode::Upgradable);
         }
         result
     }
 
     #[inline]
     fn try_lock_upgradable_for(&self, timeout: Duration) -> bool {
+        self.deadlock_check(RwLockMode::Upgradable);
         let result = if self.try_lock_upgradable_fast() {
             true
         } else {
             self.lock_upgradable_slow(util::to_deadline(timeout))
         };
         if result {
-            self.deadlock_acquire();
+            self.deadlock_acquire(RwLockMode::Upgradable);
         }
         result
     }
@@ -483,6 +529,11 @@ unsafe impl lock_api::RawRwLockUpgradeTimed for RawRwLock {
             Ordering::Relaxed,
         );
         if state & READERS_MASK == ONE_READER {
+            deadlock::transition_rwlock(
+                self as *const _ as usize,
+                RwLockMode::Upgradable,
+                RwLockMode::Write,
+            );
             true
         } else {
             self.upgrade_slow(Some(timeout))
@@ -496,6 +547,11 @@ unsafe impl lock_api::RawRwLockUpgradeTimed for RawRwLock {
             Ordering::Relaxed,
         );
         if state & READERS_MASK == ONE_READER {
+            deadlock::transition_rwlock(
+                self as *const _ as usize,
+                RwLockMode::Upgradable,
+                RwLockMode::Write,
+            );
             true
         } else {
             self.upgrade_slow(util::to_deadline(timeout))
@@ -870,9 +926,13 @@ impl RawRwLock {
 
     #[cold]
     fn upgrade_slow(&self, timeout: Option<Instant>) -> bool {
-        self.deadlock_release();
+        self.deadlock_release(RwLockMode::Upgradable);
         let result = self.wait_for_readers(timeout, ONE_READER | UPGRADABLE_BIT);
-        self.deadlock_acquire();
+        self.deadlock_acquire(if result {
+            RwLockMode::Write
+        } else {
+            RwLockMode::Upgradable
+        });
         result
     }
 
@@ -916,14 +976,14 @@ impl RawRwLock {
 
     #[cold]
     fn bump_exclusive_slow(&self) {
-        self.deadlock_release();
+        self.deadlock_release(RwLockMode::Write);
         self.unlock_exclusive_slow(true);
         self.lock_exclusive();
     }
 
     #[cold]
     fn bump_upgradable_slow(&self) {
-        self.deadlock_release();
+        self.deadlock_release(RwLockMode::Upgradable);
         self.unlock_upgradable_slow(true);
         self.lock_upgradable();
     }
@@ -1145,14 +1205,23 @@ impl RawRwLock {
     }
 
     #[inline]
-    fn deadlock_acquire(&self) {
-        unsafe { deadlock::acquire_resource(self as *const _ as usize) };
-        unsafe { deadlock::acquire_resource(self as *const _ as usize + 1) };
+    fn deadlock_check(&self, mode: RwLockMode) {
+        unsafe { deadlock::check_rwlock_acquire(self as *const _ as usize, mode) };
     }
 
     #[inline]
-    fn deadlock_release(&self) {
-        unsafe { deadlock::release_resource(self as *const _ as usize) };
-        unsafe { deadlock::release_resource(self as *const _ as usize + 1) };
+    fn deadlock_acquire(&self, mode: RwLockMode) {
+        let key = self as *const _ as usize;
+        unsafe { deadlock::acquire_rwlock(key, mode) };
+        unsafe { deadlock::acquire_resource(key) };
+        unsafe { deadlock::acquire_resource(key + 1) };
+    }
+
+    #[inline]
+    fn deadlock_release(&self, mode: RwLockMode) {
+        let key = self as *const _ as usize;
+        unsafe { deadlock::release_rwlock(key, mode) };
+        unsafe { deadlock::release_resource(key) };
+        unsafe { deadlock::release_resource(key + 1) };
     }
 }

--- a/tests/rwlock_deadlock_matrix.rs
+++ b/tests/rwlock_deadlock_matrix.rs
@@ -1,0 +1,202 @@
+use parking_lot::{RwLock, RwLockUpgradableReadGuard};
+#[cfg(feature = "deadlock_detection")]
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::sync::{mpsc, Arc};
+use std::thread;
+use std::time::Duration;
+
+const LOCK_TIMEOUT: Duration = Duration::from_millis(20);
+const CASE_TIMEOUT: Duration = Duration::from_millis(200);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Outcome {
+    Acquired,
+    TimedOut,
+}
+
+type Case = fn(Arc<RwLock<()>>) -> Outcome;
+
+fn outcome<T>(result: Option<T>) -> Outcome {
+    if result.is_some() {
+        Outcome::Acquired
+    } else {
+        Outcome::TimedOut
+    }
+}
+
+fn run_case(case: Case) -> Outcome {
+    let lock = Arc::new(RwLock::new(()));
+    let (sender, receiver) = mpsc::channel();
+
+    thread::spawn(move || {
+        sender.send(case(lock)).unwrap();
+    });
+
+    receiver
+        .recv_timeout(CASE_TIMEOUT)
+        .expect("lock matrix case did not finish")
+}
+
+#[cfg(feature = "deadlock_detection")]
+fn run_case_expect_panic(case: Case) -> bool {
+    let lock = Arc::new(RwLock::new(()));
+    let (sender, receiver) = mpsc::channel();
+
+    thread::spawn(move || {
+        let panicked = catch_unwind(AssertUnwindSafe(|| case(lock))).is_err();
+        sender.send(panicked).unwrap();
+    });
+
+    receiver
+        .recv_timeout(CASE_TIMEOUT)
+        .expect("panic matrix case did not finish")
+}
+
+macro_rules! rwlock_matrix {
+    (
+        $(
+            $case:ident: $label:literal {
+                timeout: $timeout:ident,
+                panic: $panic:literal,
+                run: |$lock:ident| $body:block
+            }
+        ),+ $(,)?
+    ) => {
+        $(
+            fn $case($lock: Arc<RwLock<()>>) -> Outcome $body
+        )+
+
+        #[test]
+        fn test1_rwlock_matrix_expect_timeout() {
+            let cases: &[(&str, Case, Outcome)] = &[
+                $(($label, $case, Outcome::$timeout),)+
+            ];
+
+            for &(name, case, expected) in cases {
+                let actual = run_case(case);
+                assert_eq!(actual, expected, "unexpected result for {name}");
+            }
+        }
+
+        #[cfg(feature = "deadlock_detection")]
+        #[test]
+        #[ignore = "the recursive-lock panic hook is not implemented yet"]
+        fn test2_rwlock_matrix_expect_panic() {
+            let cases: &[(&str, Case, bool)] = &[
+                $(($label, $case, $panic),)+
+            ];
+
+            for &(name, case, expected) in cases {
+                let actual = run_case_expect_panic(case);
+                assert_eq!(actual, expected, "unexpected panic result for {name}");
+            }
+        }
+    };
+}
+
+rwlock_matrix! {
+    read_read: "read -> read" {
+        timeout: Acquired,
+        panic: true,
+        run: |lock| {
+            let _read = lock.read();
+            outcome(lock.try_read_for(LOCK_TIMEOUT))
+        }
+    },
+    read_read_with_waiting_writer: "read -> read (writer waiting)" {
+        timeout: TimedOut,
+        panic: true,
+        run: |lock| {
+            let read = lock.read();
+            let (started_sender, started_receiver) = mpsc::channel();
+            let writer_lock = lock.clone();
+            let writer = thread::spawn(move || {
+                started_sender.send(()).unwrap();
+                let _write = writer_lock.write();
+            });
+
+            started_receiver.recv().unwrap();
+            thread::sleep(Duration::from_millis(10));
+            let result = outcome(lock.try_read_for(LOCK_TIMEOUT));
+            drop(read);
+            writer.join().unwrap();
+            result
+        }
+    },
+    read_read_recursive: "read -> read_recursive" {
+        timeout: Acquired,
+        panic: false,
+        run: |lock| {
+            let _read = lock.read();
+            outcome(lock.try_read_recursive_for(LOCK_TIMEOUT))
+        }
+    },
+    read_write: "read -> write" {
+        timeout: TimedOut,
+        panic: true,
+        run: |lock| {
+            let _read = lock.read();
+            outcome(lock.try_write_for(LOCK_TIMEOUT))
+        }
+    },
+    read_upgradable: "read -> upgradable" {
+        timeout: Acquired,
+        panic: false,
+        run: |lock| {
+            let _read = lock.read();
+            outcome(lock.try_upgradable_read_for(LOCK_TIMEOUT))
+        }
+    },
+    write_read: "write -> read" {
+        timeout: TimedOut,
+        panic: true,
+        run: |lock| {
+            let _write = lock.write();
+            outcome(lock.try_read_for(LOCK_TIMEOUT))
+        }
+    },
+    write_write: "write -> write" {
+        timeout: TimedOut,
+        panic: true,
+        run: |lock| {
+            let _write = lock.write();
+            outcome(lock.try_write_for(LOCK_TIMEOUT))
+        }
+    },
+    upgradable_read: "upgradable -> read" {
+        timeout: Acquired,
+        panic: false,
+        run: |lock| {
+            let _upgradable = lock.upgradable_read();
+            outcome(lock.try_read_for(LOCK_TIMEOUT))
+        }
+    },
+    upgradable_write: "upgradable -> write" {
+        timeout: TimedOut,
+        panic: true,
+        run: |lock| {
+            let _upgradable = lock.upgradable_read();
+            outcome(lock.try_write_for(LOCK_TIMEOUT))
+        }
+    },
+    upgradable_upgradable: "upgradable -> upgradable" {
+        timeout: TimedOut,
+        panic: true,
+        run: |lock| {
+            let _upgradable = lock.upgradable_read();
+            outcome(lock.try_upgradable_read_for(LOCK_TIMEOUT))
+        }
+    },
+    upgradable_upgrade: "upgradable -> upgrade" {
+        timeout: Acquired,
+        panic: false,
+        run: |lock| {
+            let upgradable = lock.upgradable_read();
+            if RwLockUpgradableReadGuard::try_upgrade_for(upgradable, LOCK_TIMEOUT).is_ok() {
+                Outcome::Acquired
+            } else {
+                Outcome::TimedOut
+            }
+        }
+    }
+}

--- a/tests/rwlock_deadlock_matrix.rs
+++ b/tests/rwlock_deadlock_matrix.rs
@@ -1,20 +1,23 @@
-use parking_lot::{RwLock, RwLockUpgradableReadGuard};
+use parking_lot::{RwLock, RwLockUpgradableReadGuard, RwLockWriteGuard};
 #[cfg(feature = "deadlock_detection")]
-use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::sync::Once;
 use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::Duration;
 
 const LOCK_TIMEOUT: Duration = Duration::from_millis(20);
-const CASE_TIMEOUT: Duration = Duration::from_millis(200);
+
+#[cfg(feature = "deadlock_detection")]
+fn enable_panic_on_deadlock() {
+    static ENABLE: Once = Once::new();
+    ENABLE.call_once(|| std::env::set_var("PARKING_LOT_PANIC_ON_DEADLOCK", "1"));
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Outcome {
     Acquired,
     TimedOut,
 }
-
-type Case = fn(Arc<RwLock<()>>) -> Outcome;
 
 fn outcome<T>(result: Option<T>) -> Outcome {
     if result.is_some() {
@@ -24,32 +27,32 @@ fn outcome<T>(result: Option<T>) -> Outcome {
     }
 }
 
-fn run_case(case: Case) -> Outcome {
-    let lock = Arc::new(RwLock::new(()));
-    let (sender, receiver) = mpsc::channel();
-
-    thread::spawn(move || {
-        sender.send(case(lock)).unwrap();
-    });
-
-    receiver
-        .recv_timeout(CASE_TIMEOUT)
-        .expect("lock matrix case did not finish")
-}
-
-#[cfg(feature = "deadlock_detection")]
-fn run_case_expect_panic(case: Case) -> bool {
-    let lock = Arc::new(RwLock::new(()));
-    let (sender, receiver) = mpsc::channel();
-
-    thread::spawn(move || {
-        let panicked = catch_unwind(AssertUnwindSafe(|| case(lock))).is_err();
-        sender.send(panicked).unwrap();
-    });
-
-    receiver
-        .recv_timeout(CASE_TIMEOUT)
-        .expect("panic matrix case did not finish")
+macro_rules! rwlock_panic_test {
+    (true, $label:literal, $timeout:ident, |$lock:ident| $body:block) => {
+        #[cfg(feature = "deadlock_detection")]
+        #[test]
+        #[should_panic(expected = "parking_lot: possible recursive RwLock deadlock")]
+        fn expect_panic() {
+            enable_panic_on_deadlock();
+            let $lock = Arc::new(RwLock::new(()));
+            let _ = $body;
+        }
+    };
+    (false, $label:literal, $timeout:ident, |$lock:ident| $body:block) => {
+        #[cfg(feature = "deadlock_detection")]
+        #[test]
+        fn expect_no_panic() {
+            enable_panic_on_deadlock();
+            let $lock = Arc::new(RwLock::new(()));
+            let actual = $body;
+            assert_eq!(
+                actual,
+                Outcome::$timeout,
+                "unexpected result for {}",
+                $label
+            );
+        }
+    };
 }
 
 macro_rules! rwlock_matrix {
@@ -57,40 +60,31 @@ macro_rules! rwlock_matrix {
         $(
             $case:ident: $label:literal {
                 timeout: $timeout:ident,
-                panic: $panic:literal,
+                panic: $panic:tt,
                 run: |$lock:ident| $body:block
             }
         ),+ $(,)?
     ) => {
         $(
-            fn $case($lock: Arc<RwLock<()>>) -> Outcome $body
+            mod $case {
+                use super::*;
+
+                #[cfg(not(feature = "deadlock_detection"))]
+                #[test]
+                fn expect_timeout() {
+                    let $lock = Arc::new(RwLock::new(()));
+                    let actual = $body;
+                    assert_eq!(
+                        actual,
+                        Outcome::$timeout,
+                        "unexpected result for {}",
+                        $label
+                    );
+                }
+
+                rwlock_panic_test!($panic, $label, $timeout, |$lock| $body);
+            }
         )+
-
-        #[test]
-        fn test1_rwlock_matrix_expect_timeout() {
-            let cases: &[(&str, Case, Outcome)] = &[
-                $(($label, $case, Outcome::$timeout),)+
-            ];
-
-            for &(name, case, expected) in cases {
-                let actual = run_case(case);
-                assert_eq!(actual, expected, "unexpected result for {name}");
-            }
-        }
-
-        #[cfg(feature = "deadlock_detection")]
-        #[test]
-        #[ignore = "the recursive-lock panic hook is not implemented yet"]
-        fn test2_rwlock_matrix_expect_panic() {
-            let cases: &[(&str, Case, bool)] = &[
-                $(($label, $case, $panic),)+
-            ];
-
-            for &(name, case, expected) in cases {
-                let actual = run_case_expect_panic(case);
-                assert_eq!(actual, expected, "unexpected panic result for {name}");
-            }
-        }
     };
 }
 
@@ -197,6 +191,57 @@ rwlock_matrix! {
             } else {
                 Outcome::TimedOut
             }
+        }
+    },
+    upgrade_drop_upgradable: "upgrade -> drop -> upgradable" {
+        timeout: Acquired,
+        panic: false,
+        run: |lock| {
+            let upgradable = lock.upgradable_read();
+            let write = RwLockUpgradableReadGuard::try_upgrade_for(upgradable, LOCK_TIMEOUT)
+                .ok()
+                .unwrap();
+            drop(write);
+            outcome(lock.try_upgradable_read_for(LOCK_TIMEOUT))
+        }
+    },
+    upgrade_downgrade_read: "upgrade -> downgrade -> read" {
+        timeout: Acquired,
+        panic: true,
+        run: |lock| {
+            let upgradable = lock.upgradable_read();
+            let write = RwLockUpgradableReadGuard::try_upgrade_for(upgradable, LOCK_TIMEOUT)
+                .ok()
+                .unwrap();
+            let _read = RwLockWriteGuard::downgrade(write);
+            outcome(lock.try_read_for(LOCK_TIMEOUT))
+        }
+    },
+    downgrade_read_upgradable: "write -> downgrade -> upgradable" {
+        timeout: Acquired,
+        panic: false,
+        run: |lock| {
+            let write = lock.write();
+            let _read = RwLockWriteGuard::downgrade(write);
+            outcome(lock.try_upgradable_read_for(LOCK_TIMEOUT))
+        }
+    },
+    downgrade_upgradable_read: "write -> downgrade_to_upgradable -> read" {
+        timeout: Acquired,
+        panic: false,
+        run: |lock| {
+            let write = lock.write();
+            let _upgradable = RwLockWriteGuard::downgrade_to_upgradable(write);
+            outcome(lock.try_read_for(LOCK_TIMEOUT))
+        }
+    },
+    downgrade_read_to_upgradable: "upgradable -> downgrade -> upgradable" {
+        timeout: Acquired,
+        panic: false,
+        run: |lock| {
+            let upgradable = lock.upgradable_read();
+            let _read = RwLockUpgradableReadGuard::downgrade(upgradable);
+            outcome(lock.try_upgradable_read_for(LOCK_TIMEOUT))
         }
     }
 }


### PR DESCRIPTION
fix #438 

Hi, sorry for the delay in submitting this PR.

This PR adds logic under the `detect_deadlock` feature to detect possible deadlocks with read-write locks.

I use a TLS HashMap, with the `self` pointer address as the key and an enum `RwLockMode` for the lock state. During lock, unlock, and other phases, it attempts to check whether a deadlock might occur.

By default, a detected deadlock only prints a warning. I've added a new environment variable, `PARKING_LOT_PANIC_ON_DEADLOCK`, which will cause a panic if set to `true`.

I wrote a test matrix, and here is the actually result runs on macos:

| Lock sequence | Behavior without detection | With deadlock detection | Classification |
|---|---|---|---|
| `read -> read` | Acquired | Panic | ⚠️ Potential deadlock |
| `read -> read` with a waiting writer | Timed out | Panic | ❌ Deadlock |
| `read -> read_recursive` | Acquired | No panic | ✅ Safe |
| `read -> write` | Timed out | Panic | ❌ Deadlock |
| `read -> upgradable` | Acquired | No panic | ✅ Safe |
| `write -> read` | Timed out | Panic | ❌ Deadlock |
| `write -> write` | Timed out | Panic | ❌ Deadlock |
| `upgradable -> read` | Acquired | No panic | ✅ Safe |
| `upgradable -> write` | Timed out | Panic | ❌ Deadlock; use `upgrade` |
| `upgradable -> upgradable` | Timed out | Panic | ❌ Deadlock |
| `upgradable -> upgrade` | Acquired | No panic | ✅ Safe transition |
| `upgrade -> drop -> upgradable` | Acquired | No panic | ✅ Safe |
| `upgrade -> downgrade -> read` | Acquired | Panic | ⚠️ Potential deadlock, equivalent to `read -> read` |
| `write -> downgrade(read) -> upgradable` | Acquired | No panic | ✅ Safe |
| `write -> downgrade_to_upgradable -> read` | Acquired | No panic | ✅ Safe |
| `upgradable -> downgrade(read) -> upgradable` | Acquired | No panic | ✅ Safe |
