### PR TITLE
Use pointer types for Windows handles

### DIFF
--- a/core/src/thread_parker/windows/bindings.rs
+++ b/core/src/thread_parker/windows/bindings.rs
@@ -12,8 +12,8 @@ pub const GENERIC_WRITE: u32 = 1073741824;
 pub const STATUS_SUCCESS: i32 = 0;
 pub const STATUS_TIMEOUT: i32 = 258;
 
-pub type HANDLE = isize;
-pub type HINSTANCE = isize;
+pub type HANDLE = *mut std::ffi::c_void;
+pub type HINSTANCE = *mut std::ffi::c_void;
 pub type BOOL = i32;
 pub type BOOLEAN = u8;
 pub type NTSTATUS = i32;

--- a/core/src/thread_parker/windows/keyed_event.rs
+++ b/core/src/thread_parker/windows/keyed_event.rs
@@ -50,7 +50,7 @@ impl KeyedEvent {
     #[allow(non_snake_case)]
     pub fn create() -> Option<KeyedEvent> {
         let ntdll = unsafe { GetModuleHandleA(b"ntdll.dll\0".as_ptr()) };
-        if ntdll == 0 {
+        if ntdll.is_null() {
             return None;
         }
 

--- a/core/src/thread_parker/windows/waitaddress.rs
+++ b/core/src/thread_parker/windows/waitaddress.rs
@@ -23,7 +23,7 @@ impl WaitAddress {
     #[allow(non_snake_case)]
     pub fn create() -> Option<WaitAddress> {
         let synch_dll = unsafe { GetModuleHandleA(b"api-ms-win-core-synch-l1-2-0.dll\0".as_ptr()) };
-        if synch_dll == 0 {
+        if synch_dll.is_null() {
             return None;
         }
 


### PR DESCRIPTION
This is needed to pass provenances for Miri.